### PR TITLE
translator: force clear on figure containers

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1131,6 +1131,8 @@ class ConfluenceTranslator(BaseTranslator):
                 node, 'hr', suffix=self.nl, empty=True))
 
     def depart_figure(self, node):
+        # force clear from a floating confluence image
+        self.body.append('<div style="clear: both"> </div>')
         self.body.append(self.context.pop()) # <dynamic>
 
     def visit_image(self, node):

--- a/test/unit-tests/common/expected-center/figure.conf
+++ b/test/unit-tests/common/expected-center/figure.conf
@@ -6,7 +6,7 @@
         </ac:image><p style="text-align: center;">caption</p>
         <p><p>legend</p>
         </p>
-    </ac:rich-text-body>
+    <div style="clear: both"> </div></ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
@@ -16,7 +16,7 @@
         </ac:image><p>caption</p>
         <p><p>legend</p>
         </p>
-    </ac:rich-text-body>
+    <div style="clear: both"> </div></ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
@@ -26,7 +26,7 @@
         </ac:image><p style="text-align: center;">caption</p>
         <p><p>legend</p>
         </p>
-    </ac:rich-text-body>
+    <div style="clear: both"> </div></ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
@@ -37,5 +37,5 @@
         </ac:image><p>caption</p>
         <p><p>legend</p>
         </p>
-    </ac:rich-text-body>
+    <div style="clear: both"> </div></ac:rich-text-body>
 </ac:structured-macro>

--- a/test/unit-tests/common/expected/figure.conf
+++ b/test/unit-tests/common/expected/figure.conf
@@ -6,7 +6,7 @@
         </ac:image><p>caption</p>
         <p><p>legend</p>
         </p>
-    </ac:rich-text-body>
+    <div style="clear: both"> </div></ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
@@ -16,7 +16,7 @@
         </ac:image><p>caption</p>
         <p><p>legend</p>
         </p>
-    </ac:rich-text-body>
+    <div style="clear: both"> </div></ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
@@ -26,7 +26,7 @@
         </ac:image><p style="text-align: center;">caption</p>
         <p><p>legend</p>
         </p>
-    </ac:rich-text-body>
+    <div style="clear: both"> </div></ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
@@ -37,5 +37,5 @@
         </ac:image><p>caption</p>
         <p><p>legend</p>
         </p>
-    </ac:rich-text-body>
+    <div style="clear: both"> </div></ac:rich-text-body>
 </ac:structured-macro>


### PR DESCRIPTION
Documents using the figure directive will result in a "container" to help visually group the image, caption and description together. In the event where a figure has an alignment type and is very large, the image will undesirably float outside the container area. Correcting this by explicitly clearing floating elements when closing up a figure's container.