### PR TITLE
translator: build anchors on desc sigs

### DIFF
--- a/test/unit-tests/common/test_domains.py
+++ b/test/unit-tests/common/test_domains.py
@@ -14,6 +14,7 @@ class TestConfluenceDomains(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         config = _.prepareConfiguration()
+        config['confluence_adv_restricted_macros'] = ['anchor']
         test_dir = os.path.dirname(os.path.realpath(__file__))
         dataset = os.path.join(test_dir, 'dataset-domains')
         self.expected = os.path.join(test_dir, 'expected-domains')


### PR DESCRIPTION
Adjust anchor generation for descriptions to build off signature entries instead of relying on a description's name node. For descriptions with one or more signature lines, any assigned identifier on a signature will be placed in the leading portion of the first term entry.

This should address concerns outlined in #146.