### PR TITLE
support previous/next navigation

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -216,6 +216,18 @@ If a parent page is not set, consider using the |confluence_master_homepage|_
 option as well. Note that the page's name can be case-sensitive in most
 (if not all) versions of Confluence.
 
+confluence_prev_next_buttons_location
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A string value to where to include previous/next buttons (if any) based on the
+detected order of documents to be included in processing. Values accepted are
+either ``bottom``, ``both``, ``top`` or ``None``. By default, no previous/next
+links are generated with a value of ``None``.
+
+.. code-block:: python
+
+   confluence_prev_next_buttons_location = 'top'
+
 .. _confluence_publish_prefix:
 
 confluence_publish_prefix

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -64,6 +64,8 @@ def setup(app):
     app.add_config_value('confluence_page_hierarchy', None, False)
     """Root/parent page's name to publish documents into."""
     app.add_config_value('confluence_parent_page', None, False)
+    """Show previous/next buttons (bottom, top, both, None)."""
+    app.add_config_value('confluence_prev_next_buttons_location', None, False)
     """Prefix to apply to published pages."""
     app.add_config_value('confluence_publish_prefix', None, False)
     """Enablement of purging legacy child pages from a parent page."""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -9,6 +9,7 @@ from .assets import ConfluenceAssetManager
 from .config import ConfluenceConfig
 from .exceptions import ConfluenceConfigurationError
 from .logger import ConfluenceLogger
+from .nodes import ConfluenceNavigationNode
 from .publisher import ConfluencePublisher
 from .state import ConfluenceState
 from .util import ConfluenceUtil
@@ -20,11 +21,11 @@ from os import path
 from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.errors import ExtensionError
+from sphinx.locale import _
 from sphinx.util import status_iterator
 from sphinx.util.osutil import ensuredir, SEP
 import io
 import sys
-
 
 # Clone of relative_uri() sphinx.util.osutil, with bug-fixes
 # since the original code had a few errors.
@@ -112,6 +113,8 @@ class ConfluenceBuilder(Builder):
         # Function to convert the docname to a relative URI.
         def link_transform(docname):
             return docname + self.link_suffix
+
+        self.prev_next_loc = self.config.confluence_prev_next_buttons_location
 
         if self.config.confluence_file_transform is not None:
             self.file_transform = self.config.confluence_file_transform
@@ -201,6 +204,18 @@ class ConfluenceBuilder(Builder):
         #     depth value)
         self.process_tree_structure(
             ordered_docnames, self.config.master_doc, traversed)
+
+        # track relations between accepted documents
+        #
+        # Prepares a relation mapping between each non-orphan documents which
+        # can be used by navigational elements.
+        prevdoc = ordered_docnames[0] if ordered_docnames else None
+        self.nav_next = {}
+        self.nav_prev = {}
+        for docname in ordered_docnames[1:]:
+            self.nav_prev[docname] = prevdoc
+            self.nav_next[prevdoc] = docname
+            prevdoc = docname
 
         # add orphans (if any) to the publish list
         ordered_docnames.extend(x for x in docnames if x not in traversed)
@@ -294,6 +309,18 @@ class ConfluenceBuilder(Builder):
     def write_doc(self, docname, doctree):
         if docname in self.omitted_docnames:
             return
+
+        if self.prev_next_loc in ('top', 'both'):
+            navnode = self._build_navigation_node(docname)
+            if navnode:
+                navnode.top = True
+                doctree.insert(0, navnode)
+
+        if self.prev_next_loc in ('bottom', 'both'):
+            navnode = self._build_navigation_node(docname)
+            if navnode:
+                navnode.bottom = True
+                doctree.append(navnode)
 
         # remove title from page contents (if any)
         if self.config.confluence_remove_title:
@@ -494,6 +521,42 @@ class ConfluenceBuilder(Builder):
     def cleanup(self):
         if self.publish:
             self.publisher.disconnect()
+
+    def _build_navigation_node(self, docname):
+        """
+        build a navigation node for a document
+
+        Requests to build a navigation node for a provided document name. If
+        this document has no navigational hints to apply, this method will
+        return a `None` value.
+
+        Args:
+            docname: the document name
+
+        Returns:
+            returns a navigation node; ``None`` if no nav-node for document
+        """
+        if docname not in self.nav_prev and docname not in self.nav_next:
+            return None
+
+        navnode = ConfluenceNavigationNode()
+
+        if docname in self.nav_prev:
+            prev_label = '← ' + _('Previous')
+            reference = nodes.reference(prev_label, prev_label, internal=True,
+                refuri=self.nav_prev[docname])
+            navnode.append(reference)
+
+        if docname in self.nav_prev and docname in self.nav_next:
+            navnode.append(nodes.Text(' | '))
+
+        if docname in self.nav_next:
+            next_label = _('Next') + ' →'
+            reference = nodes.reference(next_label, next_label, internal=True,
+                refuri=self.nav_next[docname])
+            navnode.append(reference)
+
+        return navnode
 
     def _find_title_element(self, doctree):
         """

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -110,6 +110,17 @@ the 'confluence_parent_page' option. Ensure the name of the parent page name
 is provided as well.
 """)
 
+            prev_next_loc = c.confluence_prev_next_buttons_location
+            if prev_next_loc and prev_next_loc not in ('bottom', 'both', 'top'):
+                errState = True
+                if log:
+                    ConfluenceLogger.error(
+"""prev-next button location invalid
+
+When defining the previous/next button locations, only the following values are
+permitted: bottom, top, both, or None.
+""")
+
             if not c.confluence_server_url:
                 errState = True
                 if log:

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+    :copyright: Copyright 2019 by the contributors (see AUTHORS file).
+    :license: BSD-2-Clause, see LICENSE for details.
+"""
+
+from docutils import nodes
+
+class ConfluenceNavigationNode(nodes.General, nodes.Element):
+
+    """
+    confluence navigational node
+
+    A Confluence builder defined navigational node provides information on how
+    to manipulate documents to add navigational enhancements (e.g. next,
+    previous, etc.) at the top or bottom of pages (based on user configuration).
+
+    Attributes:
+        bottom: show navigation information at the bottom of a document
+        top: show navigation information at the top of a document
+    """
+    def __init__(self):
+        nodes.Element.__init__(self)
+
+        self.bottom = False
+        self.top = False

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -7,6 +7,7 @@
 from __future__ import unicode_literals
 from .exceptions import ConfluenceError
 from .logger import ConfluenceLogger
+from .nodes import ConfluenceNavigationNode
 from .state import ConfluenceState
 from .std.confluence import FCMMO
 from .std.confluence import INDENT
@@ -1340,6 +1341,28 @@ class ConfluenceTranslator(BaseTranslator):
             self._visit_info(node)
 
     depart_versionmodified = _depart_admonition
+
+    # -----------------------------------------
+    # sphinx -- extension -- confluence builder
+    # -----------------------------------------
+
+    def visit_ConfluenceNavigationNode(self, node):
+        if node.bottom:
+            self.body.append(self._start_tag(
+                node, 'hr', suffix=self.nl, empty=True,
+                **{'style': 'margin-top: 30px'}))
+
+        self.body.append(self._start_tag(node, 'p', suffix=self.nl,
+            **{'style': 'text-align: right'}))
+        self.context.append(self._end_tag(node))
+
+    def depart_ConfluenceNavigationNode(self, node):
+        self.body.append(self.context.pop()) # p
+
+        if node.top:
+            self.body.append(self._start_tag(
+                node, 'hr', suffix=self.nl, empty=True,
+                **{'style': 'margin-bottom: 30px'}))
 
     # ------------------------------
     # sphinx -- extension -- autodoc

--- a/test/unit-tests/common/dataset-prevnext/final.rst
+++ b/test/unit-tests/common/dataset-prevnext/final.rst
@@ -1,0 +1,4 @@
+final
+-----
+
+content

--- a/test/unit-tests/common/dataset-prevnext/index.rst
+++ b/test/unit-tests/common/dataset-prevnext/index.rst
@@ -1,0 +1,7 @@
+prevnext
+========
+
+.. toctree::
+
+   middle
+   final

--- a/test/unit-tests/common/dataset-prevnext/middle.rst
+++ b/test/unit-tests/common/dataset-prevnext/middle.rst
@@ -1,0 +1,4 @@
+middle
+------
+
+content

--- a/test/unit-tests/common/test_prev_next.py
+++ b/test/unit-tests/common/test_prev_next.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+    :copyright: Copyright 2019 by the contributors (see AUTHORS file).
+    :license: BSD-2-Clause, see LICENSE for details.
+"""
+
+from __future__ import unicode_literals
+from sphinx.application import Sphinx
+from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
+import io
+import os
+import unittest
+
+class TestConfluencePrevNext(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+
+        self.config = _.prepareConfiguration()
+        self.dataset = os.path.join(test_dir, 'dataset-prevnext')
+        self.expected = os.path.join(test_dir, 'expected')
+
+    def _character_check(self, name, output, expected):
+        test_path = os.path.join(output, name + '.conf')
+        self.assertTrue(os.path.exists(test_path),
+            'missing output file: {}'.format(test_path))
+
+        with io.open(test_path, encoding='utf8') as test_file:
+            data = ''.join([o.strip() + '\n' for o in test_file.readlines()])
+            for char, count in expected.items():
+                found = data.count(char)
+                self.assertTrue(data.count(char) == count,
+                    'unexpected character ({}) count (expected: {}, found: {}) '
+                    'in file: {}'.format(
+                        hex(ord(char)), count, found, test_path))
+
+    def test_prevnext_bottom(self):
+        config = dict(self.config)
+        config['confluence_prev_next_buttons_location'] = 'bottom'
+
+        doc_dir, doctree_dir = _.prepareDirectories('prevnext-bottom')
+
+        with _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config) as app:
+            app.build(force_all=True)
+            self._character_check('index',  doc_dir, {'←': 0, '→': 1})
+            self._character_check('middle', doc_dir, {'←': 1, '→': 1})
+            self._character_check('final',  doc_dir, {'←': 1, '→': 0})
+
+    def test_prevnext_both(self):
+        config = dict(self.config)
+        config['confluence_prev_next_buttons_location'] = 'both'
+
+        doc_dir, doctree_dir = _.prepareDirectories('prevnext-both')
+
+        with _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config) as app:
+            app.build(force_all=True)
+            self._character_check('index',  doc_dir, {'←': 0, '→': 2})
+            self._character_check('middle', doc_dir, {'←': 2, '→': 2})
+            self._character_check('final',  doc_dir, {'←': 2, '→': 0})
+
+    def test_prevnext_none(self):
+        config = dict(self.config)
+        config['confluence_prev_next_buttons_location'] = None
+
+        doc_dir, doctree_dir = _.prepareDirectories('prevnext-none')
+
+        with _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config) as app:
+            app.build(force_all=True)
+            self._character_check('index',  doc_dir, {'←': 0, '→': 0})
+            self._character_check('middle', doc_dir, {'←': 0, '→': 0})
+            self._character_check('final',  doc_dir, {'←': 0, '→': 0})
+
+    def test_prevnext_top(self):
+        config = dict(self.config)
+        config['confluence_prev_next_buttons_location'] = 'top'
+
+        doc_dir, doctree_dir = _.prepareDirectories('prevnext-top')
+
+        with _.prepareSphinx(self.dataset, doc_dir, doctree_dir, config) as app:
+            app.build(force_all=True)
+            self._character_check('index',  doc_dir, {'←': 0, '→': 1})
+            self._character_check('middle', doc_dir, {'←': 1, '→': 1})
+            self._character_check('final',  doc_dir, {'←': 1, '→': 0})


### PR DESCRIPTION
Provides initial support to have previous/next navigational links at various locations of a document based on a user's configuration. The option `confluence_prev_next_buttons_location` (default disabled with `None`) can be configured with the following to respectively render previous/next buttons for a detected ordered list of documents: bottom, both, top, None.