### PR TITLE
translator: consistent line joining in confluence 7

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -62,6 +62,7 @@ class ConfluenceTranslator(BaseTranslator):
         self.nl = '\n'
         self.warn = document.reporter.warning
         self._building_footnotes = False
+        self._literal = False
         self._manpage_url = getattr(config, 'manpages_url', None)
         self._quote_level = 0
         self._reference_context = []
@@ -128,6 +129,8 @@ class ConfluenceTranslator(BaseTranslator):
 
     def visit_Text(self, node):
         text = node.astext()
+        if not self._literal:
+            text = text.replace(self.nl, ' ')
         text = self._escape_sf(text)
         self.body.append(text)
         raise nodes.SkipNode
@@ -487,6 +490,8 @@ class ConfluenceTranslator(BaseTranslator):
     # -------------------------------
 
     def visit_literal_block(self, node):
+        self._literal = True
+
         is_parsed_literal = node.rawsource != node.astext()
         if is_parsed_literal:
             self.body.append(self._start_tag(node, 'div', suffix=self.nl,
@@ -550,6 +555,8 @@ class ConfluenceTranslator(BaseTranslator):
         raise nodes.SkipNode
 
     def depart_literal_block(self, node):
+        self._literal = False
+
         # note: depart is only invoked for parsed-literals
         self.body.append(self.context.pop()) # code
         self.body.append(self.context.pop()) # pre

--- a/test/unit-tests/toctree/expected-hierarchy/toctree-doc2.conf
+++ b/test/unit-tests/toctree/expected-hierarchy/toctree-doc2.conf
@@ -9,8 +9,7 @@
 <p>Jump to either <ac:link ac:anchor="example-doc1-label">
     <ri:page ri:content-title="treedoc1" />
     <ac:link-body>doc1</ac:link-body>
-</ac:link> or
-<ac:link ac:anchor="example-doc3-label">
+</ac:link> or <ac:link ac:anchor="example-doc3-label">
     <ri:page ri:content-title="treedoc3" />
     <ac:link-body>doc2</ac:link-body>
 </ac:link>.</p>


### PR DESCRIPTION
This extension follows the pattern seen in builders like `html` which joins lines together since content viewers not specifically fixed. Originally, this build would just pass-through newline characters into wrapped tagged storage format documents since Confluence did not care about newline characters inside. With Confluence 7, this appears to have changed (at least Confluence Cloud 1000.0.0-bc698fa60ab and Confluence Server 7.1.0-beta1 (build 11038)). To help handle this, always* strip out newline characters from the documents (* with the exception of literal blocks).