### PR TITLE
completion of ask-user feature

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -510,6 +510,16 @@ Note that some shell sessions may not be able to pull the password value
 properly from the user. For example, Cygwin/MinGW may not be able to accept a
 password unless invoked with ``winpty``.
 
+confluence_ask_user
+~~~~~~~~~~~~~~~~~~~
+
+Similar to ``confluence_ask_password`` but applies to ``confluence_server_user``
+
+.. code-block:: python
+
+   confluence_ask_user = False
+
+
 confluence_asset_override
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -513,7 +513,12 @@ password unless invoked with ``winpty``.
 confluence_ask_user
 ~~~~~~~~~~~~~~~~~~~
 
-Similar to ``confluence_ask_password`` but applies to ``confluence_server_user``
+Provides an override for an interactive shell to request publishing documents
+using a user provided from the shell environment. While a
+user is typically defined in the option ``confluence_server_user``, select
+environments may wish to provide a way to provide a user without needing to
+modify documentation sources.
+By default, this option is disabled with a value of ``False``.
 
 .. code-block:: python
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst', 'r') as readme_rst:
 requires = [
     'future>=0.16.0',
     'requests>=2.14.0',
-    'sphinx>=1.6.3',
+    'sphinx>=1.6.3'
     ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst', 'r') as readme_rst:
 requires = [
     'future>=0.16.0',
     'requests>=2.14.0',
-    'sphinx>=1.6.3'
+    'sphinx>=1.6.3',
     ]
 
 setup(

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -102,6 +102,8 @@ def setup(app):
     app.add_config_value('confluence_remove_title', True, False)
 
     """(advanced-configuration - publishing)"""
+    """Request for publish username to come from interactive session."""
+    app.add_config_value('confluence_ask_user', False, False)
     """Request for publish password to come from interactive session."""
     app.add_config_value('confluence_ask_password', False, False)
     """File/path to Certificate Authority"""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -96,8 +96,9 @@ class ConfluenceBuilder(Builder):
 
         if self.config.confluence_ask_password:
             print('(request to accept password from interactive session)')
-            print(' Instance: ' + self.config.confluence_server_url)
-            print('     User: ' + self.config.confluence_server_user)
+            if not self.config.confluence_ask_user:
+                print(' Instance: ' + self.config.confluence_server_url)
+                print('     User: ' + self.config.confluence_server_user)
             sys.stdout.write(' Password: ')
             sys.stdout.flush()
             self.config.confluence_server_pass = getpass('')

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -77,6 +77,13 @@ class ConfluenceBuilder(Builder):
         if not ConfluenceConfig.validate(self, not suppress_conf_check):
             raise ConfluenceConfigurationError('configuration error')
 
+        if self.config.confluence_ask_user:
+            print('(request to accept username from interactive session)')
+            print(' Instance: ' + self.config.confluence_server_url)
+            self.config.confluence_server_user = input(' User: ')
+            if not self.config.confluence_server_user:
+                raise ConfluenceConfigurationError('no user provided')
+
         if self.config.confluence_ask_password:
             print('(request to accept password from interactive session)')
             print(' Instance: ' + self.config.confluence_server_url)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -80,9 +80,19 @@ class ConfluenceBuilder(Builder):
         if self.config.confluence_ask_user:
             print('(request to accept username from interactive session)')
             print(' Instance: ' + self.config.confluence_server_url)
-            self.config.confluence_server_user = input(' User [current-user-conf]: ')
-            if not self.config.confluence_server_user:
+
+            default_user = self.config.confluence_server_user
+            u_str = ''
+            if default_user:
+                u_str = ' [{}]'.format(default_user)
+
+            target_user = input(' User{}: '.format(u_str)) or default_user
+
+            print('target_user', target_user)
+            if not target_user:
                 raise ConfluenceConfigurationError('no user provided')
+
+            self.config.confluence_server_user = target_user
 
         if self.config.confluence_ask_password:
             print('(request to accept password from interactive session)')

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -80,7 +80,7 @@ class ConfluenceBuilder(Builder):
         if self.config.confluence_ask_user:
             print('(request to accept username from interactive session)')
             print(' Instance: ' + self.config.confluence_server_url)
-            self.config.confluence_server_user = input(' User: ')
+            self.config.confluence_server_user = input(' User [current-user-conf]: ')
             if not self.config.confluence_server_user:
                 raise ConfluenceConfigurationError('no user provided')
 


### PR DESCRIPTION
This is additional changes stacked onto the #230 pull request.

Tweaks include:
- Allow a pre-configured username to act as a default username.
- Limit output when using both ask-user and ask-pass.