### PR TITLE
adding missing hidden toctree and desc calls

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1454,6 +1454,13 @@ class ConfluenceTranslator(BaseTranslator):
     def depart_desc_signature(self, node):
         self.body.append(self.context.pop()) # dt
 
+    def visit_desc_signature_line(self, node):
+        self.body.append(self._start_tag(node, 'dt'))
+        self.context.append(self._end_tag(node))
+
+    def depart_desc_signature_line(self, node):
+        self.body.append(self.context.pop()) # dt
+
     def visit_desc_annotation(self, node):
         self.body.append(self._start_tag(node, 'em'))
         self.context.append(self._end_tag(node, suffix=''))
@@ -1657,6 +1664,9 @@ class ConfluenceTranslator(BaseTranslator):
 
     def depart_start_of_file(self, node):
         pass
+
+    def visit_toctree(self, node):
+        raise nodes.SkipNode
 
     # ##########################################################################
     # #                                                                        #

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1390,59 +1390,9 @@ class ConfluenceTranslator(BaseTranslator):
         # skip hidden toctree entries
         raise nodes.SkipNode
 
-    # -----------------------
-    # sphinx -- miscellaneous
-    # -----------------------
-
-    def visit_rubric(self, node):
-        self.body.append(self._start_tag(node, 'h{}'.format(self._title_level)))
-        self.context.append(self._end_tag(node))
-
-    def depart_rubric(self, node):
-        self.body.append(self.context.pop()) # h<x>
-
-    def visit_seealso(self, node):
-        self._visit_admonition(node, 'info', admonitionlabels['seealso'])
-
-    depart_seealso = _depart_admonition
-
-    def visit_versionmodified(self, node):
-        if node['type'] == 'deprecated' or node['type'] == 'versionchanged':
-            self._visit_note(node)
-        elif node['type'] == 'versionadded':
-            self._visit_info(node)
-        else:
-            ConfluenceLogger.warn('unsupported version modification type: '
-                '{}'.format(node['type']))
-            self._visit_info(node)
-
-    depart_versionmodified = _depart_admonition
-
-    # -----------------------------------------
-    # sphinx -- extension -- confluence builder
-    # -----------------------------------------
-
-    def visit_ConfluenceNavigationNode(self, node):
-        if node.bottom:
-            self.body.append(self._start_tag(
-                node, 'hr', suffix=self.nl, empty=True,
-                **{'style': 'margin-top: 30px'}))
-
-        self.body.append(self._start_tag(node, 'p', suffix=self.nl,
-            **{'style': 'text-align: right'}))
-        self.context.append(self._end_tag(node))
-
-    def depart_ConfluenceNavigationNode(self, node):
-        self.body.append(self.context.pop()) # p
-
-        if node.top:
-            self.body.append(self._start_tag(
-                node, 'hr', suffix=self.nl, empty=True,
-                **{'style': 'margin-bottom: 30px'}))
-
-    # ------------------------------
-    # sphinx -- extension -- autodoc
-    # ------------------------------
+    # -----------------
+    # sphinx -- domains
+    # -----------------
 
     def visit_desc(self, node):
         self.body.append(self._start_tag(node, 'dl', suffix=self.nl))
@@ -1541,6 +1491,56 @@ class ConfluenceTranslator(BaseTranslator):
 
     def depart_desc_content(self, node):
         self.body.append(self.context.pop()) # dd
+
+    # -----------------------
+    # sphinx -- miscellaneous
+    # -----------------------
+
+    def visit_rubric(self, node):
+        self.body.append(self._start_tag(node, 'h{}'.format(self._title_level)))
+        self.context.append(self._end_tag(node))
+
+    def depart_rubric(self, node):
+        self.body.append(self.context.pop()) # h<x>
+
+    def visit_seealso(self, node):
+        self._visit_admonition(node, 'info', admonitionlabels['seealso'])
+
+    depart_seealso = _depart_admonition
+
+    def visit_versionmodified(self, node):
+        if node['type'] == 'deprecated' or node['type'] == 'versionchanged':
+            self._visit_note(node)
+        elif node['type'] == 'versionadded':
+            self._visit_info(node)
+        else:
+            ConfluenceLogger.warn('unsupported version modification type: '
+                '{}'.format(node['type']))
+            self._visit_info(node)
+
+    depart_versionmodified = _depart_admonition
+
+    # -----------------------------------------
+    # sphinx -- extension -- confluence builder
+    # -----------------------------------------
+
+    def visit_ConfluenceNavigationNode(self, node):
+        if node.bottom:
+            self.body.append(self._start_tag(
+                node, 'hr', suffix=self.nl, empty=True,
+                **{'style': 'margin-top: 30px'}))
+
+        self.body.append(self._start_tag(node, 'p', suffix=self.nl,
+            **{'style': 'text-align: right'}))
+        self.context.append(self._end_tag(node))
+
+    def depart_ConfluenceNavigationNode(self, node):
+        self.body.append(self.context.pop()) # p
+
+        if node.top:
+            self.body.append(self._start_tag(
+                node, 'hr', suffix=self.nl, empty=True,
+                **{'style': 'margin-bottom: 30px'}))
 
     # ------------------------------------------
     # confluence-builder -- enhancements -- jira

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1452,11 +1452,12 @@ class ConfluenceTranslator(BaseTranslator):
         self.body.append(self.context.pop()) # dl
 
     def visit_desc_signature(self, node):
-        self.body.append(self._start_tag(node, 'dt'))
-        self.context.append(self._end_tag(node))
+        if not node.get('is_multiline'):
+            self.visit_desc_signature_line(node)
 
     def depart_desc_signature(self, node):
-        self.body.append(self.context.pop()) # dt
+        if not node.get('is_multiline'):
+            self.depart_desc_signature_line(node)
 
     def visit_desc_signature_line(self, node):
         self.body.append(self._start_tag(node, 'dt'))

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1386,6 +1386,10 @@ class ConfluenceTranslator(BaseTranslator):
     def depart_compound(self, node):
         pass
 
+    def visit_toctree(self, node):
+        # skip hidden toctree entries
+        raise nodes.SkipNode
+
     # -----------------------
     # sphinx -- miscellaneous
     # -----------------------
@@ -1664,9 +1668,6 @@ class ConfluenceTranslator(BaseTranslator):
 
     def depart_start_of_file(self, node):
         pass
-
-    def visit_toctree(self, node):
-        raise nodes.SkipNode
 
     # ##########################################################################
     # #                                                                        #

--- a/test/unit-tests/common/dataset-domains/c.rst
+++ b/test/unit-tests/common/dataset-domains/c.rst
@@ -1,0 +1,3 @@
+:orphan:
+
+.. c:function:: void* my_func(void *context)

--- a/test/unit-tests/common/dataset-domains/cpp.rst
+++ b/test/unit-tests/common/dataset-domains/cpp.rst
@@ -1,0 +1,4 @@
+:orphan:
+
+.. cpp:class:: template<> \
+               std::array<bool, 256>

--- a/test/unit-tests/common/dataset-domains/js.rst
+++ b/test/unit-tests/common/dataset-domains/js.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+.. js:function:: $.func(param1[, param2])
+
+   :param type param1: desc1
+   :param param2: desc2
+   :throws SomeError: desc3
+   :returns: returns

--- a/test/unit-tests/common/dataset-domains/py.rst
+++ b/test/unit-tests/common/dataset-domains/py.rst
@@ -1,0 +1,3 @@
+:orphan:
+
+.. py:function:: Timer.repeat(repeat=3, number=1000000)

--- a/test/unit-tests/common/dataset-domains/rst.rst
+++ b/test/unit-tests/common/dataset-domains/rst.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+.. rst:directive:: directive
+
+   desc

--- a/test/unit-tests/common/expected-domains/c.conf
+++ b/test/unit-tests/common/expected-domains/c.conf
@@ -1,0 +1,4 @@
+<dl>
+    <dt>void* <strong><code>my_func</code></strong>(<em>void<em> *context</em></em>)</dt>
+    <dd></dd>
+</dl>

--- a/test/unit-tests/common/expected-domains/cpp.conf
+++ b/test/unit-tests/common/expected-domains/cpp.conf
@@ -1,0 +1,5 @@
+<dl>
+    <dt>template&lt;&gt;</dt>
+    <dt><em>class </em><code>std<code>::</code></code><strong><code>array</code></strong>&lt;bool, 256&gt;</dt>
+    <dd></dd>
+</dl>

--- a/test/unit-tests/common/expected-domains/js.conf
+++ b/test/unit-tests/common/expected-domains/js.conf
@@ -1,0 +1,30 @@
+<dl>
+    <dt><code>$.</code><strong><code>func</code></strong>(<em>param1</em>[, <em>param2</em>])</dt>
+    <dd><table>
+        <tbody>
+            <tr>
+                <td style="border: none"><strong>Arguments:</strong></td>
+                <td style="border: none"><ul>
+                    <li>
+                        <p><strong>param1</strong> (<em>type</em>) – desc1</p>
+                    </li>
+                    <li>
+                        <p><strong>param2</strong> – desc2</p>
+                    </li>
+                </ul>
+                </td>
+            </tr>
+            <tr>
+                <td style="border: none"><strong>Throws:</strong></td>
+                <td style="border: none"><p><strong>SomeError</strong> – desc3</p>
+                </td>
+            </tr>
+            <tr>
+                <td style="border: none"><strong>Returns:</strong></td>
+                <td style="border: none"><p>returns</p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    </dd>
+</dl>

--- a/test/unit-tests/common/expected-domains/py.conf
+++ b/test/unit-tests/common/expected-domains/py.conf
@@ -1,0 +1,4 @@
+<dl>
+    <dt><code>Timer.</code><strong><code>repeat</code></strong>(<em>repeat=3</em>, <em>number=1000000</em>)</dt>
+    <dd></dd>
+</dl>

--- a/test/unit-tests/common/expected-domains/rst.conf
+++ b/test/unit-tests/common/expected-domains/rst.conf
@@ -1,0 +1,5 @@
+<dl>
+    <dt><strong><code>.. directive::</code></strong></dt>
+    <dd><p>desc</p>
+    </dd>
+</dl>

--- a/test/unit-tests/common/test_domains.py
+++ b/test/unit-tests/common/test_domains.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+    :copyright: Copyright 2019 by the contributors (see AUTHORS file).
+    :license: BSD-2-Clause, see LICENSE for details.
+"""
+
+from pkg_resources import parse_version
+from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
+from sphinx.__init__ import __version__ as sphinx_version
+import os
+import unittest
+
+class TestConfluenceDomains(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        config = _.prepareConfiguration()
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        dataset = os.path.join(test_dir, 'dataset-domains')
+        self.expected = os.path.join(test_dir, 'expected-domains')
+
+        doc_dir, doctree_dir = _.prepareDirectories('domains')
+        self.doc_dir = doc_dir
+
+        with _.prepareSphinx(dataset, doc_dir, doctree_dir, config) as app:
+            app.build(force_all=True)
+
+    def _assertExpectedWithOutput(self, name, expected=None):
+        expected = expected if expected else self.expected
+        _.assertExpectedWithOutput(self, name, expected, self.doc_dir)
+
+    def test_domains_c(self):
+        self._assertExpectedWithOutput('c')
+
+    def test_domains_cpp(self):
+        # cpp domain in v1.6 output processes differently when dealing with
+        # namespaces; and since v1.6 is deprecated, we care less about its
+        # output as support will go away in the future
+        if parse_version(sphinx_version) < parse_version('1.7'):
+            raise unittest.SkipTest('ignoring cpp domains verification in 1.6')
+
+        self._assertExpectedWithOutput('cpp')
+
+    def test_domains_js(self):
+        self._assertExpectedWithOutput('js')
+
+    def test_domains_py(self):
+        self._assertExpectedWithOutput('py')
+
+    def test_domains_rst(self):
+        self._assertExpectedWithOutput('rst')

--- a/test/unit-tests/toctree/dataset-hidden/index.rst
+++ b/test/unit-tests/toctree/dataset-hidden/index.rst
@@ -1,0 +1,12 @@
+toctree
+=======
+
+.. example of a hidden toctree where a document will dictate how links are
+   created manually
+
+.. toctree::
+   :hidden:
+
+   page
+
+:doc:`page`

--- a/test/unit-tests/toctree/dataset-hidden/page.rst
+++ b/test/unit-tests/toctree/dataset-hidden/page.rst
@@ -1,0 +1,4 @@
+page
+----
+
+content

--- a/test/unit-tests/toctree/expected-hidden/index.conf
+++ b/test/unit-tests/toctree/expected-hidden/index.conf
@@ -1,0 +1,4 @@
+<p><ac:link>
+    <ri:page ri:content-title="page" />
+    <ac:link-body>page</ac:link-body>
+</ac:link></p>

--- a/test/unit-tests/toctree/test_toctree.py
+++ b/test/unit-tests/toctree/test_toctree.py
@@ -13,16 +13,16 @@ class TestConfluenceToctreeMarkup(unittest.TestCase):
     def setUpClass(self):
         self.config = _.prepareConfiguration()
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
-        self.dataset = os.path.join(self.test_dir, 'dataset')
 
     def test_toctree_child_macro(self):
         config = dict(self.config)
         config['confluence_page_hierarchy'] = True
         config['confluence_adv_hierarchy_child_macro'] = True
 
+        dataset = os.path.join(self.test_dir, 'dataset')
         expected = os.path.join(self.test_dir, 'expected-cm')
         doc_dir, doctree_dir = _.prepareDirectories('toctree-markup-cm')
-        _.buildSphinx(self.dataset, doc_dir, doctree_dir, config)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config)
 
         _.assertExpectedWithOutput(self, 'index', expected, doc_dir)
         _.assertExpectedWithOutput(self, 'doca', expected, doc_dir)
@@ -30,11 +30,20 @@ class TestConfluenceToctreeMarkup(unittest.TestCase):
         _.assertExpectedWithOutput(self, 'docc', expected, doc_dir)
 
     def test_toctree_default(self):
+        dataset = os.path.join(self.test_dir, 'dataset')
         expected = os.path.join(self.test_dir, 'expected-def')
         doc_dir, doctree_dir = _.prepareDirectories('toctree-markup-def')
-        _.buildSphinx(self.dataset, doc_dir, doctree_dir, self.config)
+        _.buildSphinx(dataset, doc_dir, doctree_dir, self.config)
 
         _.assertExpectedWithOutput(self, 'index', expected, doc_dir)
         _.assertExpectedWithOutput(self, 'doca', expected, doc_dir)
         _.assertExpectedWithOutput(self, 'docb', expected, doc_dir)
         _.assertExpectedWithOutput(self, 'docc', expected, doc_dir)
+
+    def test_toctree_hidden(self):
+        dataset = os.path.join(self.test_dir, 'dataset-hidden')
+        expected = os.path.join(self.test_dir, 'expected-hidden')
+        doc_dir, doctree_dir = _.prepareDirectories('dataset-hidden')
+        _.buildSphinx(dataset, doc_dir, doctree_dir, self.config)
+
+        _.assertExpectedWithOutput(self, 'index', expected, doc_dir)


### PR DESCRIPTION
_(this pull request is based off of key changes from #219)_

This pull request is starts off with a cherry-pick of @jjcaballero's implementation for `visit_toctree` and `visit_desc_signature_line`-related calls. The goal is to introduce these key fixes in the upcoming stable release but it was decided that these changes were pulled from #219 as that pull request contains some additional examples/checks which need more consideration before migrating into `master` (see the pull request for more information).

There is one notable tweak to the description signature processing which prevents nested `dt` tags from being generated in multiline signature events.

This change introduced a more minimized set of unit testing for the hidden toctree and domains-related implementation. Note that the expected domains output for the unit tests is a preliminary data set -- the output will most likely change as improvements/tweaks are made to domains-related processing.