### PR TITLE
builder: do not prompt for username/password when not publishing

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -97,31 +97,32 @@ class ConfluenceBuilder(Builder):
         if not ConfluenceConfig.validate(self, not suppress_conf_check):
             raise ConfluenceConfigurationError('configuration error')
 
-        if self.config.confluence_ask_user:
-            print('(request to accept username from interactive session)')
-            print(' Instance: ' + self.config.confluence_server_url)
-
-            default_user = self.config.confluence_server_user
-            u_str = ''
-            if default_user:
-                u_str = ' [{}]'.format(default_user)
-
-            target_user = input(' User{}: '.format(u_str)) or default_user
-            if not target_user:
-                raise ConfluenceConfigurationError('no user provided')
-
-            self.config.confluence_server_user = target_user
-
-        if self.config.confluence_ask_password:
-            print('(request to accept password from interactive session)')
-            if not self.config.confluence_ask_user:
+        if self.config.confluence_publish:
+            if self.config.confluence_ask_user:
+                print('(request to accept username from interactive session)')
                 print(' Instance: ' + self.config.confluence_server_url)
-                print('     User: ' + self.config.confluence_server_user)
-            sys.stdout.write(' Password: ')
-            sys.stdout.flush()
-            self.config.confluence_server_pass = getpass('')
-            if not self.config.confluence_server_pass:
-                raise ConfluenceConfigurationError('no password provided')
+
+                default_user = self.config.confluence_server_user
+                u_str = ''
+                if default_user:
+                    u_str = ' [{}]'.format(default_user)
+
+                target_user = input(' User{}: '.format(u_str)) or default_user
+                if not target_user:
+                    raise ConfluenceConfigurationError('no user provided')
+
+                self.config.confluence_server_user = target_user
+
+            if self.config.confluence_ask_password:
+                print('(request to accept password from interactive session)')
+                if not self.config.confluence_ask_user:
+                    print(' Instance: ' + self.config.confluence_server_url)
+                    print('     User: ' + self.config.confluence_server_user)
+                sys.stdout.write(' Password: ')
+                sys.stdout.flush()
+                self.config.confluence_server_pass = getpass('')
+                if not self.config.confluence_server_pass:
+                    raise ConfluenceConfigurationError('no password provided')
 
         self.assets = ConfluenceAssetManager(self.config.master_doc, self.env)
         self.writer = ConfluenceWriter(self)


### PR DESCRIPTION
If a configuration is not configured to publish content, do not attempt to ask a user for either a username or password to publish with (if the respective features are enabled).