### PR TITLE
cleanup: updating references to new home

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,7 +87,7 @@
 * purging support
 * use macros for admonitions
 * (note) known issues with python 3.3, 3.4, 3.5 or 3.6 (see
-  tonybaloney/sphinxcontrib-confluencebuilder#10)
+  sphinx-contrib/confluencebuilder#10)
 
 0.4.0 (2017-02-21)
 ==================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -142,5 +142,5 @@ This Code of Conduct is adapted from the `Contributor Covenant`_, version 1.4.
 
 .. _Contributor Covenant: http://contributor-covenant.org/version/1/4/
 .. _Developer’s Certificate of Origin: https://developercertificate.org/
-.. _issue tracker: https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/issues
-.. _pull requests: https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/pulls
+.. _issue tracker: https://github.com/sphinx-contrib/confluencebuilder/issues
+.. _pull requests: https://github.com/sphinx-contrib/confluencebuilder/pulls

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -6,7 +6,7 @@ distributed on `Read the Docs`_. Sources of the documentation can be found
 inside this extension's repository ``doc`` folder:
 
    | Atlassian Confluence Builder for Confluence
-   | https://github.com/tonybaloney/sphinxcontrib-confluencebuilder
+   | https://github.com/sphinx-contrib/confluencebuilder
 
 The documentation theme used by default is set to ``sphinx_rtd_theme``. If
 locally generating documentation, the theme can be installed on systems using

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ publish them to a Confluence instance.
 * License: BSD-2-Clause
 * Confluence_ Cloud or Server |supported_confluence_ver| with  Python_
   |supported_python_ver|
-* Home: https://github.com/tonybaloney/sphinxcontrib-confluencebuilder
+* Home: https://github.com/sphinx-contrib/confluencebuilder
 * Documentation: http://sphinxcontrib-confluencebuilder.readthedocs.io
 
 documentation contents

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -154,7 +154,7 @@ To install the bleeding edge sources, the following pip_ command can be used:
 .. code-block:: shell
 
    pip install \
-       git+https://github.com/tonybaloney/sphinxcontrib-confluencebuilder
+       git+https://github.com/sphinx-contrib/confluencebuilder.git
 
 .. _Confluence: https://www.atlassian.com/software/confluence
 .. _Python: https://www.python.org/

--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -88,7 +88,7 @@ If a markup type and/or extension is not listed in the above, is not working as
 expected or brings up another concern, feel free to bring up an issue:
 
    | Atlassian Confluence Builder for Confluence - Issues
-   | https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/issues
+   | https://github.com/sphinx-contrib/confluencebuilder/issues
 
 .. _code block macro: https://confluence.atlassian.com/confcloud/code-block-macro-724765175.html
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -122,4 +122,4 @@ Having trouble or concerns using this extension? Do not hesitate to bring up an
 issue:
 
    | Atlassian Confluence Builder for Confluence - Issues
-   | https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/issues
+   | https://github.com/sphinx-contrib/confluencebuilder/issues

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requires = [
 setup(
     name='sphinxcontrib-confluencebuilder',
     version='1.2.0-dev0',
-    url='https://github.com/tonybaloney/sphinxcontrib-confluencebuilder',
+    url='https://github.com/sphinx-contrib/confluencebuilder',
     download_url='https://pypi.python.org/pypi/sphinxcontrib-confluencebuilder',
     license='BSD',  # 2-clause
     author='Anthony Shaw',

--- a/test/unit-tests/literal-markup/test_literal_markup.py
+++ b/test/unit-tests/literal-markup/test_literal_markup.py
@@ -28,7 +28,7 @@ class TestConfluenceLiteralMarkup(unittest.TestCase):
         # stable version is released, this can be re-enabled for the newer
         # version and greater
         #
-        # https://github.com/tonybaloney/sphinxcontrib-confluencebuilder/issues/148
+        # https://github.com/sphinx-contrib/confluencebuilder/issues/148
         if parse_version(sphinx_version) > parse_version('1.7'):
             raise unittest.SkipTest('not supported in sphinx-1.8.x+')
         _.assertExpectedWithOutput(

--- a/test/validation-sets/common/images.rst
+++ b/test/validation-sets/common/images.rst
@@ -155,12 +155,12 @@ link target):
    :target: https://pypi.python.org/pypi/sphinxcontrib-confluencebuilder
    :alt: pip Version
 
-.. image:: https://img.shields.io/travis/tonybaloney/sphinxcontrib-confluencebuilder.svg
-   :target: https://travis-ci.org/tonybaloney/sphinxcontrib-confluencebuilder
+.. image:: https://travis-ci.org/sphinx-contrib/confluencebuilder.svg?branch=master
+   :target: https://travis-ci.org/sphinx-contrib/confluencebuilder
    :alt: Build Status
 
 .. image:: https://readthedocs.org/projects/sphinxcontrib-confluencebuilder/badge/?version=latest
-   :target: http://sphinxcontrib-confluencebuilder.readthedocs.io/en/latest/?badge=latest
+   :target: https://sphinxcontrib-confluencebuilder.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
 .. raw:: confluence


### PR DESCRIPTION
With the `confluencebuilder` extension now part of the `sphinx-contrib` home, adjusting various references in the repository to use new URLs.