### PR TITLE
Add image files ending with star (*) instead of specifying the format

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ James Bungard <jmbungard@gmail.com>
 James Knight <james.d.knight@live.com>
 Jesse Tan <j.tan@activevideo.com>
 John Teasdale <teasdale@uber.com>
+Juan J. Caballero <jjcaballerofernandez@gmail.com>
 Logan Jones <loganasherjones@gmail.com>
 Marius van Niekerk <marius.v.niekerk@gmail.com>
 Michael Kunzmann <michael.kunzmann@gmx.net>
@@ -16,5 +17,4 @@ Paul D.Smith <paul@pauldsmith.org.uk>
 Pawel Limanowka <plimanowka@gmail.com>
 Thomas Malcher <malcher@student.tugraz.at>
 Toni Ruža <toni.ruza@gmail.com>
-jjcaballero <jjcaballerofernandez@gmail.com>
 sumau <soumaya.mauthoor@gmail.com>

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -307,7 +307,9 @@ class ConfluenceBuilder(Builder):
                         if not mf:
                             continue
 
-                        new_node = nodes.image(uri=path.join(self.outdir, mf))
+                        new_node = nodes.image(
+                            candidates={'?'},
+                            uri=path.join(self.outdir, mf))
                         if not isinstance(node, nodes.math):
                             new_node['align'] = 'center'
                         node.replace_self(new_node)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -66,6 +66,7 @@ class ConfluenceBuilder(Builder):
     name = 'confluence'
     format = 'confluence'
     supported_image_types = StandaloneHTMLBuilder.supported_image_types
+    supported_remote_images = True
 
     def __init__(self, app):
         super(ConfluenceBuilder, self).__init__(app)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -20,6 +20,7 @@ from getpass import getpass
 from os import path
 from sphinx import addnodes
 from sphinx.builders import Builder
+from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.errors import ExtensionError
 from sphinx.locale import _
 from sphinx.util import status_iterator
@@ -64,6 +65,7 @@ class ConfluenceBuilder(Builder):
     allow_parallel = True
     name = 'confluence'
     format = 'confluence'
+    supported_image_types = StandaloneHTMLBuilder.supported_image_types
 
     def __init__(self, app):
         super(ConfluenceBuilder, self).__init__(app)
@@ -255,6 +257,7 @@ class ConfluenceBuilder(Builder):
             doctitle = ConfluenceState.registerTitle(docname, doctitle,
                 self.config.confluence_publish_prefix,
                 self.config.confluence_publish_postfix)
+
             if docname in docnames:
                 # Only publish documents that Sphinx asked to prepare
                 self.publish_docnames.append(docname)
@@ -310,6 +313,9 @@ class ConfluenceBuilder(Builder):
                     except imgmath.MathExtError as exc:
                         ConfluenceLogger.warn('inline latex {}: {}'.format(
                             node.astext(), exc))
+
+            # for every doctree, pick the best image candidate
+            self.post_process_images(doctree)
 
         # Scan for assets that may exist in the documents to be published. This
         # will find most if not all assets in the documentation set. The

--- a/test/unit-tests/common/dataset-image-star/index.rst
+++ b/test/unit-tests/common/dataset-image-star/index.rst
@@ -1,0 +1,4 @@
+Index
+=====
+
+.. image:: image01.*

--- a/test/unit-tests/common/expected-image-star/index.conf
+++ b/test/unit-tests/common/expected-image-star/index.conf
@@ -1,0 +1,3 @@
+<ac:image>
+    <ri:attachment ri:filename="image01.@REPLACE_EXTENSION@"></ri:attachment>
+</ac:image>

--- a/test/unit-tests/common/test_image_star.py
+++ b/test/unit-tests/common/test_image_star.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""
+    :copyright: Copyright 2017-2019 by the contributors (see AUTHORS file).
+    :license: BSD-2-Clause, see LICENSE for details.
+"""
+
+import os
+import re
+import shutil
+import tempfile
+import unittest
+
+from sphinxcontrib.confluencebuilder.state import ConfluenceState
+from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
+from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
+
+
+class TestImageStar(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        cls.image_file = os.path.join(test_dir, 'assets', 'image01.png')
+        cls.image_basename = cls.file_basename(cls.image_file)
+        cls.datasetdir = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree(self.datasetdir)
+
+    @staticmethod
+    def file_basename(filepath):
+        return os.path.basename(filepath).rsplit('.')[0]
+
+    @staticmethod
+    def file_extension(filepath):
+        return os.path.basename(filepath).rsplit('.')[1]
+
+    def build_document_given_dataset(self, dataset):
+        config = _.prepareConfiguration()
+        doc_dir, doctree_dir = _.prepareDirectories('image-star')
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config)
+        return doc_dir
+
+    def write_index_file(self, indexfile):
+        with open(indexfile, 'w') as out:
+            out.write('.. image:: {}.*'.format(self.image_basename))
+
+    def write_expected_index_file(self, outfile, actual_extension):
+        ''' writes the expected content into outfile using
+        the actual extension
+        '''
+        image_filename = self.image_basename + '.' + actual_extension
+        content = '<ri:attachment ri:filename="{}">'.format(image_filename)
+        content += '</ri:attachment>\n'
+        content = '<ac:image>\n' + content + '</ac:image>'
+        with open(outfile, 'w') as out:
+            out.write(content)
+
+    def test_image_ending_with_star(self):
+        ''' Test how Confluence Builder resolves the image path when
+        it ends with star (*).
+        A temporary datasetdir is created to store::
+        - image with the extension as the image type to be tested (png): copy
+          of the image01.png from assets folder
+        - index.rst: created on the fly using star notation
+        - expected output file: expected_index.conf (created on the fly too)
+
+        Sphinx builders finds the png as the candidate. Similar tests
+        can be created for all ConfluenceBuilder.supported_image_types
+        but it requires an actual image of each image type.
+        '''
+        image_extension = self.file_extension(self.image_file)
+        self.assertIn('image/' + image_extension,
+                      ConfluenceBuilder.supported_image_types)
+        shutil.copyfile(
+            self.image_file,
+            os.path.join(self.datasetdir,
+                         self.image_basename + '.' + image_extension))
+
+        self.write_index_file(os.path.join(self.datasetdir, 'index.rst'))
+            
+        expected_outfile = os.path.join(self.datasetdir,
+                                        'expected_index.conf')
+        self.write_expected_index_file(expected_outfile, image_extension)
+
+        doc_dir = self.build_document_given_dataset(self.datasetdir)
+        _.assertExpectedWithOutput(self,
+                                   self.file_basename(expected_outfile),
+                                   self.datasetdir,
+                                   doc_dir,
+                                   tpn='index')


### PR DESCRIPTION
**Some context:**
I was trying to include plots generated by matplotlib.sphinext when using the confluence builder. Then I learned that plots were properly generated and the only problem was the matplotlib.sphinext extension was not considering confluence as a possible builder.
Therefore, I created this PR (https://github.com/matplotlib/matplotlib/pull/14681) there, to ask them to include it. Eventually, this was addressed in other PR (https://github.com/matplotlib/matplotlib/pull/14683) which enhance the same but in a more general way. Now, builders which want to include plots from matplotlibs should handle images ending with star. 

And handling image with star is the goal of this PR. I have added the parameter **supported_image_types** to the builder like here:  [sphinx builders doc](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.html.StandaloneHTMLBuilder.supported_image_types) 
We might want to include more image formats, I have just considered png, jpeg and pdf.

**In a nutshell:** 
when the image ends with star and does not exists, then the ConfluenceAssetManager will use the first found image with the same name but ending with a supported image type.


**Side note:** maybe I am wrong, but I think there are no tests to verify the publishing itself.  Is there any recommendation to do such a thing? It would be very convenient to be able to run tests choosing confluence server and parent page. I mean using the same infrastructure used to run tests but publishing.