### PR TITLE
maintenance -- 2020-01-01

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,26 +1,31 @@
 master
 ======
 
-* (note) sphinx v1.6 support for this extension is deprecated
+* (note) sphinx v1.[6-7] support for this extension is deprecated
 * (note) xml-rpc support for this extension is deprecated
 * fixed issue when using hierarchy on sphinx 2.1+ (new citations domain)
 * fixed issue with document names with path separators for windows users
+* fixed issue with multi-line description signatures (e.g. c++ autodocs)
+* fixed issue with processing hidden toctrees
 * fixed issue with unicode paths with confluence_publish_subset and python 2.7
 * improved formatting for option list arguments
 * improved handling and feedback when configured with incorrect publish instance
 * improved name management for published assets
+* improved reference linking for sphinx domains capability (meth, attr, etc.)
 * introduce a series of jira directives
 * support 'firstline' parameter in the code block macro
 * support base admonition directive
 * support confluence 7 series newline management
 * support default alignment in sphinx 2.1+
 * support document postfixes
+* support for generated image assets (asterisk marked)
 * support passthrough authentication handlers for rest calls
 * support previous/next navigation
 * support prompting for publish username
 * support sphinx.ext.autosummary extension
 * support sphinx.ext.todo extension
 * support the math directive
+* support toctree's numbered option
 * support users injecting cookie data (for authentication) into rest calls
 
 1.1.0 (2019-03-16)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Sphinx Confluence Builder'
-copyright = '2019. Anthony Shaw and contributors'
+copyright = '2020. Anthony Shaw and contributors'
 author = 'Anthony Shaw and contributors'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -19,10 +19,8 @@ All Atlassian Confluence Builder configurations are prefixed with
 
 .. contents:: :local:
 
-.. #############################################################################
-
-essential
----------
+essential configuration
+-----------------------
 
 confluence_publish
 ~~~~~~~~~~~~~~~~~~
@@ -34,6 +32,8 @@ value is set to ``False``.
 .. code-block:: python
 
    confluence_publish = True
+
+--------------------------------------------------------------------------------
 
 confluence_server_pass
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -63,6 +63,8 @@ username value should be used:
    provides a method for prompting for a password (see
    |confluence_ask_password|_).
 
+--------------------------------------------------------------------------------
+
 confluence_server_url
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -89,6 +91,8 @@ follows:
 
    confluence_server_url = 'https://intranet-wiki.example.com/'
 
+--------------------------------------------------------------------------------
+
 confluence_server_user
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -101,6 +105,8 @@ If using Confluence instance, this value will most likely be the username value.
    confluence_server_user = 'myawesomeuser@example.com'
        (or)
    confluence_server_user = 'myawesomeuser'
+
+--------------------------------------------------------------------------------
 
 .. |confluence_space_name| replace:: ``confluence_space_name``
 .. _confluence_space_name:
@@ -117,13 +123,18 @@ Key of the space in Confluence to be used to publish generated documents to.
 Note that the space name can be **case-sensitive** in most (if not all) versions
 of Confluence.
 
-.. #############################################################################
+--------------------------------------------------------------------------------
 
-generic
--------
+generic configuration
+---------------------
+
+.. |confluence_add_secnumbers| replace:: ``confluence_add_secnumbers``
+.. _confluence_add_secnumbers:
 
 confluence_add_secnumbers
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.2
 
 Add section numbers to page and section titles if ``doctree`` uses the
 ``:numbered:`` option. By default, this is enabled:
@@ -131,6 +142,13 @@ Add section numbers to page and section titles if ``doctree`` uses the
 .. code-block:: python
 
     confluence_add_secnumbers = True
+
+See also |confluence_publish_prefix|_.
+
+--------------------------------------------------------------------------------
+
+.. |confluence_header_file| replace:: ``confluence_header_file``
+.. _confluence_header_file:
 
 confluence_header_file
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -144,6 +162,13 @@ For example:
 
    confluence_header_file = 'assets/header.tpl'
 
+See also |confluence_footer_file|_.
+
+--------------------------------------------------------------------------------
+
+.. |confluence_footer_file| replace:: ``confluence_footer_file``
+.. _confluence_footer_file:
+
 confluence_footer_file
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -155,6 +180,10 @@ For example:
 .. code-block:: python
 
    confluence_footer_file = 'assets/footer.tpl'
+
+See also |confluence_header_file|_.
+
+--------------------------------------------------------------------------------
 
 confluence_max_doc_depth
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -169,6 +198,8 @@ depth is disabled with a value of ``None``.
 .. code-block:: python
 
    confluence_max_doc_depth = 2
+
+--------------------------------------------------------------------------------
 
 confluence_page_hierarchy
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -188,8 +219,12 @@ other published pages that are not defined in the complete toctree_, these
 documents will still be published based off the configured (or unconfigured)
 |confluence_parent_page|_ setting.
 
+--------------------------------------------------------------------------------
+
 confluence_prev_next_buttons_location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.2
 
 A string value to where to include previous/next buttons (if any) based on the
 detected order of documents to be included in processing. Values accepted are
@@ -200,8 +235,15 @@ links are generated with a value of ``None``.
 
    confluence_prev_next_buttons_location = 'top'
 
+--------------------------------------------------------------------------------
+
+.. |confluence_secnumber_suffix| replace:: ``confluence_secnumber_suffix``
+.. _confluence_secnumber_suffix:
+
 confluence_secnumber_suffix
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.2
 
 The suffix to put after section numbers, before section name.
 
@@ -209,10 +251,12 @@ The suffix to put after section numbers, before section name.
 
     confluence_secnumber_suffix = '. '
 
-.. #############################################################################
+See also |confluence_add_secnumbers|_.
 
-publishing
-----------
+--------------------------------------------------------------------------------
+
+publishing configuration
+------------------------
 
 .. |confluence_ask_password| replace:: ``confluence_ask_password``
 .. _confluence_ask_password:
@@ -250,8 +294,12 @@ Note that some shell sessions may not be able to pull the password value
 properly from the user. For example, Cygwin/MinGW may not be able to accept a
 password unless invoked with ``winpty``.
 
+--------------------------------------------------------------------------------
+
 confluence_ask_user
 ~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.2
 
 Provides an override for an interactive shell to request publishing documents
 using a user provided from the shell environment. While a
@@ -263,6 +311,8 @@ By default, this option is disabled with a value of ``False``.
 .. code-block:: python
 
    confluence_ask_user = False
+
+--------------------------------------------------------------------------------
 
 confluence_disable_autogen_title
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -280,6 +330,8 @@ option can be set to ``True``. By default, this option is set to ``False``.
 
    confluence_disable_autogen_title = True
 
+--------------------------------------------------------------------------------
+
 confluence_disable_notifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -290,6 +342,8 @@ notifications are enabled with a value of ``False``.
 .. code-block:: python
 
    confluence_disable_notifications = True
+
+--------------------------------------------------------------------------------
 
 .. |confluence_master_homepage| replace:: ``confluence_master_homepage``
 .. _confluence_master_homepage:
@@ -304,6 +358,8 @@ the master_doc_ configuration is ignored with a value of ``False``.
 .. code-block:: python
 
    confluence_master_homepage = False
+
+--------------------------------------------------------------------------------
 
 .. |confluence_parent_page| replace:: ``confluence_parent_page``
 .. _confluence_parent_page:
@@ -327,11 +383,15 @@ If a parent page is not set, consider using the |confluence_master_homepage|_
 option as well. Note that the page's name can be case-sensitive in most
 (if not all) versions of Confluence.
 
+--------------------------------------------------------------------------------
+
 .. |confluence_publish_postfix| replace:: ``confluence_publish_postfix``
 .. _confluence_publish_postfix:
 
 confluence_publish_postfix
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.2
 
 If set, the postfix value is added to the title of all published documents. In
 Confluence, page names need to be unique for a space. A postfix can be set to
@@ -349,6 +409,8 @@ An example publish postfix is as follows:
    confluence_publish_postfix = '-postfix'
 
 By default, no postfix is used. See also |confluence_publish_prefix|_.
+
+--------------------------------------------------------------------------------
 
 .. |confluence_publish_prefix| replace:: ``confluence_publish_prefix``
 .. _confluence_publish_prefix:
@@ -372,6 +434,8 @@ An example publish prefix is as follows:
    confluence_publish_prefix = 'prefix-'
 
 By default, no prefix is used. See also |confluence_publish_postfix|_.
+
+--------------------------------------------------------------------------------
 
 .. |confluence_purge| replace:: ``confluence_purge``
 .. _confluence_purge:
@@ -403,6 +467,8 @@ example, if an original request publishes ten documents and purges excess
 documents, a following publish attempt with only one of the documents will purge
 the other nine pages.
 
+--------------------------------------------------------------------------------
+
 confluence_purge_from_master
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -419,6 +485,8 @@ to ``True`` before taking effect.
 .. code-block:: python
 
    confluence_purge_from_master = False
+
+--------------------------------------------------------------------------------
 
 .. _confluence_timeout:
 
@@ -437,10 +505,10 @@ seconds, the following can be used:
 
    confluence_timeout = 10
 
-.. #############################################################################
+--------------------------------------------------------------------------------
 
-advanced publishing
--------------------
+advanced publishing configuration
+---------------------------------
 
 confluence_asset_override
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -461,6 +529,8 @@ occurs with a value of ``None``.
 
    confluence_asset_override = None
 
+--------------------------------------------------------------------------------
+
 confluence_ca_cert
 ~~~~~~~~~~~~~~~~~~
 
@@ -477,6 +547,8 @@ option is ignored with a value of ``None``.
 .. code-block:: python
 
    confluence_ca_cert = 'ca.crt'
+
+--------------------------------------------------------------------------------
 
 .. |confluence_client_cert| replace:: ``confluence_client_cert``
 .. _confluence_client_cert:
@@ -498,6 +570,8 @@ of ``None``.
    # or
    confluence_client_cert = ('client.cert', 'client.key')
 
+--------------------------------------------------------------------------------
+
 .. |confluence_client_cert_pass| replace:: ``confluence_client_cert_pass``
 .. _confluence_client_cert_pass:
 
@@ -513,11 +587,12 @@ ignored. By default, this option is ignored with a value of ``None``.
 
    confluence_client_cert_pass = 'passphrase'
 
+--------------------------------------------------------------------------------
+
 confluence_disable_rest
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. warning::
-
+.. deprecated:: 1.2
    It is not recommended to use this option with a value of ``True`` as the
    XML-RPC API has been deprecated by Atlassian as well as in this extension.
    This configuration option will have no effect in v1.3. Only use if required.
@@ -532,6 +607,8 @@ XML-RPC instead. By default, this option is set to ``False``.
 .. code-block:: python
 
    confluence_disable_rest = False
+
+--------------------------------------------------------------------------------
 
 .. |confluence_disable_ssl_validation| replace::
    ``confluence_disable_ssl_validation``
@@ -551,13 +628,14 @@ when making a publish request. By default, this option is set to ``False``.
 
    confluence_disable_ssl_validation = False
 
+--------------------------------------------------------------------------------
+
 .. _confluence_disable_xmlrpc:
 
 confluence_disable_xmlrpc
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. warning::
-
+.. deprecated:: 1.2
    XML-RPC API has been deprecated by Atlassian as well as in this extension.
    XML-RPC API support will be removed from this extension in v1.3.
 
@@ -572,6 +650,8 @@ default, this option is set to ``False``.
 
    confluence_disable_xmlrpc = False
 
+--------------------------------------------------------------------------------
+
 confluence_parent_page_id_check
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -584,8 +664,15 @@ This serves as a sanity-check configuration for the cautious.
 
    confluence_parent_page_id_check = 1
 
+--------------------------------------------------------------------------------
+
 confluence_proxy
 ~~~~~~~~~~~~~~~~
+
+.. deprecated:: 1.2
+   This proxy configuration only applies to XML-RPC API which has been
+   deprecated by Atlassian as well as in this extension. Setting this option in
+   v1.3 of this extension will have no effect.
 
 Provide the proxy needed to be used to interact with the Confluence instance
 over the network. At this time, the proxy configuration only applies to XML-RPC
@@ -595,6 +682,8 @@ configuration).
 .. code-block:: python
 
    confluence_proxy = 'myawesomeproxy:8080'
+
+--------------------------------------------------------------------------------
 
 .. _confluence_publish_subset:
 
@@ -629,6 +718,8 @@ A user can force a publishing subset through the command line:
 By default, this option is ignored with a value of ``[]``. See also
 :ref:`manage publishing a document subset<tip_manage_publish_subset>`.
 
+--------------------------------------------------------------------------------
+
 confluence_server_auth
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -656,6 +747,8 @@ requests (if any).
        resource_owner_key=resource_owner_key,
        resource_owner_secret=resource_owner_secret)
 
+--------------------------------------------------------------------------------
+
 confluence_server_cookies
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -671,10 +764,10 @@ default, no cookies are set with a value of ``None``.
        'U_ID': '<username>'
    }
 
-.. #############################################################################
+--------------------------------------------------------------------------------
 
-advanced processing
--------------------
+advanced processing configuration
+---------------------------------
 
 .. |confluence_file_suffix| replace:: ``confluence_file_suffix``
 .. _confluence_file_suffix:
@@ -689,6 +782,8 @@ files will use the extension ``.conf`` (see |confluence_file_transform|_).
 
    confluence_file_suffix = '.conf'
 
+--------------------------------------------------------------------------------
+
 .. |confluence_file_transform| replace:: ``confluence_file_transform``
 .. _confluence_file_transform:
 
@@ -700,10 +795,14 @@ provided function is used to perform translations for both Sphinx's
 get_outdated_docs_ and write_doc_ methods. The default translation will be the
 combination of "``docname`` + |confluence_file_suffix|_".
 
+--------------------------------------------------------------------------------
+
 .. _confluence_jira_servers:
 
 confluence_jira_servers
 ~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.2
 
 Provides a dictionary of named JIRA servers to reference when using the ``jira``
 or ``jira_issue`` directives. In a typical Confluence environment which is
@@ -742,6 +841,8 @@ used instance inside a document:
     .. jira_issue:: TEST-151
         :server: server-1
 
+--------------------------------------------------------------------------------
+
 confluence_lang_transform
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -757,6 +858,8 @@ default translation accepts `Pygments documented language types`_ to
 
    confluence_lang_transform = my_language_translation
 
+--------------------------------------------------------------------------------
+
 .. |confluence_link_suffix| replace:: ``confluence_link_suffix``
 .. _confluence_link_suffix:
 
@@ -771,6 +874,8 @@ links will use the value defined by |confluence_file_suffix|_ (see
 
    confluence_link_suffix = '.conf'
 
+--------------------------------------------------------------------------------
+
 .. |confluence_link_transform| replace:: ``confluence_link_transform``
 .. _confluence_link_transform:
 
@@ -781,6 +886,8 @@ A function to override the translation of a document name to a (partial) URI.
 The provided function is used to perform translations for both Sphinx's
 get_relative_uri_ method. The default translation will be the combination of
 "``docname`` + |confluence_link_suffix|_".
+
+--------------------------------------------------------------------------------
 
 confluence_remove_title
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -796,7 +903,6 @@ option is enabled with a value of ``True``.
 
    confluence_remove_title = True
 
-.. #############################################################################
 
 .. references ------------------------------------------------------------------
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -19,8 +19,10 @@ All Atlassian Confluence Builder configurations are prefixed with
 
 .. contents:: :local:
 
-essential configuration
------------------------
+.. #############################################################################
+
+essential
+---------
 
 confluence_publish
 ~~~~~~~~~~~~~~~~~~
@@ -50,8 +52,6 @@ username value should be used:
 .. code-block:: python
 
    confluence_server_pass = 'myawesomepassword'
-
-See also :ref:`advanced authentication options<confluence_advanced_conf_auth>`.
 
 .. caution::
 
@@ -117,19 +117,20 @@ Key of the space in Confluence to be used to publish generated documents to.
 Note that the space name can be **case-sensitive** in most (if not all) versions
 of Confluence.
 
-general configuration
----------------------
+.. #############################################################################
 
-confluence_disable_notifications
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+generic
+-------
 
-A boolean value which explicitly disable any page update notifications (i.e.
-treats page updates from a publish request as minor updates). By default,
-notifications are enabled with a value of ``False``.
+confluence_add_secnumbers
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add section numbers to page and section titles if ``doctree`` uses the
+``:numbered:`` option. By default, this is enabled:
 
 .. code-block:: python
 
-   confluence_disable_notifications = True
+    confluence_add_secnumbers = True
 
 confluence_header_file
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -154,62 +155,6 @@ For example:
 .. code-block:: python
 
    confluence_footer_file = 'assets/footer.tpl'
-
-.. _confluence_jira_servers:
-
-confluence_jira_servers
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Provides a dictionary of named JIRA servers to reference when using the ``jira``
-or ``jira_issue`` directives. In a typical Confluence environment which is
-linked with a JIRA instance, users do not need to take advantage of this
-configuration -- Confluence should automatically be able to link to respectively
-JIRA issues or map JIRA query languages with a configured JIRA instance. In
-select cases where an instance has more than one JIRA instance attached, a user
-may need to explicitly reference a JIRA instance to properly render a JIRA
-macro. JIRA-related directives have the ability to reference JIRA instances,
-with a combination of a UUID and name; for example:
-
-.. code-block:: rst
-
-    .. jira_issue:: TEST-151
-        :server-id: d005bcc2-ca4e-4065-8ce8-49ff5ac5857d
-        :server-name: MyAwesomeJiraServer
-
-It may be tedious for some projects to add this information in each document. As
-an alternative, a configuration can define JIRA instance information inside a
-configuration option as follows:
-
-.. code-block:: python
-
-    confluence_jira_servers = {
-        'server-1': {
-            'id': '<UUID of JIRA Instance>',
-            'name': '<Name of JIRA Instance>'
-        }
-    }
-
-With the above option defined in a project's configuration, the following can be
-used instance inside a document:
-
-.. code-block:: rst
-
-    .. jira_issue:: TEST-151
-        :server: server-1
-
-.. |confluence_master_homepage| replace:: ``confluence_master_homepage``
-.. _confluence_master_homepage:
-
-confluence_master_homepage
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A boolean value to whether or not force the configured space's homepage to be
-set to the page defined by the Sphinx configuration's master_doc_. By default,
-the master_doc_ configuration is ignored with a value of ``False``.
-
-.. code-block:: python
-
-   confluence_master_homepage = False
 
 confluence_max_doc_depth
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -243,28 +188,6 @@ other published pages that are not defined in the complete toctree_, these
 documents will still be published based off the configured (or unconfigured)
 |confluence_parent_page|_ setting.
 
-.. |confluence_parent_page| replace:: ``confluence_parent_page``
-.. _confluence_parent_page:
-
-confluence_parent_page
-~~~~~~~~~~~~~~~~~~~~~~
-
-The root page found inside the configured space (|confluence_space_name|_)
-where published pages will be a descendant of. The parent page value is used
-to match with the title of an existing page. If this option is not provided,
-pages will be published to the root of the configured space. If the parent page
-cannot be found, the publish attempt will stop with an error message. For
-example, the following will publish documentation under the ``MyAwesomeDocs``
-page:
-
-.. code-block:: python
-
-   confluence_parent_page = 'MyAwesomeDocs'
-
-If a parent page is not set, consider using the |confluence_master_homepage|_
-option as well. Note that the page's name can be case-sensitive in most
-(if not all) versions of Confluence.
-
 confluence_prev_next_buttons_location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -277,62 +200,6 @@ links are generated with a value of ``None``.
 
    confluence_prev_next_buttons_location = 'top'
 
-.. |confluence_publish_postfix| replace:: ``confluence_publish_postfix``
-.. _confluence_publish_postfix:
-
-confluence_publish_postfix
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If set, the postfix value is added to the title of all published documents. In
-Confluence, page names need to be unique for a space. A postfix can be set to
-either:
-
-* Add a unique naming schema to generated/published documents in a space which
-  has manually created pages; or,
-* Allow multiple published sets of documentation, each with their own postfix
-  value.
-
-An example publish postfix is as follows:
-
-.. code-block:: python
-
-   confluence_publish_postfix = '-postfix'
-
-By default, no postfix is used. See also |confluence_publish_prefix|_.
-
-.. |confluence_publish_prefix| replace:: ``confluence_publish_prefix``
-.. _confluence_publish_prefix:
-
-confluence_publish_prefix
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If set, the prefix value is added to the title of all published documents. In
-Confluence, page names need to be unique for a space. A prefix can be set to
-either:
-
-* Add a unique naming schema to generated/published documents in a space which
-  has manually created pages; or,
-* Allow multiple published sets of documentation, each with their own prefix
-  value.
-
-An example publish prefix is as follows:
-
-.. code-block:: python
-
-   confluence_publish_prefix = 'prefix-'
-
-By default, no prefix is used. See also |confluence_publish_postfix|_.
-
-confluence_add_secnumbers
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Add section numbers to page and section titles if ``doctree`` uses the
-``:numbered:`` option. By default, this is enabled:
-
-.. code-block:: python
-
-    confluence_add_secnumbers = True
-
 confluence_secnumber_suffix
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -342,183 +209,10 @@ The suffix to put after section numbers, before section name.
 
     confluence_secnumber_suffix = '. '
 
-.. |confluence_purge| replace:: ``confluence_purge``
-.. _confluence_purge:
+.. #############################################################################
 
-confluence_purge
-~~~~~~~~~~~~~~~~
-
-.. warning::
-
-   Publishing individual/subset of documents with this option may lead to
-   unexpected results.
-
-A boolean value to whether or not purge legacy pages detected in a space or
-parent page. By default, this value is set to ``False`` to indicate that no
-pages will be removed. If this configuration is set to ``True``, detected pages
-in Confluence that do not match the set of published documents will be
-automatically removed. If the option |confluence_parent_page|_ is set, only
-pages which are a descendant of the configured parent page can be removed;
-otherwise, all pages in the configured space could be removed.
-
-.. code-block:: python
-
-   confluence_purge = False
-
-While this capability is useful for updating a series of pages, it may lead to
-unexpected results when attempting to publish a single-page update. The purge
-operation will remove all pages that are not publish in the request. For
-example, if an original request publishes ten documents and purges excess
-documents, a following publish attempt with only one of the documents will purge
-the other nine pages.
-
-confluence_purge_from_master
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A boolean value to which indicates that any purging attempt should be done from
-the root of a published master_doc_ page (instead of a configured parent page;
-i.e. |confluence_parent_page|_). In specific publishing scenarios, a user may
-wish to publish multiple documentation sets based off a single parent/container
-page. To prevent any purging between multiple documentation sets, this option
-can be set to ``True``. When generating legacy pages to be removed, this
-extension will only attempt to populate legacy pages based off the children of
-the master_doc_ page. This option still requires |confluence_purge|_ to be set
-to ``True`` before taking effect.
-
-.. code-block:: python
-
-   confluence_purge_from_master = False
-
-.. _confluence_advanced_conf_auth:
-
-advanced configuration - authentication
----------------------------------------
-
-confluence_server_auth
-~~~~~~~~~~~~~~~~~~~~~~
-
-An authentication handler which can be directly provided to a REST API request.
-REST calls in this extension use the Requests_ library, which provide various
-methods for a client to perform authentication. While this extension already
-provided simple authentication support (via ``confluence_server_user`` and
-``confluence_server_pass``), a publisher may need to configure an advanced
-authentication handler to support a target Confluence instance.
-
-Note that this extension does not define custom authentication handlers. This
-configuration is a passthrough option only. For more details on various ways to
-use authentication handlers, please consult `Requests -- Authentication`_. By
-default, no custom authentication handler is provided to generated REST API
-requests (if any).
-
-.. code-block:: python
-
-   from requests_oauthlib import OAuth1
-
-   ...
-
-   confluence_server_auth = OAuth1(client_key,
-       client_secret=client_secret,
-       resource_owner_key=resource_owner_key,
-       resource_owner_secret=resource_owner_secret)
-
-confluence_server_cookies
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A dictionary value which allows a user to pass key-value cookie information for
-authentication purposes. This is useful for users who need to authenticate with
-a single sign-on (SSO) provider to access a target Confluence instance. By
-default, no cookies are set with a value of ``None``.
-
-.. code-block:: python
-
-   confluence_server_cookies = {
-       'SESSION_ID': '<session id string>',
-       'U_ID': '<username>'
-   }
-
-advanced configuration - processing
------------------------------------
-
-.. |confluence_file_suffix| replace:: ``confluence_file_suffix``
-.. _confluence_file_suffix:
-
-confluence_file_suffix
-~~~~~~~~~~~~~~~~~~~~~~
-
-The file name suffix to use for all generated files. By default, all generated
-files will use the extension ``.conf`` (see |confluence_file_transform|_).
-
-.. code-block:: python
-
-   confluence_file_suffix = '.conf'
-
-.. |confluence_file_transform| replace:: ``confluence_file_transform``
-.. _confluence_file_transform:
-
-confluence_file_transform
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A function to override the translation of a document name to a filename. The
-provided function is used to perform translations for both Sphinx's
-get_outdated_docs_ and write_doc_ methods. The default translation will be the
-combination of "``docname`` + |confluence_file_suffix|_".
-
-confluence_lang_transform
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A function to override the translation of literal block-based directive
-language values to Confluence-support code block macro language values. The
-default translation accepts `Pygments documented language types`_ to
-`Confluence-supported syntax highlight languages`_.
-
-.. code-block:: python
-
-   def my_language_translation(lang):
-       return 'default'
-
-   confluence_lang_transform = my_language_translation
-
-.. |confluence_link_suffix| replace:: ``confluence_link_suffix``
-.. _confluence_link_suffix:
-
-confluence_link_suffix
-~~~~~~~~~~~~~~~~~~~~~~
-
-The suffix name to use for generated links to files. By default, all generated
-links will use the value defined by |confluence_file_suffix|_ (see
-|confluence_link_transform|_).
-
-.. code-block:: python
-
-   confluence_link_suffix = '.conf'
-
-.. |confluence_link_transform| replace:: ``confluence_link_transform``
-.. _confluence_link_transform:
-
-confluence_link_transform
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A function to override the translation of a document name to a (partial) URI.
-The provided function is used to perform translations for both Sphinx's
-get_relative_uri_ method. The default translation will be the combination of
-"``docname`` + |confluence_link_suffix|_".
-
-confluence_remove_title
-~~~~~~~~~~~~~~~~~~~~~~~
-
-A boolean value to whether or not automatically remove the title section from
-all published pages. In Confluence, page names are already presented at the top.
-With this option enabled, this reduces having two leading headers with the
-document's title. In some cases, a user may wish to not remove titles when
-custom prefixes or other custom modifications are in play. By default, this
-option is enabled with a value of ``True``.
-
-.. code-block:: python
-
-   confluence_remove_title = True
-
-advanced configuration - publishing
------------------------------------
+publishing
+----------
 
 .. |confluence_ask_password| replace:: ``confluence_ask_password``
 .. _confluence_ask_password:
@@ -570,6 +264,183 @@ By default, this option is disabled with a value of ``False``.
 
    confluence_ask_user = False
 
+confluence_disable_autogen_title
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A boolean value to explicitly disable the automatic generation of titles for
+documents which do not have a title set. When this extension processes a set of
+documents to publish, a document needs a title value to know which Confluence
+page to create/update. In the event where a title value cannot be extracted from
+a document, a title value will be automatically generated for the document. For
+automatically generated titles, the value will always be prefixed with
+``autogen-``. For users who wish to ignore pages which have no title, this
+option can be set to ``True``. By default, this option is set to ``False``.
+
+.. code-block:: python
+
+   confluence_disable_autogen_title = True
+
+confluence_disable_notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A boolean value which explicitly disable any page update notifications (i.e.
+treats page updates from a publish request as minor updates). By default,
+notifications are enabled with a value of ``False``.
+
+.. code-block:: python
+
+   confluence_disable_notifications = True
+
+.. |confluence_master_homepage| replace:: ``confluence_master_homepage``
+.. _confluence_master_homepage:
+
+confluence_master_homepage
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A boolean value to whether or not force the configured space's homepage to be
+set to the page defined by the Sphinx configuration's master_doc_. By default,
+the master_doc_ configuration is ignored with a value of ``False``.
+
+.. code-block:: python
+
+   confluence_master_homepage = False
+
+.. |confluence_parent_page| replace:: ``confluence_parent_page``
+.. _confluence_parent_page:
+
+confluence_parent_page
+~~~~~~~~~~~~~~~~~~~~~~
+
+The root page found inside the configured space (|confluence_space_name|_)
+where published pages will be a descendant of. The parent page value is used
+to match with the title of an existing page. If this option is not provided,
+pages will be published to the root of the configured space. If the parent page
+cannot be found, the publish attempt will stop with an error message. For
+example, the following will publish documentation under the ``MyAwesomeDocs``
+page:
+
+.. code-block:: python
+
+   confluence_parent_page = 'MyAwesomeDocs'
+
+If a parent page is not set, consider using the |confluence_master_homepage|_
+option as well. Note that the page's name can be case-sensitive in most
+(if not all) versions of Confluence.
+
+.. |confluence_publish_postfix| replace:: ``confluence_publish_postfix``
+.. _confluence_publish_postfix:
+
+confluence_publish_postfix
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set, the postfix value is added to the title of all published documents. In
+Confluence, page names need to be unique for a space. A postfix can be set to
+either:
+
+* Add a unique naming schema to generated/published documents in a space which
+  has manually created pages; or,
+* Allow multiple published sets of documentation, each with their own postfix
+  value.
+
+An example publish postfix is as follows:
+
+.. code-block:: python
+
+   confluence_publish_postfix = '-postfix'
+
+By default, no postfix is used. See also |confluence_publish_prefix|_.
+
+.. |confluence_publish_prefix| replace:: ``confluence_publish_prefix``
+.. _confluence_publish_prefix:
+
+confluence_publish_prefix
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If set, the prefix value is added to the title of all published documents. In
+Confluence, page names need to be unique for a space. A prefix can be set to
+either:
+
+* Add a unique naming schema to generated/published documents in a space which
+  has manually created pages; or,
+* Allow multiple published sets of documentation, each with their own prefix
+  value.
+
+An example publish prefix is as follows:
+
+.. code-block:: python
+
+   confluence_publish_prefix = 'prefix-'
+
+By default, no prefix is used. See also |confluence_publish_postfix|_.
+
+.. |confluence_purge| replace:: ``confluence_purge``
+.. _confluence_purge:
+
+confluence_purge
+~~~~~~~~~~~~~~~~
+
+.. warning::
+
+   Publishing individual/subset of documents with this option may lead to
+   unexpected results.
+
+A boolean value to whether or not purge legacy pages detected in a space or
+parent page. By default, this value is set to ``False`` to indicate that no
+pages will be removed. If this configuration is set to ``True``, detected pages
+in Confluence that do not match the set of published documents will be
+automatically removed. If the option |confluence_parent_page|_ is set, only
+pages which are a descendant of the configured parent page can be removed;
+otherwise, all pages in the configured space could be removed.
+
+.. code-block:: python
+
+   confluence_purge = False
+
+While this capability is useful for updating a series of pages, it may lead to
+unexpected results when attempting to publish a single-page update. The purge
+operation will remove all pages that are not publish in the request. For
+example, if an original request publishes ten documents and purges excess
+documents, a following publish attempt with only one of the documents will purge
+the other nine pages.
+
+confluence_purge_from_master
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A boolean value to which indicates that any purging attempt should be done from
+the root of a published master_doc_ page (instead of a configured parent page;
+i.e. |confluence_parent_page|_). In specific publishing scenarios, a user may
+wish to publish multiple documentation sets based off a single parent/container
+page. To prevent any purging between multiple documentation sets, this option
+can be set to ``True``. When generating legacy pages to be removed, this
+extension will only attempt to populate legacy pages based off the children of
+the master_doc_ page. This option still requires |confluence_purge|_ to be set
+to ``True`` before taking effect.
+
+.. code-block:: python
+
+   confluence_purge_from_master = False
+
+.. _confluence_timeout:
+
+confluence_timeout
+~~~~~~~~~~~~~~~~~~
+
+Force a timeout (in seconds) for network interaction. The timeout used by this
+extension is not explicitly configured (i.e. managed by Requests_ and other
+implementations). By default, assume that any network interaction will not
+timeout. Since the target Confluence instance is most likely to be found on an
+external server, is it recommended to explicitly configure a timeout value based
+on the environment being used. For example, to configure a timeout of ten
+seconds, the following can be used:
+
+.. code-block:: python
+
+   confluence_timeout = 10
+
+.. #############################################################################
+
+advanced publishing
+-------------------
 
 confluence_asset_override
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -641,22 +512,6 @@ ignored. By default, this option is ignored with a value of ``None``.
 .. code-block:: python
 
    confluence_client_cert_pass = 'passphrase'
-
-confluence_disable_autogen_title
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A boolean value to explicitly disable the automatic generation of titles for
-documents which do not have a title set. When this extension processes a set of
-documents to publish, a document needs a title value to know which Confluence
-page to create/update. In the event where a title value cannot be extracted from
-a document, a title value will be automatically generated for the document. For
-automatically generated titles, the value will always be prefixed with
-``autogen-``. For users who wish to ignore pages which have no title, this
-option can be set to ``True``. By default, this option is set to ``False``.
-
-.. code-block:: python
-
-   confluence_disable_autogen_title = True
 
 confluence_disable_rest
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -774,23 +629,174 @@ A user can force a publishing subset through the command line:
 By default, this option is ignored with a value of ``[]``. See also
 :ref:`manage publishing a document subset<tip_manage_publish_subset>`.
 
-.. _confluence_timeout:
+confluence_server_auth
+~~~~~~~~~~~~~~~~~~~~~~
 
-confluence_timeout
-~~~~~~~~~~~~~~~~~~
+An authentication handler which can be directly provided to a REST API request.
+REST calls in this extension use the Requests_ library, which provide various
+methods for a client to perform authentication. While this extension already
+provided simple authentication support (via ``confluence_server_user`` and
+``confluence_server_pass``), a publisher may need to configure an advanced
+authentication handler to support a target Confluence instance.
 
-Force a timeout (in seconds) for network interaction. The timeout used by this
-extension is not explicitly configured (i.e. managed by Requests_ and other
-implementations). By default, assume that any network interaction will not
-timeout. Since the target Confluence instance is most likely to be found on an
-external server, is it recommended to explicitly configure a timeout value based
-on the environment being used. For example, to configure a timeout of ten
-seconds, the following can be used:
+Note that this extension does not define custom authentication handlers. This
+configuration is a passthrough option only. For more details on various ways to
+use authentication handlers, please consult `Requests -- Authentication`_. By
+default, no custom authentication handler is provided to generated REST API
+requests (if any).
 
 .. code-block:: python
 
-   confluence_timeout = 10
+   from requests_oauthlib import OAuth1
 
+   ...
+
+   confluence_server_auth = OAuth1(client_key,
+       client_secret=client_secret,
+       resource_owner_key=resource_owner_key,
+       resource_owner_secret=resource_owner_secret)
+
+confluence_server_cookies
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A dictionary value which allows a user to pass key-value cookie information for
+authentication purposes. This is useful for users who need to authenticate with
+a single sign-on (SSO) provider to access a target Confluence instance. By
+default, no cookies are set with a value of ``None``.
+
+.. code-block:: python
+
+   confluence_server_cookies = {
+       'SESSION_ID': '<session id string>',
+       'U_ID': '<username>'
+   }
+
+.. #############################################################################
+
+advanced processing
+-------------------
+
+.. |confluence_file_suffix| replace:: ``confluence_file_suffix``
+.. _confluence_file_suffix:
+
+confluence_file_suffix
+~~~~~~~~~~~~~~~~~~~~~~
+
+The file name suffix to use for all generated files. By default, all generated
+files will use the extension ``.conf`` (see |confluence_file_transform|_).
+
+.. code-block:: python
+
+   confluence_file_suffix = '.conf'
+
+.. |confluence_file_transform| replace:: ``confluence_file_transform``
+.. _confluence_file_transform:
+
+confluence_file_transform
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A function to override the translation of a document name to a filename. The
+provided function is used to perform translations for both Sphinx's
+get_outdated_docs_ and write_doc_ methods. The default translation will be the
+combination of "``docname`` + |confluence_file_suffix|_".
+
+.. _confluence_jira_servers:
+
+confluence_jira_servers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Provides a dictionary of named JIRA servers to reference when using the ``jira``
+or ``jira_issue`` directives. In a typical Confluence environment which is
+linked with a JIRA instance, users do not need to take advantage of this
+configuration -- Confluence should automatically be able to link to respectively
+JIRA issues or map JIRA query languages with a configured JIRA instance. In
+select cases where an instance has more than one JIRA instance attached, a user
+may need to explicitly reference a JIRA instance to properly render a JIRA
+macro. JIRA-related directives have the ability to reference JIRA instances,
+with a combination of a UUID and name; for example:
+
+.. code-block:: rst
+
+    .. jira_issue:: TEST-151
+        :server-id: d005bcc2-ca4e-4065-8ce8-49ff5ac5857d
+        :server-name: MyAwesomeJiraServer
+
+It may be tedious for some projects to add this information in each document. As
+an alternative, a configuration can define JIRA instance information inside a
+configuration option as follows:
+
+.. code-block:: python
+
+    confluence_jira_servers = {
+        'server-1': {
+            'id': '<UUID of JIRA Instance>',
+            'name': '<Name of JIRA Instance>'
+        }
+    }
+
+With the above option defined in a project's configuration, the following can be
+used instance inside a document:
+
+.. code-block:: rst
+
+    .. jira_issue:: TEST-151
+        :server: server-1
+
+confluence_lang_transform
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A function to override the translation of literal block-based directive
+language values to Confluence-support code block macro language values. The
+default translation accepts `Pygments documented language types`_ to
+`Confluence-supported syntax highlight languages`_.
+
+.. code-block:: python
+
+   def my_language_translation(lang):
+       return 'default'
+
+   confluence_lang_transform = my_language_translation
+
+.. |confluence_link_suffix| replace:: ``confluence_link_suffix``
+.. _confluence_link_suffix:
+
+confluence_link_suffix
+~~~~~~~~~~~~~~~~~~~~~~
+
+The suffix name to use for generated links to files. By default, all generated
+links will use the value defined by |confluence_file_suffix|_ (see
+|confluence_link_transform|_).
+
+.. code-block:: python
+
+   confluence_link_suffix = '.conf'
+
+.. |confluence_link_transform| replace:: ``confluence_link_transform``
+.. _confluence_link_transform:
+
+confluence_link_transform
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A function to override the translation of a document name to a (partial) URI.
+The provided function is used to perform translations for both Sphinx's
+get_relative_uri_ method. The default translation will be the combination of
+"``docname`` + |confluence_link_suffix|_".
+
+confluence_remove_title
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A boolean value to whether or not automatically remove the title section from
+all published pages. In Confluence, page names are already presented at the top.
+With this option enabled, this reduces having two leading headers with the
+document's title. In some cases, a user may wish to not remove titles when
+custom prefixes or other custom modifications are in play. By default, this
+option is enabled with a value of ``True``.
+
+.. code-block:: python
+
+   confluence_remove_title = True
+
+.. #############################################################################
 
 .. references ------------------------------------------------------------------
 

--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -67,8 +67,7 @@ rubric                 supported     - `Sphinx Rubric`_
 sections               supported     - `reStructuredText Sections`_
 tables                 supported     - `reStructuredText Tables`_
 toctree                supported     - `Sphinx TOC Tree Markup`_
-                                     - Pending work to validate/improve toctree
-                                       options ``caption`` and ``numbered``.
+                                     - Argument ``caption`` not yet supported.
 transitions            supported     - `reStructuredText Transitions`_
 versionadded           supported     - `Sphinx Version Added`_
 versionchanged         supported     - `Sphinx Version Changed`_

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -74,76 +74,61 @@ def setup(app):
                 app.registry.get_post_transforms().remove(transform)
                 break
 
-    """(essential)"""
+    # ##########################################################################
+
+    """(configuration - essential)"""
     """Enablement of publishing."""
     app.add_config_value('confluence_publish', None, False)
     """API key/password to login to Confluence API with."""
     app.add_config_value('confluence_server_pass', None, False)
-    """Username to login to Confluence API with."""
-    app.add_config_value('confluence_server_user', None, False)
     """URL of the Confluence instance to publish to."""
     app.add_config_value('confluence_server_url', None, False)
+    """Username to login to Confluence API with."""
+    app.add_config_value('confluence_server_user', None, False)
     """Confluence Space to publish to."""
     app.add_config_value('confluence_space_name', None, False)
 
-    """(generic)"""
-    """Explicitly prevent page notifications on update."""
-    app.add_config_value('confluence_disable_notifications', None, False)
+    """(configuration - generic)"""
+    """Add page and section numbers if doctree has :numbered: option"""
+    app.add_config_value('confluence_add_secnumbers', True, False)
     """File to get page header information from."""
     app.add_config_value('confluence_header_file', None, False)
     """File to get page footer information from."""
     app.add_config_value('confluence_footer_file', None, False)
-    """Enablement of configuring master as space's homepage."""
-    app.add_config_value('confluence_master_homepage', None, False)
     """Enablement of the maximum document depth (before inlining)."""
     app.add_config_value('confluence_max_doc_depth', None, False)
     """Enablement of publishing pages into a hierarchy from a master toctree."""
     app.add_config_value('confluence_page_hierarchy', None, False)
-    """Root/parent page's name to publish documents into."""
-    app.add_config_value('confluence_parent_page', None, False)
     """Show previous/next buttons (bottom, top, both, None)."""
     app.add_config_value('confluence_prev_next_buttons_location', None, False)
+    """Suffix to put after section numbers, before section name"""
+    app.add_config_value('confluence_secnumber_suffix', '. ', False)
+
+    """(configuration - publishing)"""
+    """Request for publish password to come from interactive session."""
+    app.add_config_value('confluence_ask_password', False, False)
+    """Request for publish username to come from interactive session."""
+    app.add_config_value('confluence_ask_user', False, False)
+    """Explicitly prevent auto-generation of titles for titleless documents."""
+    app.add_config_value('confluence_disable_autogen_title', None, False)
+    """Explicitly prevent page notifications on update."""
+    app.add_config_value('confluence_disable_notifications', None, False)
+    """Enablement of configuring master as space's homepage."""
+    app.add_config_value('confluence_master_homepage', None, False)
+    """Root/parent page's name to publish documents into."""
+    app.add_config_value('confluence_parent_page', None, False)
     """Postfix to apply to title of published pages."""
     app.add_config_value('confluence_publish_postfix', None, False)
     """Prefix to apply to published pages."""
     app.add_config_value('confluence_publish_prefix', None, False)
-    """Add page and section numbers if doctree has :numbered: option"""
-    app.add_config_value('confluence_add_secnumbers', True, False)
-    """Suffix to put after section numbers, before section name"""
-    app.add_config_value('confluence_secnumber_suffix', '. ', False)
     """Enablement of purging legacy child pages from a parent page."""
     app.add_config_value('confluence_purge', None, False)
     """Enablement of purging legacy child pages from a master page."""
     app.add_config_value('confluence_purge_from_master', None, False)
+    """Timeout for network-related calls (publishing)."""
+    app.add_config_value('confluence_timeout', None, False)
 
-    """(advanced-configuration - authentication)"""
-    """Authentication passthrough for Confluence REST interaction."""
-    app.add_config_value('confluence_server_auth', None, False)
-    """Cookie(s) to use for Confluence REST interaction."""
-    app.add_config_value('confluence_server_cookies', None, False)
-
-    """(advanced-configuration - processing)"""
-    """Filename suffix for generated files."""
-    app.add_config_value('confluence_file_suffix', ".conf", False)
-    """Translation of docname to a filename."""
-    app.add_config_value('confluence_file_transform', None, False)
-    """Indent to use for generated documents."""
-    app.add_config_value('confluence_indent', STDINDENT, False)
-    """Translation of a raw language to code block macro language."""
-    app.add_config_value('confluence_lang_transform', None, False)
-    """Link suffix for generated files."""
-    app.add_config_value('confluence_link_suffix', None, False)
-    """Translation of docname to a (partial) URI."""
-    app.add_config_value('confluence_link_transform', None, False)
-    """Remove a detected title from generated documents."""
-    app.add_config_value('confluence_remove_title', True, False)
-
-    """(advanced-configuration - publishing)"""
-    """Request for publish username to come from interactive session."""
-    app.add_config_value('confluence_ask_user', False, False)
-    """Request for publish password to come from interactive session."""
-    app.add_config_value('confluence_ask_password', False, False)
-    """File/path to Certificate Authority"""
+    """(configuration - advanced publishing)"""
     """Tri-state asset handling (auto, force push or disable)."""
     app.add_config_value('confluence_asset_override', None, False)
     """File/path to Certificate Authority"""
@@ -152,8 +137,6 @@ def setup(app):
     app.add_config_value('confluence_client_cert', None, False)
     """Password for client certificate to use for publishing"""
     app.add_config_value('confluence_client_cert_pass', None, False)
-    """Explicitly prevent auto-generation of titles for titleless documents."""
-    app.add_config_value('confluence_disable_autogen_title', None, False)
     """Explicitly prevent any Confluence REST API callers."""
     app.add_config_value('confluence_disable_rest', None, False)
     """Disable SSL validation with Confluence server."""
@@ -166,12 +149,28 @@ def setup(app):
     app.add_config_value('confluence_proxy', None, False)
     """Subset of document names to publish"""
     app.add_config_value('confluence_publish_subset', [], False)
-    """Timeout for network-related calls (publishing)."""
-    app.add_config_value('confluence_timeout', None, False)
+    """Authentication passthrough for Confluence REST interaction."""
+    app.add_config_value('confluence_server_auth', None, False)
+    """Cookie(s) to use for Confluence REST interaction."""
+    app.add_config_value('confluence_server_cookies', None, False)
+
+    """(configuration - advanced processing)"""
+    """Filename suffix for generated files."""
+    app.add_config_value('confluence_file_suffix', ".conf", False)
+    """Translation of docname to a filename."""
+    app.add_config_value('confluence_file_transform', None, False)
     """Configuration for named JIRA Servers"""
     app.add_config_value('confluence_jira_servers', {}, True)
+    """Translation of a raw language to code block macro language."""
+    app.add_config_value('confluence_lang_transform', None, False)
+    """Link suffix for generated files."""
+    app.add_config_value('confluence_link_suffix', None, False)
+    """Translation of docname to a (partial) URI."""
+    app.add_config_value('confluence_link_transform', None, False)
+    """Remove a detected title from generated documents."""
+    app.add_config_value('confluence_remove_title', True, False)
 
-    """(advanced - undocumented)"""
+    """(configuration - undocumented)"""
     """Enablement for aggressive descendents search (for purge)."""
     app.add_config_value('confluence_adv_aggressive_search', None, False)
     """Enablement of the children macro for hierarchy mode."""
@@ -184,6 +183,10 @@ def setup(app):
     app.add_config_value('confluence_adv_trace_data', False, False)
     """Do not cap sections to a maximum of six (6) levels."""
     app.add_config_value('confluence_adv_writer_no_section_cap', None, False)
+    """Indent to use for generated documents."""
+    app.add_config_value('confluence_indent', STDINDENT, False)
+
+    # ##########################################################################
 
     """JIRA directives"""
     """Adds the custom nodes needed for JIRA directives"""


### PR DESCRIPTION
Performing a series of maintenance changes in preparation for an upcoming release:

- doc: cleanup configuration document
- doc: recatagorize configuration options
- \_\_init\_\_: recategorize configuration options
- CHANGES.rst: adding features and cleanup
- doc: remove toctree numbered option from pending
- doc: bumping copyright year 