### PR TITLE
Do not fail with NotImplementedError on math_block

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1300,6 +1300,10 @@ class ConfluenceTranslator(BaseTranslator):
         # unsupported
         raise nodes.SkipNode
 
+    def visit_math_block(self, node):
+        # unsupported
+        raise nodes.SkipNode
+
     # -------------------------
     # sphinx -- production list
     # -------------------------


### PR DESCRIPTION
Sphinx v2.2+ shows the following warning on every build:
`RemovedInSphinx30Warning: Translator for <class 'sphinxcontrib.confluencebuilder.translator.ConfluenceTranslator'> does not support math_block node'. Please update your extension.`

It does not seem like a problem because [the code that generates this warning](https://github.com/sphinx-doc/sphinx/blob/v2.2.0/sphinx/transforms/post_transforms/compat.py#L50) does not actually check if `math_block` is supported.

However when one does have a document that includes math, the build fails with the following error:
```
Exception occurred:
  File "/usr/local/lib/python3.7/site-packages/sphinxcontrib/confluencebuilder/translator.py", line 132, in unknown_visit
    raise NotImplementedError('unknown node: ' + node.__class__.__name__)
NotImplementedError: unknown node: math_block
```

This PR does not add support for `math_block` (since math is not supported yet, see #136), but it does stop the build from failing by defining a visit function that just skips the node.