### PR TITLE
generate anchors for targets

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -966,7 +966,10 @@ class ConfluenceTranslator(BaseTranslator):
         self._reference_context = []
 
     def visit_target(self, node):
-        if 'refid' in node and self.can_anchor:
+        if not self.can_anchor:
+            raise nodes.SkipNode
+    
+        if 'refid' in node:
             anchor = ''.join(node['refid'].split())
 
             # only build an anchor if required (e.x. is a reference label
@@ -976,6 +979,11 @@ class ConfluenceTranslator(BaseTranslator):
             if not target:
                 self.body.append(self._start_ac_macro(node, 'anchor'))
                 self.body.append(self._build_ac_parameter(node, '', anchor))
+                self.body.append(self._end_ac_macro(node))
+        elif 'ids' in node and 'refuri' not in node:
+            for id in node['ids']:
+                self.body.append(self._start_ac_macro(node, 'anchor'))
+                self.body.append(self._build_ac_parameter(node, '', id))
                 self.body.append(self._end_ac_macro(node))
 
         raise nodes.SkipNode

--- a/test/validation-sets/auto-ext/index.rst
+++ b/test/validation-sets/auto-ext/index.rst
@@ -5,6 +5,7 @@ The following is a base page to show an example of Sphinx's auto-based extension
 found inside the internal tree.
 
 .. toctree::
+   :maxdepth: 1
 
    autodocs
    autosummary


### PR DESCRIPTION
For target nodes which have non-reference identifiers, generate an anchor macro (if supported) to help internally referenced and externally referenced identifiers.

This changes helps ensure references generated from autosummary directive have a proper target to jump to.