### PR TITLE
Add missing argument to usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Usage
 
 .. code-block:: shell
 
-    sphinx-build -b confluence _build/confluence -E -a
+    sphinx-build -b confluence . _build/confluence -E -a
         (or)
     python -m sphinx -b confluence . _build/confluence -E -a
 


### PR DESCRIPTION
The build script example was missing the local folder `.`