### PR TITLE
Add support for :guilabel: role

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1090,6 +1090,21 @@ class ConfluenceTranslator(BaseTranslator):
     def depart_superscript(self, node):
         self.body.append(self.context.pop()) # sup
 
+    def visit_inline(self, node):
+        classes = node.get('classes', [])
+        if classes in [['guilabel']]:
+            self.body.append(self._start_tag(node, 'em'))
+            self.context.append(self._end_tag(node, suffix=''))
+        elif classes in [['accelerator']]:
+            self.body.append(self._start_tag(node, 'u'))
+            self.context.append(self._end_tag(node, suffix=''))
+        else:
+            # ignoring; no special handling of other inline entries
+            self.context.append('')
+
+    def depart_inline(self, node):
+        self.body.append(self.context.pop())
+
     visit_literal_emphasis = visit_emphasis
     depart_literal_emphasis = depart_emphasis
     visit_literal_strong = visit_strong
@@ -1568,13 +1583,6 @@ class ConfluenceTranslator(BaseTranslator):
     def visit_hlist(self, node):
         # unsupported
         raise nodes.SkipNode
-
-    def visit_inline(self, node):
-        # ignoring; no need to handle specific inline entries
-        pass
-
-    def depart_inline(self, node):
-        pass
 
     def visit_line(self, node):
         # ignoring; no need to handle specific line entries

--- a/test/unit-tests/common/dataset-common/markup.rst
+++ b/test/unit-tests/common/dataset-common/markup.rst
@@ -16,3 +16,5 @@ markup
 :sub:`subscript`
 
 :sup:`superscript`
+
+:guilabel:`&guilabel`

--- a/test/unit-tests/common/expected/markup.conf
+++ b/test/unit-tests/common/expected/markup.conf
@@ -4,3 +4,4 @@
 <p><code>inline</code></p>
 <p><sub>subscript</sub></p>
 <p><sup>superscript</sup></p>
+<p><em><u>g</u>uilabel</em></p>

--- a/test/validation-sets/common/markup.rst
+++ b/test/validation-sets/common/markup.rst
@@ -18,4 +18,6 @@ This is :sub:`subscript` text.
 
 This is :sup:`superscript` text.
 
+This is a :guilabel:`&guilabel`.
+
 .. _inline markup: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-markup


### PR DESCRIPTION
Includes support for accelerators.

Sphinx documentation: http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-guilabel