### PR TITLE
properly check for string type in subset configuration

### DIFF
--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -7,6 +7,10 @@
 from .logger import ConfluenceLogger
 import os.path
 
+try:
+    basestring
+except NameError:
+    basestring = str
 
 class ConfluenceConfig:
     """
@@ -69,7 +73,7 @@ string, etc.).
 
         if c.confluence_publish_subset:
             if not (isinstance(c.confluence_publish_subset, (tuple, list, set))
-                    and all(isinstance(docname, str)
+                    and all(isinstance(docname, basestring)
                             for docname in c.confluence_publish_subset)):
                 errState = True
                 if log:

--- a/test/unit-tests/common/test_config.py
+++ b/test/unit-tests/common/test_config.py
@@ -23,6 +23,7 @@ class TestConfluenceConfig(unittest.TestCase):
         # legacy
         with self._build_app() as app:
             self.app = app
+            super(TestConfluenceConfig, self).run(result)
 
     @contextmanager
     def _build_app(self):
@@ -88,29 +89,28 @@ class TestConfluenceConfig(unittest.TestCase):
             builder.init(suppress_conf_check=True)
 
     def test_publish_subset(self):
-        with self._build_app() as app:
-            builder = ConfluenceBuilder(app)
-            builder.config.source_suffix = {
-                '.rst': 'restructuredtext',
-            }
+        builder = ConfluenceBuilder(self.app)
+        builder.config.source_suffix = {
+            '.rst': 'restructuredtext',
+        }
 
-            builder.config.confluence_publish_subset = 'doc' # expect list-like
-            with self.assertRaises(ConfluenceConfigurationError):
-                builder.init(suppress_conf_check=True)
+        builder.config.confluence_publish_subset = 'doc' # expect list-like
+        with self.assertRaises(ConfluenceConfigurationError):
+            builder.init(suppress_conf_check=True)
 
-            builder.config.confluence_publish_subset = [True, False]
-            with self.assertRaises(ConfluenceConfigurationError):
-                builder.init(suppress_conf_check=True)
+        builder.config.confluence_publish_subset = [True, False]
+        with self.assertRaises(ConfluenceConfigurationError):
+            builder.init(suppress_conf_check=True)
 
-            builder.config.confluence_publish_subset = ['admonitions.rst']
-            with self.assertRaises(ConfluenceConfigurationError):
-                builder.init(suppress_conf_check=True)
+        builder.config.confluence_publish_subset = ['admonitions.rst']
+        with self.assertRaises(ConfluenceConfigurationError):
+            builder.init(suppress_conf_check=True)
 
-            builder.config.confluence_publish_subset = ['admonitions']
-            try:
-                builder.init(suppress_conf_check=True)
-            except ConfluenceConfigurationError:
-                self.fail('configuration exception raised with valid subset')
+        builder.config.confluence_publish_subset = ['admonitions']
+        try:
+            builder.init(suppress_conf_check=True)
+        except ConfluenceConfigurationError:
+            self.fail('configuration exception raised with valid subset')
 
     def test_invalid_ca_cert(self):
         builder = ConfluenceBuilder(self.app)

--- a/test/unit-tests/common/test_config.py
+++ b/test/unit-tests/common/test_config.py
@@ -112,6 +112,14 @@ class TestConfluenceConfig(unittest.TestCase):
         except ConfluenceConfigurationError:
             self.fail('configuration exception raised with valid subset')
 
+        # explicitly force unicode strings to help verify python 2.x series
+        # dealing with unicode strings inside the document subset
+        builder.config.confluence_publish_subset = [u'admonitions']
+        try:
+            builder.init(suppress_conf_check=True)
+        except ConfluenceConfigurationError:
+            self.fail('configuration exception raised with unicode subset')
+
     def test_invalid_ca_cert(self):
         builder = ConfluenceBuilder(self.app)
         ca_cert = os.path.join(self.test_dir, 'certs', 'non_existant.crt')


### PR DESCRIPTION
The `confluence_publish_subset` option includes a configuration check to ensure the type is of a non-string sequence type which contains string entries; however, the implementation would verify a string type by checking if the type is of `str`. This causes issues in Python 2.x since Unicode strings are not of the `str` type. Adjusting the string check to verify against a `basestring` type (with an appropriate fallback for Python 2.x interpreters).