### PR TITLE
add confluence_publish_postfix / confluence_publish_numbered settings

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -62,13 +62,17 @@ def setup(app):
     app.add_config_value('confluence_page_hierarchy', None, False)
     """Root/parent page's name to publish documents into."""
     app.add_config_value('confluence_parent_page', None, False)
-    """Prefix to apply to published pages."""
+    """Prefix to apply to title of published pages."""
     app.add_config_value('confluence_publish_prefix', None, False)
+    """Postfix to apply to title of published pages."""
+    app.add_config_value('confluence_publish_postfix', None, False)
+    """Add running number to published pages (enforce order)."""
+    app.add_config_value('confluence_publish_numbered', 0, False)
     """Enablement of purging legacy child pages from a parent page."""
     app.add_config_value('confluence_purge', None, False)
     """Enablement of purging legacy child pages from a master page."""
     app.add_config_value('confluence_purge_from_master', None, False)
-    
+
     """(advanced-configuration - processing)"""
     """Filename suffix for generated files."""
     app.add_config_value('confluence_file_suffix', ".conf", False)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -205,7 +205,9 @@ class ConfluenceBuilder(Builder):
                 continue
 
             doctitle = ConfluenceState.registerTitle(docname, doctitle,
-                self.config.confluence_publish_prefix)
+                self.config.confluence_publish_prefix,
+                self.config.confluence_publish_postfix,
+                self.config.confluence_publish_numbered)
             self.publish_docnames.append(docname)
 
             toctrees = doctree.traverse(addnodes.toctree)

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -29,6 +29,7 @@ class ConfluenceState:
     doc2title = {}
     doc2ttd = {}
     refid2target = {}
+    title_number = -1  # do not number the main document
 
     @staticmethod
     def registerParentDocname(docname, parent_docname):
@@ -66,7 +67,7 @@ class ConfluenceState:
         ConfluenceLogger.verbose("mapping %s to target: %s" % (refid, target))
 
     @staticmethod
-    def registerTitle(docname, title, prefix = None):
+    def registerTitle(docname, title, prefix=None, postfix=None, numbered=0):
         """
         register the title for the provided document name
 
@@ -80,13 +81,23 @@ class ConfluenceState:
         If a prefix value is provided, it will be added to the beginning of the
         provided title value.
         """
-        if prefix:
-            title = prefix + title
+        maxlen = CONFLUENCE_MAX_TITLE_LEN - len(prefix or '') - len(postfix or '')
+        if numbered:
+            maxlen -= numbered + 1
 
-        if len(title) > CONFLUENCE_MAX_TITLE_LEN:
-            title = title[0:CONFLUENCE_MAX_TITLE_LEN]
+        if len(title) > maxlen:
+            title = title[:maxlen]
             ConfluenceLogger.warn("document title has been trimmed due to "
                 "length: %s" % docname)
+
+        if prefix:
+            title = prefix + title
+        if postfix:
+            title += postfix
+        if numbered:
+            ConfluenceState.title_number += 1
+            if ConfluenceState.title_number > 0:
+                title = '{:{}d} {}'.format(ConfluenceState.title_number, '0' + str(numbered), title)
 
         ConfluenceState.doc2title[docname] = title
         ConfluenceLogger.verbose("mapping %s to title: %s" % (docname, title))


### PR DESCRIPTION
confluence_publish_postfix is just complementary to
the existing confluence_publish_prefix.

confluence_publish_numbered adds a running counter to each page
title, so they are ordered as they appear in the Sphinx document.
The REST API unfortunately does not offer ordering (tickets to
fix that are open for years now, as usual), so this is the next
best thing.