### PR TITLE
translator: allow ignoring unknown nodes

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -139,6 +139,8 @@ def setup(app):
     app.add_config_value('confluence_adv_aggressive_search', None, False)
     """Enablement of the children macro for hierarchy mode."""
     app.add_config_value('confluence_adv_hierarchy_child_macro', None, False)
+    """List of node types to ignore if no translator support exists."""
+    app.add_config_value('confluence_adv_ignore_nodes', [], False)
     """List of extension-provided macros restricted for use."""
     app.add_config_value('confluence_adv_restricted_macros', [], False)
     """Enablement of tracing processed data."""

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -137,7 +137,13 @@ class ConfluenceTranslator(BaseTranslator):
         raise nodes.SkipNode
 
     def unknown_visit(self, node):
-        raise NotImplementedError('unknown node: ' + node.__class__.__name__)
+        node_name = node.__class__.__name__
+        ignore_nodes = self.builder.config.confluence_adv_ignore_nodes
+        if node_name in ignore_nodes:
+            ConfluenceLogger.verbose('ignore node {} (conf)'.format(node_name))
+            raise nodes.SkipNode
+
+        raise NotImplementedError('unknown node: ' + node_name)
 
     # ---------
     # structure


### PR DESCRIPTION
Introduces an advanced option `confluence_adv_ignore_nodes` to allow a builder to ignore one or more specific node types. The existing `NotImplementedError` purposely exists to help notify that the running translator cannot properly process a given documentation's source; however, there may be select times where a user may not care about specific node types (i.e. nodes not specific relevant to Confluence or developing/testing support with other extension types). For these scenarios, a builder can define one or more node types inside an ignore-nodes list:

```
    confluence_adv_ignore_nodes = ['nodea', 'nodeb', ...]
```