### PR TITLE
Allow cookie for authentications

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -51,6 +51,8 @@ username value should be used:
 
    confluence_server_pass = 'myawesomepassword'
 
+See also :ref:`advanced authentication options<confluence_advanced_conf_auth>`.
+
 .. caution::
 
    It is never recommended to store an API token or raw password into a
@@ -94,16 +96,6 @@ If using Confluence instance, this value will most likely be the username value.
    confluence_server_user = 'myawesomeuser@example.com'
        (or)
    confluence_server_user = 'myawesomeuser'
-
-confluence_server_cookies
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Cookie(s) that can used to authenticate with the Confluence instance. This needs to
-be a dictionary.
-
-.. code-block:: python
-
-   confluence_server_cookies = {'SESSION_ID': 'random session id string', 'U_ID': 'some_user'}
 
 .. |confluence_space_name| replace:: ``confluence_space_name``
 .. _confluence_space_name:
@@ -292,6 +284,26 @@ to ``True`` before taking effect.
 .. code-block:: python
 
    confluence_purge_from_master = False
+
+.. _confluence_advanced_conf_auth:
+
+advanced configuration - authentication
+---------------------------------------
+
+confluence_server_cookies
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A dictionary value which allows a user to pass key-value cookie information for
+authentication purposes. This is useful for users who need to authenticate with
+a single sign-on (SSO) provider to access a target Confluence instance. By
+default, no cookies are set with a value of ``None``.
+
+.. code-block:: python
+
+   confluence_server_cookies = {
+       'SESSION_ID': '<session id string>',
+       'U_ID': '<username>'
+   }
 
 advanced configuration - processing
 -----------------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -95,6 +95,16 @@ If using Confluence instance, this value will most likely be the username value.
        (or)
    confluence_server_user = 'myawesomeuser'
 
+confluence_server_cookies
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cookie(s) that can used to authenticate with the Confluence instance. This needs to
+be a dictionary.
+
+.. code-block:: python
+
+   confluence_server_cookies = {'SESSION_ID': 'random session id string', 'U_ID': 'some_user'}
+
 .. |confluence_space_name| replace:: ``confluence_space_name``
 .. _confluence_space_name:
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -44,6 +44,8 @@ def setup(app):
     app.add_config_value('confluence_server_pass', None, False)
     """Username to login to Confluence API with."""
     app.add_config_value('confluence_server_user', None, False)
+    """Cookie(s) to login to Confluence API with."""
+    app.add_config_value('confluence_server_cookies', None, False)
     """URL of the Confluence instance to publish to."""
     app.add_config_value('confluence_server_url', None, False)
     """Confluence Space to publish to."""

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -44,8 +44,6 @@ def setup(app):
     app.add_config_value('confluence_server_pass', None, False)
     """Username to login to Confluence API with."""
     app.add_config_value('confluence_server_user', None, False)
-    """Cookie(s) to login to Confluence API with."""
-    app.add_config_value('confluence_server_cookies', None, False)
     """URL of the Confluence instance to publish to."""
     app.add_config_value('confluence_server_url', None, False)
     """Confluence Space to publish to."""
@@ -72,7 +70,11 @@ def setup(app):
     app.add_config_value('confluence_purge', None, False)
     """Enablement of purging legacy child pages from a master page."""
     app.add_config_value('confluence_purge_from_master', None, False)
-    
+
+    """(advanced-configuration - authentication)"""
+    """Cookie(s) to use for Confluence REST interaction."""
+    app.add_config_value('confluence_server_cookies', None, False)
+
     """(advanced-configuration - processing)"""
     """Filename suffix for generated files."""
     app.add_config_value('confluence_file_suffix', ".conf", False)

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -143,6 +143,17 @@ however, no username has been configured. Ensure 'confluence_server_user' is
 properly set with the publisher's Confluence username.
 """)
 
+            if not c.confluence_server_cookies and c.confluence_server_pass:
+                errState = True
+                if log:
+                    ConfluenceLogger.error(
+"""confluence password and cookie provided
+
+A publishing cookie has been configured with 'confluence_server_cookies';
+however, a password has been configured as well. Ensure either 'confluence_server_cookies' is
+used or the combination of 'confluence_server_user' and 'confluence_server_pass'.
+""")
+
             if c.confluence_ca_cert:
                 if not os.path.exists(c.confluence_ca_cert):
                     errState = True

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -143,17 +143,6 @@ however, no username has been configured. Ensure 'confluence_server_user' is
 properly set with the publisher's Confluence username.
 """)
 
-            if not c.confluence_server_cookies and c.confluence_server_pass:
-                errState = True
-                if log:
-                    ConfluenceLogger.error(
-"""confluence password and cookie provided
-
-A publishing cookie has been configured with 'confluence_server_cookies';
-however, a password has been configured as well. Ensure either 'confluence_server_cookies' is
-used or the combination of 'confluence_server_user' and 'confluence_server_pass'.
-""")
-
             if c.confluence_ca_cert:
                 if not os.path.exists(c.confluence_ca_cert):
                     errState = True

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -80,8 +80,10 @@ class Rest:
             session.auth = (
                 config.confluence_server_user,
                 config.confluence_server_pass)
-        elif config.confluence_server_cookies:
+
+        if config.confluence_server_cookies:
             session.cookies.update(config.confluence_server_cookies)
+
         return session
 
     def get(self, key, params):

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -80,6 +80,8 @@ class Rest:
             session.auth = (
                 config.confluence_server_user,
                 config.confluence_server_pass)
+        elif config.confluence_server_cookies:
+            session.cookies.update(config.confluence_server_cookies)
         return session
 
     def get(self, key, params):


### PR DESCRIPTION
Allow usage of a cookie for authentication to the confluence API. This
might be useful if the confluence instance is hidden behind some single-
sign-on services.

Signed-off-by: Michael Kunzmann <michael.kunzmann@gmx.net>