### PR TITLE
handle new sphinx major

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
     env: TOXENV=py35-sphinx21
   - python: "3.5"
     env: TOXENV=py35-sphinx22
+  - python: "3.5"
+    env: TOXENV=py35-sphinx23
   - python: "3.6"
     env: TOXENV=py36-sphinx16
   - python: "3.6"
@@ -38,6 +40,8 @@ matrix:
     env: TOXENV=py36-sphinx21
   - python: "3.6"
     env: TOXENV=py36-sphinx22
+  - python: "3.6"
+    env: TOXENV=py36-sphinx23
   - python: "3.7"
     env: TOXENV=py37-sphinx16
     dist: xenial
@@ -61,6 +65,9 @@ matrix:
   - python: "3.7"
     env: TOXENV=py37-sphinx22
     dist: xenial
+  - python: "3.7"
+    env: TOXENV=py37-sphinx23
+    dist: xenial
   - python: "3.8"
     env: TOXENV=py38-sphinx16
     dist: bionic
@@ -79,11 +86,14 @@ matrix:
   - python: "3.8"
     env: TOXENV=py38-sphinx22
     dist: bionic
+  - python: "3.8"
+    env: TOXENV=py38-sphinx23
+    dist: bionic
   - os: osx
     env: TOXENV=py27-sphinx18
     language: minimal
   - os: osx
-    env: TOXENV=py37-sphinx22
+    env: TOXENV=py37-sphinx23
     language: minimal
     osx_image: xcode10.2 # python 3.7.3
   - os: windows
@@ -93,7 +103,7 @@ matrix:
       - choco install python2
       - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
   - os: windows
-    env: TOXENV=py38-sphinx22
+    env: TOXENV=py38-sphinx23
     language: sh
     before_install:
       - choco install python3 --params "/InstallDir:C:\Python" --version=3.8.0

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -56,7 +56,6 @@ def setup(app):
             'TOX_WORK_DIR' in os.environ):
         ConfluenceLogger.warn('(deprecated) builder {} deprecated for '
             'Sphinx v1.6 and older'.format(ConfluenceBuilder.name))
-    proxy = os.environ.get('http_proxy', None)
 
     # Images defined by data uri schemas can be resolved into generated images
     # after a document's post-transformation stage. After a document's doctree

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -50,12 +50,12 @@ def setup(app):
     app.add_builder(ConfluenceBuilder)
     app.registry.add_translator(ConfluenceBuilder.name, ConfluenceTranslator)
 
-    # sphinx v1.6 is deprecated and is planned to be dropped in v1.3+
+    # sphinx v1.[6-7] is deprecated and is planned to be dropped in v1.3+
     # (ignore when tox is running; TOX_WORK_DIR)
-    if (parse_version(sphinx_version) < parse_version('1.7') and not
+    if (parse_version(sphinx_version) < parse_version('1.8') and not
             'TOX_WORK_DIR' in os.environ):
         ConfluenceLogger.warn('(deprecated) builder {} deprecated for '
-            'Sphinx v1.6 and older'.format(ConfluenceBuilder.name))
+            'Sphinx v1.7 and older'.format(ConfluenceBuilder.name))
 
     # Images defined by data uri schemas can be resolved into generated images
     # after a document's post-transformation stage. After a document's doctree

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,35,36,37,38}-sphinx{16,17,18}
-    py{35,36,37,38}-sphinx{20,21,22}
+    py{35,36,37,38}-sphinx{20,21,22,23}
     lint
     pylint
 
@@ -13,6 +13,7 @@ deps = -r{toxinidir}/requirements_dev.txt
     sphinx20: sphinx>=2.0,<2.1
     sphinx21: sphinx>=2.1,<2.2
     sphinx22: sphinx>=2.2,<2.3
+    sphinx23: sphinx>=2.3,<2.4
 changedir = test
 commands =
     python -m test_main {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,16 @@ envlist =
     py{35,36,37,38}-sphinx{20,21,22}
     lint
     pylint
+
 [testenv]
 deps = -r{toxinidir}/requirements_dev.txt
-        sphinx16: sphinx==1.6.3
-        sphinx17: sphinx>=1.7,<1.8
-        sphinx18: sphinx>=1.8,<2.0
-        sphinx20: sphinx>=2.0,<2.1
-        sphinx21: sphinx>=2.1,<2.2
-        sphinx22: sphinx>=2.2,<2.3
-changedir=test
+    sphinx16: sphinx==1.6.3
+    sphinx17: sphinx>=1.7,<1.8
+    sphinx18: sphinx>=1.8,<2.0
+    sphinx20: sphinx>=2.0,<2.1
+    sphinx21: sphinx>=2.1,<2.2
+    sphinx22: sphinx>=2.2,<2.3
+changedir = test
 commands =
     python -m test_main {posargs}
 


### PR DESCRIPTION
Adding testing for Sphinx v2.3.x series.

Since this extension aims to provides support for five Sphinx major releases, Sphinx v1.7 is now marked as deprecated for the next stable release.