### PR TITLE
introduce math support

### DIFF
--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -55,7 +55,9 @@ list table             supported     - `reStructuredText List Table`_
                                        ``widths``.
 literal blocks         supported     - `reStructuredText Literal Blocks`_
 manpage                supported     - `Sphinx Manpage`_
-math                   unplanned     - `reStructuredText Math`_
+math                   supported     - `reStructuredText Math`_
+                                     - Requires a LaTeX and dvipng/dvisvgm
+                                       installation.
 parsed literal block   supported     - `reStructuredText Parsed Literal Block`_
 option lists           supported     - `reStructuredText Option Lists`_
 production list        supported     - `Sphinx Production List`_

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -25,6 +25,12 @@ try:
 except ImportError:
     pass
 
+# load imgmath extension if available to handle math configuration options
+try:
+    from sphinx.ext import imgmath
+except:
+    imgmath = None
+
 __version__='1.2.0-dev0'
 
 def main():
@@ -179,6 +185,13 @@ def setup(app):
 
     if 'sphinx.ext.autosummary' in app.config.extensions:
         add_autosummary_nodes(app)
+
+    # if sphinx.ext.imgmath is not already explicitly loaded, bind it into the
+    # setup process to a configurer can use the same configuration options
+    # outlined in the sphinx.ext.imgmath in this extension
+    if (imgmath is not None and
+            'sphinx.ext.imgmath' not in app.config.extensions):
+        imgmath.setup(app)
 
     return {
         'version': __version__,

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -186,11 +186,16 @@ def setup(app):
     if 'sphinx.ext.autosummary' in app.config.extensions:
         add_autosummary_nodes(app)
 
-    # if sphinx.ext.imgmath is not already explicitly loaded, bind it into the
+    # lazy bind sphinx.ext.imgmath to provide configuration options
+    #
+    # If 'sphinx.ext.imgmath' is not already explicitly loaded, bind it into the
     # setup process to a configurer can use the same configuration options
-    # outlined in the sphinx.ext.imgmath in this extension
+    # outlined in the sphinx.ext.imgmath in this extension. This applies for
+    # Sphinx 1.8 and higher which math support is embedded; for older versions,
+    # users will need to explicitly load 'sphinx.ext.mathbase'.
     if (imgmath is not None and
-            'sphinx.ext.imgmath' not in app.config.extensions):
+            'sphinx.ext.imgmath' not in app.config.extensions and
+            parse_version(sphinx_version) >= parse_version('1.8')):
         imgmath.setup(app)
 
     return {

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1322,10 +1322,6 @@ class ConfluenceTranslator(BaseTranslator):
     # sphinx -- math
     # --------------
 
-    def visit_math(self, node):
-        # unsupported
-        raise nodes.SkipNode
-
     def visit_displaymath(self, node):
         # unsupported
         raise nodes.SkipNode
@@ -1334,8 +1330,12 @@ class ConfluenceTranslator(BaseTranslator):
         # unsupported
         raise nodes.SkipNode
 
+    def visit_math(self, node):
+        # handled in "builder" at this time
+        raise nodes.SkipNode
+
     def visit_math_block(self, node):
-        # unsupported
+        # handled in "builder" at this time
         raise nodes.SkipNode
 
     # -------------------------

--- a/test/test_sandbox.py
+++ b/test/test_sandbox.py
@@ -14,7 +14,7 @@ def process_sandbox():
     sandbox_dir = os.path.join(test_dir, 'sandbox')
 
     doc_dir, doctree_dir = _.prepareDirectories('sandbox-test')
-    _.buildSphinx(sandbox_dir, doc_dir, doctree_dir)
+    _.buildSphinx(sandbox_dir, doc_dir, doctree_dir, relax=True)
 
 def process_raw_upload():
     test_dir = os.path.dirname(os.path.realpath(__file__))
@@ -26,7 +26,7 @@ def process_raw_upload():
         return
 
     doc_dir, doctree_dir = _.prepareDirectories('sandbox-test')
-    with _.prepareSphinx(sandbox_dir, doc_dir, doctree_dir) as app:
+    with _.prepareSphinx(sandbox_dir, doc_dir, doctree_dir, relax=True) as app:
         publisher = ConfluencePublisher()
         publisher.init(app.config)
         publisher.connect()

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -98,6 +98,7 @@ class TestConfluenceValidation(unittest.TestCase):
 
     def test_common(self):
         config = dict(self.config)
+        config['imgmath_image_format'] = 'svg'
 
         dataset = os.path.join(self.datasets, 'common')
         doc_dir, doctree_dir = _.prepareDirectories('validation-set-common')

--- a/test/validation-sets/common/index.rst
+++ b/test/validation-sets/common/index.rst
@@ -14,6 +14,7 @@ The following is a Sphinx generated `table of contents`_:
    indentation
    lists
    markup
+   math
    other
    paragraph-level-markup
    references

--- a/test/validation-sets/common/math.rst
+++ b/test/validation-sets/common/math.rst
@@ -1,0 +1,16 @@
+math
+====
+
+reStructuredText defines a `math directive`_.
+
+----
+
+The area of a circle is :math:`A_\text{c} = (\pi/4) d^2`.
+
+The mass–energy equivalence formula:
+
+.. math::
+
+   E = mc^2
+
+.. _math directive: http://docutils.sourceforge.net/docs/ref/rst/directives.html#math


### PR DESCRIPTION
This pull request provides the initial implementation to help processing math directives for Confluence publication. This extension handles this by converting math directives into images, which can be published to a Confluence instance for rendering. These changes follow closely to how `sphinx.ext.imgmath` operates.

Note that for a user to take advantage of math directives, they will need to install LaTeX and either dvipng or dvisvgm to properly generate images; otherwise math directives will be ignored.