### PR TITLE
translator: allow users to override unknown nodes

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -164,6 +164,8 @@ def setup(app):
     app.add_config_value('confluence_adv_hierarchy_child_macro', None, False)
     """List of node types to ignore if no translator support exists."""
     app.add_config_value('confluence_adv_ignore_nodes', [], False)
+    """Unknown node handler dictionary for advanced integrations."""
+    app.add_config_value('confluence_adv_node_handler', None, '')
     """List of extension-provided macros restricted for use."""
     app.add_config_value('confluence_adv_restricted_macros', [], False)
     """Enablement of tracing processed data."""

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -146,6 +146,18 @@ class ConfluenceTranslator(BaseTranslator):
             ConfluenceLogger.verbose('ignore node {} (conf)'.format(node_name))
             raise nodes.SkipNode
 
+        # allow users to override unknown nodes
+        #
+        # A node handler allows an advanced user to provide implementation to
+        # process a node not supported by this extension. This is to assist in
+        # providing a quick alternative to supporting another third party
+        # extension in this translator (without having to take the time in
+        # building a third extension).
+        handler = self.builder.config.confluence_adv_node_handler
+        if handler and isinstance(handler, dict) and node_name in handler:
+            handler[node_name](self, node)
+            raise nodes.SkipNode
+
         raise NotImplementedError('unknown node: ' + node_name)
 
     # ---------


### PR DESCRIPTION
A node handler allows an advanced user to provide implementation to process a node not supported by this extension. This is to assist in providing a quick alternative to supporting another third party extension in this translator (without having to take the time in building a third extension).