### PR TITLE
prepare for docutils iterable-returned traverse

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -13,6 +13,7 @@ from .nodes import ConfluenceNavigationNode
 from .publisher import ConfluencePublisher
 from .state import ConfluenceState
 from .util import ConfluenceUtil
+from .util import first
 from .writer import ConfluenceWriter
 from docutils import nodes
 from docutils.io import StringOutput
@@ -279,10 +280,10 @@ class ConfluenceBuilder(Builder):
                 # Only publish documents that Sphinx asked to prepare
                 self.publish_docnames.append(docname)
 
-            toctrees = doctree.traverse(addnodes.toctree)
-            if toctrees and toctrees[0].get('maxdepth') > 0:
+            toctree = first(doctree.traverse(addnodes.toctree))
+            if toctree and toctree.get('maxdepth') > 0:
                 ConfluenceState.registerToctreeDepth(
-                    docname, toctrees[0].get('maxdepth'))
+                    docname, toctree.get('maxdepth'))
 
             doc_used_names = {}
             for node in doctree.traverse(nodes.title):

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -59,3 +59,19 @@ class ConfluenceUtil:
             elif not url.endswith('/'):
                 url += '/'
         return url
+
+def first(it):
+    """
+    returns the first element in an iterable
+
+    Returns the first element found in a provided iterable no matter if it is a
+    list or generator type. If no element is found, this call will return a
+    `None` value.
+
+    Args:
+        it: an iterable type
+
+    Returns:
+        the first element
+    """
+    return next(iter(it), None)


### PR DESCRIPTION
When using the most recent Docutils, the following message is generated:

```
    FutureWarning:
       The iterable returned by Node.traverse()
       will become an iterator instead of a list in Docutils > 0.16.
```

Adjusting a series of index-fetched "first" element calls to use a new `first` utility method to deal with various iterable types.