### PR TITLE
publisher: ability to control watch state

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -343,6 +343,9 @@ option can be set to ``True``. By default, this option is set to ``False``.
 
 --------------------------------------------------------------------------------
 
+.. |confluence_disable_notifications| replace:: ``confluence_disable_notifications``
+.. _confluence_disable_notifications:
+
 confluence_disable_notifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -353,6 +356,8 @@ notifications are enabled with a value of ``False``.
 .. code-block:: python
 
    confluence_disable_notifications = True
+
+See also |confluence_watch|_.
 
 --------------------------------------------------------------------------------
 
@@ -515,6 +520,30 @@ seconds, the following can be used:
 .. code-block:: python
 
    confluence_timeout = 10
+
+--------------------------------------------------------------------------------
+
+.. |confluence_watch| replace:: ``confluence_watch``
+.. _confluence_watch:
+
+confluence_watch
+~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.3
+
+Indicate whether or not the user publishing content will automatically watch
+pages for changes. In Confluence, when creating a new page or updating an
+existing page, the editing user will automatically watch the page. Notifications
+on automatically published content is typically not relevant to publishers
+through this extension, especially if the content is volatile. If a publisher 
+wishes to be keep informed on notification for published pages, this option can
+be set to ``True``. By default, watching is disabled with a value of ``False``.
+
+.. code-block:: python
+
+   confluence_watch = False
+
+See also |confluence_disable_notifications|_.
 
 --------------------------------------------------------------------------------
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -120,6 +120,8 @@ def setup(app):
     app.add_config_value('confluence_purge_from_master', None, False)
     """Timeout for network-related calls (publishing)."""
     app.add_config_value('confluence_timeout', None, False)
+    """Whether or not new content should be watched."""
+    app.add_config_value('confluence_watch', None, False)
 
     """(configuration - advanced publishing)"""
     """Tri-state asset handling (auto, force push or disable)."""

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -32,6 +32,7 @@ class ConfluencePublisher():
         self.server_pass = config.confluence_server_pass
         self.space_name = config.confluence_space_name
         self.timeout = config.confluence_timeout
+        self.watch = config.confluence_watch
         self.ca_cert = config.confluence_ca_cert
         self.client_cert = config.confluence_client_cert
         self.client_cert_pass = config.confluence_client_cert_pass
@@ -315,6 +316,10 @@ class ConfluencePublisher():
                     page_id, attachment['id'])
                 rsp = self.rest_client.post(url, None, files=data)
                 uploaded_attachment_id = rsp['id']
+
+            if not self.watch:
+                self.rest_client.delete('user/watch/content',
+                    uploaded_attachment_id)
         except ConfluencePermissionError:
             raise ConfluencePermissionError(
                 """Publish user does not have permission to add an """
@@ -413,6 +418,9 @@ class ConfluencePublisher():
                 """Publish user does not have permission to add page """
                 """content to the configured space."""
             )
+
+        if not self.watch:
+            self.rest_client.delete('user/watch/content', uploaded_page_id)
 
         return uploaded_page_id
 


### PR DESCRIPTION
When this extension takes advantage of creating new documents or editing existing documents through the publishing feature, pages will be automatically watched by the publishing user. This is not typically ideal for documentation sets which may be published automatically (e.g. pages purged and edited using multiple users can generate multiple Emails in a publish event).

This commit adjusts the default watch state for pages to unwatched. Publishers can override this by setting `confluence_watch` to a value of `True` to always watch the state of published documents.