### PR TITLE
rest: convert none-password value to an empty string

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -79,9 +79,10 @@ class Rest:
         if config.confluence_server_auth:
             session.auth = config.confluence_server_auth
         elif config.confluence_server_user:
-            session.auth = (
-                config.confluence_server_user,
-                config.confluence_server_pass)
+            passwd = config.confluence_server_pass
+            if passwd is None:
+                passwd = ''
+            session.auth = (config.confluence_server_user, passwd)
 
         if config.confluence_server_cookies:
             session.cookies.update(config.confluence_server_cookies)


### PR DESCRIPTION
If a `None` value password (typically, a representation of no password needed) into an empty string. This is to help prepare for future Requests versions which desire a string/bytes value. This removes the following warning on newer versions of Requests (for non-password user scenarios):

    DeprecationWarning: Non-string passwords will no longer be supported in Requests 3.0.0. Please convert the object you've passed in (None) to a string or bytes object in the near future to avoid problems.