### PR TITLE
test: introduce test sandbox

### DIFF
--- a/test/sandbox/.gitignore
+++ b/test/sandbox/.gitignore
@@ -1,0 +1,6 @@
+# ignore all in sandbox
+*
+
+# with the exceptions below
+!.gitignore
+!README

--- a/test/sandbox/README
+++ b/test/sandbox/README
@@ -1,0 +1,10 @@
+test sandbox
+============
+
+The following folder provides an easy setup to dump a fresh ``conf.py``,
+``requirements.txt`` and documentation to test against this extension when
+invoking with the following command:
+
+.. code-block:: shell
+
+   tox -e sandbox

--- a/test/sphinxcontrib_confluencebuilder_util.py
+++ b/test/sphinxcontrib_confluencebuilder_util.py
@@ -113,7 +113,7 @@ class ConfluenceTestUtil:
 
     @staticmethod
     @contextmanager
-    def prepareSphinx(src_dir, out_dir, doctree_dir, config):
+    def prepareSphinx(src_dir, out_dir, doctree_dir, config=None):
         """
         prepare a sphinx application instance
 
@@ -128,23 +128,24 @@ class ConfluenceTestUtil:
             nocolor()
 
         sts = ConfluenceTestUtil.default_sphinx_status
+        conf = dict(config) if config else None
+        conf_dir = src_dir if not conf else None
 
         with docutils_namespace():
             app = Sphinx(
                 src_dir,                # output for document sources
-                None,                   # ignore configuration directory
+                conf_dir,               # ignore configuration directory
                 out_dir,                # output for generated documents
                 doctree_dir,            # output for doctree files
                 ConfluenceBuilder.name, # use this extension's builder
-                confoverrides=dict(config),
-                                        # load provided configuration (volatile)
+                confoverrides=conf,     # load provided configuration (volatile)
                 status=sts,             # status output
                 warning=sys.stderr)     # warnings output
 
             yield app
 
     @staticmethod
-    def buildSphinx(src_dir, out_dir, doctree_dir, config):
+    def buildSphinx(src_dir, out_dir, doctree_dir, config=None):
         """
         prepare a sphinx application instance
 

--- a/test/test_sandbox.py
+++ b/test/test_sandbox.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""
+    :copyright: Copyright 2019 by the contributors (see AUTHORS file).
+    :license: BSD-2-Clause, see LICENSE for details.
+"""
+from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
+import os
+import sys
+
+def main():
+    _.enableVerbose()
+
+    # find sandbox base folder
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    sandbox_dir = os.path.join(test_dir, 'sandbox')
+    doc_dir, doctree_dir = _.prepareDirectories('sandbox-test')
+
+    _.buildSphinx(sandbox_dir, doc_dir, doctree_dir)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,11 @@ commands = flake8 \
            --ignore=E402 \
            sphinxcontrib.confluencebuilder
 
+[testenv:sandbox]
+deps = -r{toxinidir}/test/sandbox/requirements.txt
+commands = python -m test_sandbox {posargs}
+passenv = *
+
 [testenv:validation]
 deps = -r{toxinidir}/requirements_dev.txt
 commands = python -m test_validation {posargs}


### PR DESCRIPTION
Adds an empty test sandbox environment where a developer/testing can quickly dump a custom Sphinx configuration, documentation and a tox requirements file for rapid development. A tox custom environment `sandbox` can be invoked to use content in this folder:

    tox -e sandbox