### PR TITLE
.travis.yml: use specific osx images for specific python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,9 @@ matrix:
     env: TOXENV=py27-sphinx18
     language: minimal
   - os: osx
-    env: TOXENV=py36-sphinx22
+    env: TOXENV=py37-sphinx22
     language: minimal
+    osx_image: xcode10.2 # python 3.7.3
   - os: windows
     env: TOXENV=py27-sphinx18
     language: sh


### PR DESCRIPTION
Adjust OSX builds to use specific images to ensure which Python revision is available to test against.