### PR TITLE
previous-next improvements

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -216,8 +216,8 @@ class ConfluenceBuilder(Builder):
         self.nav_next = {}
         self.nav_prev = {}
         for docname in ordered_docnames[1:]:
-            self.nav_prev[docname] = prevdoc
-            self.nav_next[prevdoc] = docname
+            self.nav_prev[docname] = self.get_relative_uri(docname, prevdoc)
+            self.nav_next[prevdoc] = self.get_relative_uri(prevdoc, docname)
             prevdoc = docname
 
         # add orphans (if any) to the publish list

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -42,32 +42,6 @@ try:
 except NameError:
     pass
 
-# Clone of relative_uri() sphinx.util.osutil, with bug-fixes
-# since the original code had a few errors.
-# This was fixed in Sphinx 1.2b.
-def relative_uri(base, to):
-    """Return a relative URL from ``base`` to ``to``."""
-    if to.startswith(SEP):
-        return to
-    b2 = base.split(SEP)
-    t2 = to.split(SEP)
-    # remove common segments (except the last segment)
-    for x, y in zip(b2[:-1], t2[:-1]):
-        if x != y:
-            break
-        b2.pop(0)
-        t2.pop(0)
-    if b2 == t2:
-        # Special case: relative_uri('f/index.html','f/index.html')
-        # returns '', not 'index.html'
-        return ''
-    if len(b2) == 1 and t2 == ['']:
-        # Special case: relative_uri('f/index.html','f/') should
-        # return './', not ''
-        return '.' + SEP
-    return ('..' + SEP) * (len(b2)-1) + SEP.join(t2)
-
-
 class ConfluenceBuilder(Builder):
     allow_parallel = True
     name = 'confluence'
@@ -213,15 +187,6 @@ class ConfluenceBuilder(Builder):
 
     def get_target_uri(self, docname, typ=None):
         return self.link_transform(docname)
-
-    def get_relative_uri(self, from_, to, typ=None):
-        """
-        Return a relative URI between two source filenames.
-        """
-        # This is slightly different from Builder.get_relative_uri,
-        # as it contains a small bug (which was fixed in Sphinx 1.2).
-        return relative_uri(self.get_target_uri(from_),
-                            self.get_target_uri(to, typ))
 
     def prepare_writing(self, docnames):
         ordered_docnames = []

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -599,15 +599,18 @@ class ConfluenceBuilder(Builder):
             prev_label = '← ' + _('Previous')
             reference = nodes.reference(prev_label, prev_label, internal=True,
                 refuri=self.nav_prev[docname])
+            reference._navnode = True
+            reference._navnode_next = False
+            reference._navnode_previous = True
             navnode.append(reference)
-
-        if docname in self.nav_prev and docname in self.nav_next:
-            navnode.append(nodes.Text(' | '))
 
         if docname in self.nav_next:
             next_label = _('Next') + ' →'
             reference = nodes.reference(next_label, next_label, internal=True,
                 refuri=self.nav_next[docname])
+            reference._navnode = True
+            reference._navnode_next = True
+            reference._navnode_previous = False
             navnode.append(reference)
 
         return navnode

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -971,6 +971,13 @@ class ConfluenceTranslator(BaseTranslator):
             elif self.can_anchor:
                 anchor_value = anchor
 
+        navnode = getattr(node, '_navnode', False)
+
+        if navnode:
+            float = 'right' if node._navnode_next else 'left'
+            self.body.append(self._start_tag(node, 'div',
+                **{'style': 'float: ' + float + ';'}))
+
         # build link to internal anchor (on another page)
         #  Note: plain-text-link body cannot have inline markup; add the node
         #        contents into body and skip processing the rest of this node.
@@ -979,11 +986,21 @@ class ConfluenceTranslator(BaseTranslator):
         self.body.append(self._start_tag(node, 'ri:page',
             suffix=self.nl, empty=True, **{'ri:content-title': doctitle}))
         self.body.append(self._start_ac_link_body(node))
+
+        # style navigation references with an aui-button look
+        if navnode:
+            self.body.append(self._start_tag(
+                node, 'span', **{'class': 'aui-button'}))
+            self._reference_context.append(self._end_tag(node, suffix=''))
+
         if self.add_secnumbers and node.get('secnumber'):
             self.body.append('.'.join(map(str, node['secnumber'])) +
                              self.secnumber_suffix)
         self._reference_context.append(self._end_ac_link_body(node))
         self._reference_context.append(self._end_ac_link(node))
+
+        if navnode:
+            self._reference_context.append(self._end_tag(node))
 
     def depart_reference(self, node):
         for element in self._reference_context:
@@ -1608,19 +1625,16 @@ class ConfluenceTranslator(BaseTranslator):
         if node.bottom:
             self.body.append(self._start_tag(
                 node, 'hr', suffix=self.nl, empty=True,
-                **{'style': 'margin-top: 30px'}))
-
-        self.body.append(self._start_tag(node, 'p', suffix=self.nl,
-            **{'style': 'text-align: right'}))
-        self.context.append(self._end_tag(node))
+                **{'style': 'padding-bottom: 10px; margin-top: 30px'}))
 
     def depart_ConfluenceNavigationNode(self, node):
-        self.body.append(self.context.pop()) # p
-
         if node.top:
             self.body.append(self._start_tag(
                 node, 'hr', suffix=self.nl, empty=True,
-                **{'style': 'margin-bottom: 30px'}))
+                **{'style':
+                    'clear: both; padding-top: 10px; margin-bottom: 30px'}))
+        else:
+            self.body.append('<div style="clear: both"> </div>\n')
 
     # ------------------------------------------
     # confluence-builder -- enhancements -- jira


### PR DESCRIPTION
Performs two changes with respect to previous-next navigation buttons.

First, the original navigation implementation would compile a list of previous and next documents for the determined order of documents; however, the references compiled did not properly take into account the relative URL between the respective documents. Adjusting the caching to use the builder's `get_relative_uri` call when forming this information.

Second, tweaks the "Previous" and "Next" buttons on pages to have better visualization. Links are now styled through a Confluence-defined button class (`aui-button`). Buttons are also pushed to left and right sides (respectively) in a similar design approach seen in stock builders.