### PR TITLE
Output useful error message when server does not return JSON

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -222,6 +222,6 @@ class Rest:
         err += "API: " + key + "\n"
         try:
             err += 'DATA: {}'.format(json.dumps(rsp.json(), indent=2))
-        except TypeError:
+        except:
             err += 'DATA: <not-or-invalid-json>'
         return err

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -5,6 +5,7 @@
 """
 
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadApiError
 from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
 from subprocess import check_output
 import io
@@ -150,6 +151,15 @@ class TestConfluenceValidation(unittest.TestCase):
         doc_dir, doctree_dir = _.prepareDirectories('validation-set-xmlrpc')
 
         _.buildSphinx(dataset, doc_dir, doctree_dir, config)
+
+    def test_nonjsonresponse(self):
+        config = dict(self.config)
+        config['confluence_server_url'] = 'https://example.com/'
+        dataset = os.path.join(self.datasets, 'base')
+        doc_dir, doctree_dir = _.prepareDirectories('validation-set-nonjsonresponse')
+
+        with self.assertRaises(ConfluenceBadApiError):
+            _.buildSphinx(dataset, doc_dir, doctree_dir, config)
 
 if __name__ == '__main__':
     sys.exit(unittest.main(verbosity=0))


### PR DESCRIPTION
If the Confluence server to publish to returns non-JSON response (e.g. a 404 page), the build fails with an uncaught error:
```
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This PR changes the code handle `ValueError` (superclass of `JSONDecodeError`) to output a proper error message:
```
sphinxcontrib.confluencebuilder error:
---
An issue has been detected when trying to communicate with Confluence server.

Ensure the server is running or your Confluence server URL is valid:

    https://example.com/

(details: <ProtocolError for example.com/rpc/xmlrpc: 404 Not Found>)
---
```

Note that the `err` variable is not printed here.

I added a testcase; it tries to call example.com, which returns a 404. Might be better to use a different server for this, but it needs to return a 404 or some other non-JSON response. If I use atlassian.net it will return a different type of REST error that is valid JSON.