### PR TITLE
translator: ignore nested references

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -851,8 +851,12 @@ class ConfluenceTranslator(BaseTranslator):
     # -------------------
 
     def visit_reference(self, node):
-        # nested references should never happen
-        assert(not self._reference_context)
+        # ignore reference if it is wrapped by another reference; observed
+        # when a local table of contents contains a section name which is a
+        # reference to another document
+        if self._reference_context:
+            ConfluenceLogger.verbose('skipping nested reference container')
+            return
 
         if 'iscurrent' in node:
             pass

--- a/test/unit-tests/common/dataset-common/contents-ref.rst
+++ b/test/unit-tests/common/dataset-common/contents-ref.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+.. support contents local reference verification
+
+contents-ref
+------------
+
+content

--- a/test/unit-tests/common/dataset-common/contents.rst
+++ b/test/unit-tests/common/dataset-common/contents.rst
@@ -1,0 +1,16 @@
+:orphan:
+
+.. contents local reference -- tocs point to headers; header link points to doc
+
+contents
+--------
+
+.. contents::
+    :depth: 1
+    :local:
+
+plain
+^^^^^
+
+:doc:`contents-ref`
+^^^^^^^^^^^^^^^^^^^

--- a/test/unit-tests/common/expected/contents.conf
+++ b/test/unit-tests/common/expected/contents.conf
@@ -1,0 +1,17 @@
+<ul>
+    <li>
+        <p><ac:link ac:anchor="plain">
+        <ac:link-body>plain</ac:link-body>
+        </ac:link></p>
+    </li>
+    <li>
+        <p><ac:link ac:anchor="contents-ref">
+        <ac:link-body>contents-ref</ac:link-body>
+        </ac:link></p>
+    </li>
+</ul>
+<h2>plain</h2>
+<h2><ac:link>
+<ri:page ri:content-title="contents-ref" />
+<ac:link-body>contents-ref</ac:link-body>
+</ac:link></h2>

--- a/test/unit-tests/common/test_common.py
+++ b/test/unit-tests/common/test_common.py
@@ -49,6 +49,9 @@ class TestConfluenceCommon(unittest.TestCase):
     def test_citations(self):
         self._assertExpectedWithOutput('citations')
 
+    def test_contents(self):
+        self._assertExpectedWithOutput('contents')
+
     def test_definition_lists(self):
         self._assertExpectedWithOutput('definition-lists')
 


### PR DESCRIPTION
Reference management assumed that nested references were not possible; however, it has been observed in select scenarios (such as a toctree referencing a header which also is a reference to another page) that this is not always the case. Instead of asserting on such a scenario, ignore a nested reference instead -- this extension will prioritize the initial reference.

Note that this is a slight variation to what Sphinx (v2.2.0, at time of testing) does for a documentation set applied to the HTML builder. It has been observed that a `:local`: table of contents will generate a reference directly to the content instead of the subsection of the current document. It is assumed that this is not expected, thus this extension will follow reStructuredText's wording which the local table of contents will reference the subsection instead.