### PR TITLE
promote case-sensitive space name design

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -112,8 +112,8 @@ Key of the space in Confluence to be used to publish generated documents to.
 
    confluence_space_name = 'MyAwesomeSpace'
 
-Note that the space name can be case-sensitive in most (if not all) versions of
-Confluence.
+Note that the space name can be **case-sensitive** in most (if not all) versions
+of Confluence.
 
 general configuration
 ---------------------

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -39,6 +39,8 @@ class ConfluenceBadSpaceError(ConfluenceError):
             """---\n"""
             """The configured Confluence space does not appear to be """
             """valid: %s\n""" % space_name +
+            """\n"""
+            """Note: Confluence space names are case-sensitive.\n"""
             """---\n"""
         )
 


### PR DESCRIPTION
The configured Confluence space name is case-sensitive, which is not always emphasized to users. This may cause some confusion for initial environments where a user believed their configured environment is right but still gets a bad space error. Adding a note inside the bad-space exception to reflect this in the user's failed output (if observed) as well as put a strong emphasis in the documentation's configuration section.