### PR TITLE
introduce requests auth passthrough

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -375,6 +375,33 @@ to ``True`` before taking effect.
 advanced configuration - authentication
 ---------------------------------------
 
+confluence_server_auth
+~~~~~~~~~~~~~~~~~~~~~~
+
+An authentication handler which can be directly provided to a REST API request.
+REST calls in this extension use the Requests_ library, which provide various
+methods for a client to perform authentication. While this extension already
+provided simple authentication support (via ``confluence_server_user`` and
+``confluence_server_pass``), a publisher may need to configure an advanced
+authentication handler to support a target Confluence instance.
+
+Note that this extension does not define custom authentication handlers. This
+configuration is a passthrough option only. For more details on various ways to
+use authentication handlers, please consult `Requests -- Authentication`_. By
+default, no custom authentication handler is provided to generated REST API
+requests (if any).
+
+.. code-block:: python
+
+   from requests_oauthlib import OAuth1
+
+   ...
+
+   confluence_server_auth = OAuth1(client_key,
+       client_secret=client_secret,
+       resource_owner_key=resource_owner_key,
+       resource_owner_secret=resource_owner_secret)
+
 confluence_server_cookies
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -752,6 +779,7 @@ seconds, the following can be used:
 .. _Pygments documented language types: http://pygments.org/docs/lexers/
 .. _Requests SSL Cert Verification: http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
 .. _Requests: https://pypi.python.org/pypi/requests
+.. _Requests -- Authentication: https://2.python-requests.org/projects/3/user/authentication/
 .. _TLS/SSL wrapper for socket object: https://docs.python.org/3/library/ssl.html#ssl.create_default_context
 .. _api_tokens: https://confluence.atlassian.com/cloud/api-tokens-938839638.html
 .. _get_outdated_docs: https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder.get_outdated_docs

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -93,6 +93,8 @@ def setup(app):
     app.add_config_value('confluence_purge_from_master', None, False)
 
     """(advanced-configuration - authentication)"""
+    """Authentication passthrough for Confluence REST interaction."""
+    app.add_config_value('confluence_server_auth', None, False)
     """Cookie(s) to use for Confluence REST interaction."""
     app.add_config_value('confluence_server_cookies', None, False)
 

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -40,6 +40,9 @@ class ConfluenceBadSpaceError(ConfluenceError):
             """The configured Confluence space does not appear to be """
             """valid: %s\n""" % space_name +
             """\n"""
+            """Ensure the server is running or your Confluence URL is valid. """
+            """Also ensure your authentication options are properly set.\n"""
+            """\n"""
             """Note: Confluence space names are case-sensitive.\n"""
             """---\n"""
         )

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -76,7 +76,9 @@ class Rest:
                                  config.confluence_disable_ssl_validation)
             session.mount(self.url, adapter)
 
-        if config.confluence_server_user:
+        if config.confluence_server_auth:
+            session.auth = config.confluence_server_auth
+        elif config.confluence_server_user:
             session.auth = (
                 config.confluence_server_user,
                 config.confluence_server_pass)


### PR DESCRIPTION
Users may require more complex authentication handlers for their respective Confluence instances. For these cases, allow a user to directly pass in an authentication handler directly to the Request's call.

This prevents the need for this extension to keep expanding on various authentication methods; leaving only the maintenance of simple authentication in this implementation.