### PR TITLE
translator: default unknown code language to none

### DIFF
--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -131,3 +131,11 @@ LITERAL2LANG_MAP = {
     # [1]: http://www.sphinx-doc.org/en/stable/config.html#confval-highlight_language
     DEFAULT_HIGHLIGHT_STYLE: 'python'
 }
+
+"""
+fallback highlight language
+
+When provided a language type that is not supported by Confluence is detected on
+a code block, this fallback style will be applied instead.
+"""
+FALLBACK_HIGHLIGHT_STYLE = 'none'

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -10,6 +10,7 @@ from .exceptions import ConfluenceError
 from .logger import ConfluenceLogger
 from .nodes import ConfluenceNavigationNode
 from .state import ConfluenceState
+from .std.confluence import FALLBACK_HIGHLIGHT_STYLE
 from .std.confluence import FCMMO
 from .std.confluence import INDENT
 from .std.confluence import LITERAL2LANG_MAP
@@ -545,7 +546,7 @@ class ConfluenceTranslator(BaseTranslator):
             if lang not in self._tracked_unknown_code_lang:
                 ConfluenceLogger.warn('unknown code language: {}'.format(lang))
                 self._tracked_unknown_code_lang.append(lang)
-            lang = LITERAL2LANG_MAP[DEFAULT_HIGHLIGHT_STYLE]
+            lang = LITERAL2LANG_MAP[FALLBACK_HIGHLIGHT_STYLE]
 
         data = self.nl.join(node.astext().splitlines())
 


### PR DESCRIPTION
By default, an unspecified coding language will default to python (based off of Sphinx's choice of default language). In the event where an unsupported language for Confluence is provided to this extension (since Confluence will not be able to render it), this extension would fallback on a default language. This is unexpected since something like `shell-session` would translate to `python`. Instead, all unknown language types will be translated to `none`.