### PR TITLE
Make '-Dconfluence_publish=...' work

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -124,7 +124,8 @@ class ConfluenceBuilder(Builder):
         else:
             self.lang_transform = None
 
-        if self.config.confluence_publish:
+        if self.config.confluence_publish and (self.config.confluence_publish.lower()
+                                               not in ('0', 'false', 'n', 'no', 'off')):
             self.publish = True
             self.publisher.connect()
         else:

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -124,7 +124,7 @@ class ConfluenceBuilder(Builder):
         else:
             self.lang_transform = None
 
-        if self.config.confluence_publish and (self.config.confluence_publish.lower()
+        if self.config.confluence_publish and (str(self.config.confluence_publish).lower()
                                                not in ('0', 'false', 'n', 'no', 'off')):
             self.publish = True
             self.publisher.connect()


### PR DESCRIPTION
When passed on the command line, options are strings. Make a few
common negative strings known to 'confluence_publish'.