### PR TITLE
added configuration option confluence_ask_user

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -446,6 +446,16 @@ Note that some shell sessions may not be able to pull the password value
 properly from the user. For example, Cygwin/MinGW may not be able to accept a
 password unless invoked with ``winpty``.
 
+confluence_ask_user
+~~~~~~~~~~~~~~~~~~~
+
+Similar to ``confluence_ask_password`` but applies to ``confluence_server_user``
+
+.. code-block:: python
+
+   confluence_ask_user = False
+
+
 confluence_asset_override
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -449,7 +449,12 @@ password unless invoked with ``winpty``.
 confluence_ask_user
 ~~~~~~~~~~~~~~~~~~~
 
-Similar to ``confluence_ask_password`` but applies to ``confluence_server_user``
+Provides an override for an interactive shell to request publishing documents
+using a user provided from the shell environment. While a
+user is typically defined in the option ``confluence_server_user``, select
+environments may wish to provide a way to provide a user without needing to
+modify documentation sources.
+By default, this option is disabled with a value of ``False``.
 
 .. code-block:: python
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst', 'r') as readme_rst:
 requires = [
     'future>=0.16.0',
     'requests>=2.14.0',
-    'sphinx>=1.6.3',
+    'sphinx>=1.6.3'
     ]
 
 setup(

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -74,7 +74,7 @@ def setup(app):
     app.add_config_value('confluence_purge', None, False)
     """Enablement of purging legacy child pages from a master page."""
     app.add_config_value('confluence_purge_from_master', None, False)
-    
+
     """(advanced-configuration - processing)"""
     """Filename suffix for generated files."""
     app.add_config_value('confluence_file_suffix', ".conf", False)
@@ -92,6 +92,8 @@ def setup(app):
     app.add_config_value('confluence_remove_title', True, False)
 
     """(advanced-configuration - publishing)"""
+    """Request for publish username to come from interactive session."""
+    app.add_config_value('confluence_ask_user', False, False)
     """Request for publish password to come from interactive session."""
     app.add_config_value('confluence_ask_password', False, False)
     """File/path to Certificate Authority"""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -77,6 +77,13 @@ class ConfluenceBuilder(Builder):
         if not ConfluenceConfig.validate(self, not suppress_conf_check):
             raise ConfluenceConfigurationError('configuration error')
 
+        if self.config.confluence_ask_user:
+            print('(request to accept username from interactive session)')
+            print(' Instance: ' + self.config.confluence_server_url)
+            self.config.confluence_server_user = input(' User: ')
+            if not self.config.confluence_server_user:
+                raise ConfluenceConfigurationError('no user provided')
+
         if self.config.confluence_ask_password:
             print('(request to accept password from interactive session)')
             print(' Instance: ' + self.config.confluence_server_url)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -80,7 +80,7 @@ class ConfluenceBuilder(Builder):
         if self.config.confluence_ask_user:
             print('(request to accept username from interactive session)')
             print(' Instance: ' + self.config.confluence_server_url)
-            self.config.confluence_server_user = input(' User: ')
+            self.config.confluence_server_user = input(' User [current-user-conf]: ')
             if not self.config.confluence_server_user:
                 raise ConfluenceConfigurationError('no user provided')
 


### PR DESCRIPTION
This option acts similarly to `confluence_ask_password` but applies to `confluence_server_user`. 

Users might want to avoid writing their username in files tracked by version control. 

This is less important than not writing passwords but still useful.