### PR TITLE
translator: support base admonition translation

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -658,11 +658,14 @@ class ConfluenceTranslator(BaseTranslator):
     # admonitions
     # -----------
 
-    def _visit_admonition(self, node, atype, title=None):
+    def _visit_admonition(self, node, atype, title=None, logo=True):
         if self.can_admonition:
             self.body.append(self._start_ac_macro(node, atype))
             if title:
                 self.body.append(self._build_ac_parameter(node, 'title', title))
+            if not logo:
+                self.body.append(
+                    self._build_ac_parameter(node, 'icon', 'false'))
             self.body.append(self._start_ac_rich_text_body_macro(node))
             self.context.append(self._end_ac_rich_text_body_macro(node) +
                 self._end_ac_macro(node))
@@ -693,6 +696,15 @@ class ConfluenceTranslator(BaseTranslator):
     def _visit_warning(self, node):
         self._visit_admonition(node, 'warning')
 
+    def visit_admonition(self, node):
+        title_node = node.traverse(nodes.title)
+        if title_node:
+            title = title_node[0].astext()
+            self._visit_admonition(node, 'info', title, logo=False)
+        else:
+            self._visit_admonition(node, 'info', logo=False)
+
+    depart_admonition = _depart_admonition
     visit_attention = _visit_note
     depart_attention = _depart_admonition
     visit_caution = _visit_note

--- a/test/unit-tests/common/dataset-common/admonitions.rst
+++ b/test/unit-tests/common/dataset-common/admonitions.rst
@@ -5,6 +5,10 @@
 admonitions
 -----------
 
+.. admonition:: title
+
+   admonition
+
 .. attention::
 
    attention

--- a/test/unit-tests/common/expected/admonitions.conf
+++ b/test/unit-tests/common/expected/admonitions.conf
@@ -1,3 +1,10 @@
+<ac:structured-macro ac:name="info">
+    <ac:parameter ac:name="title">title</ac:parameter>
+    <ac:parameter ac:name="icon">false</ac:parameter>
+    <ac:rich-text-body>
+        <p>admonition</p>
+    </ac:rich-text-body>
+</ac:structured-macro>
 <ac:structured-macro ac:name="note">
     <ac:rich-text-body>
         <p>attention</p>

--- a/test/validation-sets/common/admonitions.rst
+++ b/test/validation-sets/common/admonitions.rst
@@ -5,6 +5,10 @@ This page shows the usage of the `reStructuredText's admonitions`_ set.
 Admonitions are translated to respective `Confluence's informative macros`_
 (info, tip, etc.).
 
+.. admonition:: title
+
+   This is an "admonition" block message.
+
 .. attention::
 
    This is an "attention" block message.


### PR DESCRIPTION
Re-introduce the visit/depart calls for the admonition type which were removed during the re-work to support Confluence's storage format. This allows the admonition directive to be used in documents (which explicitly provide a title).