### PR TITLE
builder: ensure input calls support python 2.7

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -35,6 +35,12 @@ try:
 except:
     imgmath = None
 
+# handle proper input request in python 2.7
+try:
+    input = raw_input
+except NameError:
+    pass
+
 # Clone of relative_uri() sphinx.util.osutil, with bug-fixes
 # since the original code had a few errors.
 # This was fixed in Sphinx 1.2b.
@@ -101,8 +107,6 @@ class ConfluenceBuilder(Builder):
                 u_str = ' [{}]'.format(default_user)
 
             target_user = input(' User{}: '.format(u_str)) or default_user
-
-            print('target_user', target_user)
             if not target_user:
                 raise ConfluenceConfigurationError('no user provided')
 


### PR DESCRIPTION
A series of `input` calls were introduced (to support ask-user/password features); however, the use of `input` does not work under Python 2.7. Adjusting imports to help use `raw_input` instead.