### PR TITLE
Wrap arguments in option list in <code>

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -449,8 +449,11 @@ class ConfluenceTranslator(BaseTranslator):
         self.body.append(self._start_tag(node, 'td',
             **{'style': 'border: none'}))
         self.context.append(self._end_tag(node))
+        self.body.append(self._start_tag(node, 'code'))
+        self.context.append(self._end_tag(node, suffix=''))
 
     def depart_option_group(self, node):
+        self.body.append(self.context.pop()) # code
         self.body.append(self.context.pop()) # td
 
     def visit_option(self, node):
@@ -470,9 +473,11 @@ class ConfluenceTranslator(BaseTranslator):
 
     def visit_option_argument(self, node):
         self.body.append(node['delimiter'])
+        self.body.append(self._start_tag(node, 'em'))
+        self.context.append(self._end_tag(node, suffix=''))
 
     def depart_option_argument(self, node):
-        pass
+        self.body.append(self.context.pop()) # em
 
     def visit_description(self, node):
         self.body.append(self._start_tag(node, 'td',

--- a/test/unit-tests/common/dataset-common/option-lists.rst
+++ b/test/unit-tests/common/dataset-common/option-lists.rst
@@ -19,3 +19,6 @@ option lists
 
 --long-option
            description 5
+
+--long-option=value
+           description 6

--- a/test/unit-tests/common/expected/option-lists.conf
+++ b/test/unit-tests/common/expected/option-lists.conf
@@ -1,22 +1,22 @@
 <table>
     <tbody>
         <tr>
-            <td style="border: none">-a</td>
+            <td style="border: none"><code>-a</code></td>
             <td style="border: none"><p>description 1</p>
             </td>
         </tr>
         <tr>
-            <td style="border: none">-b</td>
+            <td style="border: none"><code>-b</code></td>
             <td style="border: none"><p>description 2</p>
             </td>
         </tr>
         <tr>
-            <td style="border: none">-c arg</td>
+            <td style="border: none"><code>-c <em>arg</em></code></td>
             <td style="border: none"><p>description 3</p>
             </td>
         </tr>
         <tr>
-            <td style="border: none">-d</td>
+            <td style="border: none"><code>-d</code></td>
             <td style="border: none"><p>description 4 1</p>
                 <ul>
                     <li>
@@ -30,8 +30,13 @@
             </td>
         </tr>
         <tr>
-            <td style="border: none">--long-option</td>
+            <td style="border: none"><code>--long-option</code></td>
             <td style="border: none"><p>description 5</p>
+            </td>
+        </tr>
+        <tr>
+            <td style="border: none"><code>--long-option=<em>value</em></code></td>
+            <td style="border: none"><p>description 6</p>
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
This PR wraps the first table cell of option lists (used to document arguments for CLI programs) in `<code>` so that they are displayed as monospaced text.

Arguments are wrapped in `<em>`. This is in line with how the sphinx_rtd_theme HTML theme does it, but different from stock docutils, which just uses monospace for everything.