### PR TITLE
test: enable verbosity environment variable

### DIFF
--- a/test/sphinxcontrib_confluencebuilder_util.py
+++ b/test/sphinxcontrib_confluencebuilder_util.py
@@ -135,6 +135,13 @@ class ConfluenceTestUtil:
         conf_dir = src_dir if not conf else None
         warnerr = not relax
 
+        verbosity = 0
+        if 'SPHINX_VERBOSITY' in os.environ:
+            try:
+                verbosity = int(os.environ['SPHINX_VERBOSITY'])
+            except:
+                pass
+
         with docutils_namespace():
             app = Sphinx(
                 src_dir,                # output for document sources
@@ -145,7 +152,8 @@ class ConfluenceTestUtil:
                 confoverrides=conf,     # load provided configuration (volatile)
                 status=sts,             # status output
                 warning=sys.stderr,     # warnings output
-                warningiserror=warnerr) # treat warnings as errors
+                warningiserror=warnerr, # treat warnings as errors
+                verbosity=verbosity)    # verbosity
 
             yield app
 


### PR DESCRIPTION
When under a test environment, there is not a gracefully way to enable Sphinx's verbosity flag -- primarily since we explicitly prepare Sphinx instances ourselves in tests and do not set the verbosity flag. Typically, a verbose Sphinx engine is not really required except for advanced cases. To test development/testers to easily enable this option (when using this repository's test options), allow them to enable verbosity by setting the `SPHINX_VERBOSITY` option. For example:

    $ SPHINX_VERBOSITY=2 tox -e sandbox