### PR TITLE
alignment improvements for figures

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -141,6 +141,23 @@ See also |confluence_publish_prefix|_.
 
 --------------------------------------------------------------------------------
 
+confluence_default_alignment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.3
+
+Explicitly set which alignment type to use when a default alignment value is
+detected. As of Sphinx 2.0+, the default alignment is set to ``center``. Legacy
+versions of Sphinx had a default alignment of ``left``. By default, this
+extension will use a Sphinx-defined default alignment unless explicitly set by
+this configuration value. Accepted values are ``left``, ``center`` or ``right``.
+
+.. code-block:: python
+
+    confluence_default_alignment = 'left'
+
+--------------------------------------------------------------------------------
+
 .. |confluence_header_file| replace:: ``confluence_header_file``
 .. _confluence_header_file:
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -82,6 +82,8 @@ def setup(app):
     """(configuration - generic)"""
     """Add page and section numbers if doctree has :numbered: option"""
     app.add_config_value('confluence_add_secnumbers', True, False)
+    """Default alignment for tables, figures, etc."""
+    app.add_config_value('confluence_default_alignment', None, 'env')
     """File to get page header information from."""
     app.add_config_value('confluence_header_file', None, False)
     """File to get page footer information from."""

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -34,6 +34,19 @@ class ConfluenceConfig:
         c = builder.config
         env = builder.app.env
 
+        if c.confluence_default_alignment:
+            if not c.confluence_default_alignment in (
+                    'left', 'center', 'right'):
+                errState = True
+                if log:
+                    ConfluenceLogger.error(
+"""invalid default alignment
+
+The option 'confluence_default_alignment' has been provided to override the
+default alignment for tables, figures, etc. Accepted values include 'left',
+'center' and 'right'.
+""")
+
         if c.confluence_footer_file:
             if not os.path.isfile(os.path.join(env.srcdir,
                     c.confluence_footer_file)):

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -75,6 +75,11 @@ class ConfluenceTranslator(BaseTranslator):
         self._thead_context = []
         self._tocdepth = ConfluenceState.toctreeDepth(self.docname)
 
+        if config.confluence_default_alignment:
+            self._default_alignment = config.confluence_default_alignment
+        else:
+            self._default_alignment = DEFAULT_ALIGNMENT
+
         if config.highlight_language:
             self._highlight = config.highlight_language
         else:
@@ -1186,12 +1191,16 @@ class ConfluenceTranslator(BaseTranslator):
 
     def visit_caption(self, node):
         attribs = {}
+        attribs['style'] = 'clear: both;'
+
         if 'align' in node.parent:
             alignment = node.parent['align']
+
             if alignment == 'default':
-                alignment = DEFAULT_ALIGNMENT
-            if alignment == 'center':
-                attribs['style'] = 'text-align: center;'
+                alignment = self._default_alignment
+            if alignment != 'left':
+                attribs['style'] = '{}text-align: {};'.format(
+                    attribs['style'], alignment)
 
         self.body.append(self._start_tag(node, 'p', **attribs))
         self.context.append(self._end_tag(node))
@@ -1231,7 +1240,7 @@ class ConfluenceTranslator(BaseTranslator):
             alignment = node.parent['align']
 
         if alignment == 'default':
-            alignment = DEFAULT_ALIGNMENT
+            alignment = self._default_alignment
 
         if alignment:
             alignment = self._escape_sf(alignment)
@@ -1289,9 +1298,9 @@ class ConfluenceTranslator(BaseTranslator):
         if 'align' in node.parent:
             alignment = node.parent['align']
             if alignment == 'default':
-                alignment = DEFAULT_ALIGNMENT
-            if alignment == 'center':
-                attribs['style'] = 'text-align: center;'
+                alignment = self._default_alignment
+            if alignment != 'left':
+                attribs['style'] = 'text-align: {};'.format(alignment)
 
         self.body.append(self._start_tag(node, 'div', **attribs))
         self.context.append(self._end_tag(node))

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -67,6 +67,7 @@ class ConfluenceTranslator(BaseTranslator):
         self.secnumber_suffix = config.confluence_secnumber_suffix
         self.warn = document.reporter.warning
         self._building_footnotes = False
+        self._figure_context = []
         self._literal = False
         self._manpage_url = getattr(config, 'manpages_url', None)
         self._quote_level = 0
@@ -1192,6 +1193,7 @@ class ConfluenceTranslator(BaseTranslator):
     def visit_caption(self, node):
         attribs = {}
         attribs['style'] = 'clear: both;'
+        self._figure_context.append('')
 
         if 'align' in node.parent:
             alignment = node.parent['align']
@@ -1223,8 +1225,12 @@ class ConfluenceTranslator(BaseTranslator):
                 node, 'hr', suffix=self.nl, empty=True))
 
     def depart_figure(self, node):
-        # force clear from a floating confluence image
-        self.body.append('<div style="clear: both"> </div>')
+        # force clear from a floating confluence image if not handled in caption
+        if self._figure_context:
+            self._figure_context.pop()
+        else:
+            self.body.append('<div style="clear: both"> </div>\n')
+
         self.body.append(self.context.pop()) # <dynamic>
 
     def visit_image(self, node):

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1284,8 +1284,20 @@ class ConfluenceTranslator(BaseTranslator):
 
         raise nodes.SkipNode
 
-    visit_legend = visit_paragraph
-    depart_legend = depart_paragraph
+    def visit_legend(self, node):
+        attribs = {}
+        if 'align' in node.parent:
+            alignment = node.parent['align']
+            if alignment == 'default':
+                alignment = DEFAULT_ALIGNMENT
+            if alignment == 'center':
+                attribs['style'] = 'text-align: center;'
+
+        self.body.append(self._start_tag(node, 'div', **attribs))
+        self.context.append(self._end_tag(node))
+
+    def depart_legend(self, node):
+        self.body.append(self.context.pop()) # div
 
     # ------------------
     # sphinx -- download

--- a/test/unit-tests/common/dataset-alignment/index.rst
+++ b/test/unit-tests/common/dataset-alignment/index.rst
@@ -1,0 +1,6 @@
+default alignment
+-----------------
+
+.. figure:: https://example.com/image.png
+
+   caption

--- a/test/unit-tests/common/dataset-common/figure.rst
+++ b/test/unit-tests/common/dataset-common/figure.rst
@@ -5,6 +5,11 @@
 figure
 ------
 
+.. external image (default align; no caption)
+
+.. figure:: https://www.example.com/image.png
+   :alt: alt text
+
 .. external image (default align)
 
 .. figure:: https://www.example.com/image.png

--- a/test/unit-tests/common/expected-center/figure.conf
+++ b/test/unit-tests/common/expected-center/figure.conf
@@ -3,30 +3,38 @@
     <ac:rich-text-body>
         <ac:image ac:align="center" ac:alt="alt text">
             <ri:url ri:value="https://www.example.com/image.png" />
-        </ac:image><p style="text-align: center;">caption</p>
-        <p><p>legend</p>
-        </p>
-    <div style="clear: both"> </div></ac:rich-text-body>
+        </ac:image><div style="clear: both"> </div>
+    </ac:rich-text-body>
+</ac:structured-macro>
+<ac:structured-macro ac:name="info">
+    <ac:parameter ac:name="icon">false</ac:parameter>
+    <ac:rich-text-body>
+        <ac:image ac:align="center" ac:alt="alt text">
+            <ri:url ri:value="https://www.example.com/image.png" />
+        </ac:image><p style="clear: both;text-align: center;">caption</p>
+        <div style="text-align: center;"><p>legend</p>
+        </div>
+    </ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
     <ac:rich-text-body>
         <ac:image ac:align="left" ac:alt="alt text">
             <ri:url ri:value="https://www.example.com/image.png" />
-        </ac:image><p>caption</p>
-        <p><p>legend</p>
-        </p>
-    <div style="clear: both"> </div></ac:rich-text-body>
+        </ac:image><p style="clear: both;">caption</p>
+        <div><p>legend</p>
+        </div>
+    </ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
     <ac:rich-text-body>
         <ac:image ac:align="center">
             <ri:attachment ri:filename="image02.png"></ri:attachment>
-        </ac:image><p style="text-align: center;">caption</p>
-        <p><p>legend</p>
-        </p>
-    <div style="clear: both"> </div></ac:rich-text-body>
+        </ac:image><p style="clear: both;text-align: center;">caption</p>
+        <div style="text-align: center;"><p>legend</p>
+        </div>
+    </ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
@@ -34,8 +42,8 @@
         <ac:image ac:align="right" ac:style="float: right;">
             <ri:attachment ri:filename="image03.png"><ri:page ri:content-title="table of contents" />
             </ri:attachment>
-        </ac:image><p>caption</p>
-        <p><p>legend</p>
-        </p>
-    <div style="clear: both"> </div></ac:rich-text-body>
+        </ac:image><p style="clear: both;text-align: right;">caption</p>
+        <div style="text-align: right;"><p>legend</p>
+        </div>
+    </ac:rich-text-body>
 </ac:structured-macro>

--- a/test/unit-tests/common/expected/alignment-center.conf
+++ b/test/unit-tests/common/expected/alignment-center.conf
@@ -1,0 +1,8 @@
+<ac:structured-macro ac:name="info">
+    <ac:parameter ac:name="icon">false</ac:parameter>
+    <ac:rich-text-body>
+        <ac:image ac:align="center">
+            <ri:url ri:value="https://example.com/image.png" />
+        </ac:image><p style="clear: both;text-align: center;">caption</p>
+    </ac:rich-text-body>
+</ac:structured-macro>

--- a/test/unit-tests/common/expected/alignment-left.conf
+++ b/test/unit-tests/common/expected/alignment-left.conf
@@ -1,0 +1,8 @@
+<ac:structured-macro ac:name="info">
+    <ac:parameter ac:name="icon">false</ac:parameter>
+    <ac:rich-text-body>
+        <ac:image ac:align="left">
+            <ri:url ri:value="https://example.com/image.png" />
+        </ac:image><p style="clear: both;">caption</p>
+    </ac:rich-text-body>
+</ac:structured-macro>

--- a/test/unit-tests/common/expected/alignment-right.conf
+++ b/test/unit-tests/common/expected/alignment-right.conf
@@ -1,0 +1,8 @@
+<ac:structured-macro ac:name="info">
+    <ac:parameter ac:name="icon">false</ac:parameter>
+    <ac:rich-text-body>
+        <ac:image ac:align="right" ac:style="float: right;">
+            <ri:url ri:value="https://example.com/image.png" />
+        </ac:image><p style="clear: both;text-align: right;">caption</p>
+    </ac:rich-text-body>
+</ac:structured-macro>

--- a/test/unit-tests/common/expected/figure.conf
+++ b/test/unit-tests/common/expected/figure.conf
@@ -1,32 +1,40 @@
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
+        <ac:rich-text-body>
+            <ac:image ac:alt="alt text">
+            <ri:url ri:value="https://www.example.com/image.png" />
+        </ac:image><div style="clear: both"> </div>
+    </ac:rich-text-body>
+</ac:structured-macro>
+<ac:structured-macro ac:name="info">
+    <ac:parameter ac:name="icon">false</ac:parameter>
     <ac:rich-text-body>
         <ac:image ac:alt="alt text">
             <ri:url ri:value="https://www.example.com/image.png" />
-        </ac:image><p>caption</p>
-        <p><p>legend</p>
-        </p>
-    <div style="clear: both"> </div></ac:rich-text-body>
+        </ac:image><p style="clear: both;">caption</p>
+        <div><p>legend</p>
+        </div>
+    </ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
     <ac:rich-text-body>
         <ac:image ac:align="left" ac:alt="alt text">
             <ri:url ri:value="https://www.example.com/image.png" />
-        </ac:image><p>caption</p>
-        <p><p>legend</p>
-        </p>
-    <div style="clear: both"> </div></ac:rich-text-body>
+        </ac:image><p style="clear: both;">caption</p>
+        <div><p>legend</p>
+        </div>
+    </ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
     <ac:rich-text-body>
         <ac:image ac:align="center">
             <ri:attachment ri:filename="image02.png"></ri:attachment>
-        </ac:image><p style="text-align: center;">caption</p>
-        <p><p>legend</p>
-        </p>
-    <div style="clear: both"> </div></ac:rich-text-body>
+        </ac:image><p style="clear: both;text-align: center;">caption</p>
+        <div style="text-align: center;"><p>legend</p>
+        </div>
+    </ac:rich-text-body>
 </ac:structured-macro>
 <ac:structured-macro ac:name="info">
     <ac:parameter ac:name="icon">false</ac:parameter>
@@ -34,8 +42,8 @@
         <ac:image ac:align="right" ac:style="float: right;">
             <ri:attachment ri:filename="image03.png"><ri:page ri:content-title="table of contents" />
             </ri:attachment>
-        </ac:image><p>caption</p>
-        <p><p>legend</p>
-        </p>
-    <div style="clear: both"> </div></ac:rich-text-body>
+        </ac:image><p style="clear: both;text-align: right;">caption</p>
+        <div style="text-align: right;"><p>legend</p>
+        </div>
+    </ac:rich-text-body>
 </ac:structured-macro>

--- a/test/unit-tests/common/test_alignment.py
+++ b/test/unit-tests/common/test_alignment.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""
+    :copyright: Copyright 2020 by the contributors (see AUTHORS file).
+    :license: BSD-2-Clause, see LICENSE for details.
+"""
+
+from pkg_resources import parse_version
+from sphinx.__init__ import __version__ as sphinx_version
+from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
+import os
+import unittest
+
+class TestConfluenceAlignment(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # skip alignment tests pre-sphinx 2.1 as 'default' hints do not exist
+        if parse_version(sphinx_version) < parse_version('2.1'):
+            raise unittest.SkipTest('default hints not supported in sphinx')
+
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+
+        self.config = _.prepareConfiguration()
+        self.dataset = os.path.join(test_dir, 'dataset-alignment')
+        self.expected = os.path.join(test_dir, 'expected')
+
+    def test_alignment_default(self):
+        doc_dir, doctree_dir = _.prepareDirectories('alignment-center')
+        app = _.buildSphinx(self.dataset, doc_dir, doctree_dir, self.config)
+        _.assertExpectedWithOutput(
+            self, 'alignment-center', self.expected, doc_dir, tpn='index')
+
+    def test_alignment_left(self):
+        config = dict(self.config)
+        config['confluence_default_alignment'] = 'left'
+
+        doc_dir, doctree_dir = _.prepareDirectories('alignment-left')
+        app = _.buildSphinx(self.dataset, doc_dir, doctree_dir, config)
+        _.assertExpectedWithOutput(
+            self, 'alignment-left', self.expected, doc_dir, tpn='index')
+
+    def test_alignment_center(self):
+        config = dict(self.config)
+        config['confluence_default_alignment'] = 'center'
+
+        doc_dir, doctree_dir = _.prepareDirectories('alignment-center')
+        app = _.buildSphinx(self.dataset, doc_dir, doctree_dir, config)
+        _.assertExpectedWithOutput(
+            self, 'alignment-center', self.expected, doc_dir, tpn='index')
+
+    def test_alignment_right(self):
+        config = dict(self.config)
+        config['confluence_default_alignment'] = 'right'
+
+        doc_dir, doctree_dir = _.prepareDirectories('alignment-right')
+        app = _.buildSphinx(self.dataset, doc_dir, doctree_dir, config)
+        _.assertExpectedWithOutput(
+            self, 'alignment-right', self.expected, doc_dir, tpn='index')


### PR DESCRIPTION
First, this pull request corrects an issue with a figure's legend alignment. When a figure is assigned an alignment type, it is expected that the caption and legend contents also follows the same alignment type (based off observed Sphinx stock builders). This commit adjusts the built legend to be a div element with the respective text alignment value assigned to a parent figure (if any is set).

Second, introducing a new configuration option `confluence_default_alignment` to allow users to override the default alignment value applied. If a user wishes to use legacy alignment style, the following may be used:

```
confluence_default_alignment = 'left'
```

Note that the default alignment value will only be used when a `default` alignment hint is provided in Sphinx, which only exists in Sphinx 2.1+ (Sphinx 2.0 always defaults to `center` and Sphinx 1.8 applies to default alignment).