### PR TITLE
publisher: allow a user to dry run a publish event

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -645,6 +645,29 @@ providing a proxy server using this configuration.
 
 --------------------------------------------------------------------------------
 
+.. |confluence_publish_dryrun| replace:: ``confluence_publish_dryrun``
+.. _confluence_publish_dryrun:
+
+confluence_publish_dryrun
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a user wishes to start managing a new document set for publishing, there
+maybe concerns about conflicts with existing content. When the dry run feature
+is enabled to ``True``, a publish event will not edit or remove any existing
+content. Instead, the extension will inform the user which pages will be
+created, whether or not pages will be moved and whether or not pages/attachments
+will be removed. By default, the dry run feature is disabled with a value of
+``False``.
+
+.. code-block:: python
+
+   confluence_publish_dryrun = True
+
+See also
+:ref:`Confluence Spaces and Unique Page Names <confluence_unique_page_names>`.
+
+--------------------------------------------------------------------------------
+
 .. _confluence_publish_subset:
 
 confluence_publish_subset

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -4,6 +4,8 @@ tips
 .. contents::
    :local:
 
+.. _confluence_unique_page_names:
+
 confluence spaces and unique page names
 ---------------------------------------
 
@@ -67,6 +69,8 @@ Users needing to restrict the extension from possibly mangling manually prepared
 content can use the ``confluence_publish_prefix``
 (:ref:`jump<confluence_publish_prefix>`) or ``confluence_publish_postfix``
 (:ref:`jump<confluence_publish_postfix>`) options.
+
+See also the :ref:`dry run capability <confluence_publish_dryrun>`.
 
 setting a publishing timeout
 ----------------------------

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -110,6 +110,8 @@ def setup(app):
     app.add_config_value('confluence_master_homepage', None, False)
     """Root/parent page's name to publish documents into."""
     app.add_config_value('confluence_parent_page', None, False)
+    """Perform a dry run of publishing to inspect what publishing will do."""
+    app.add_config_value('confluence_publish_dryrun', None, '')
     """Postfix to apply to title of published pages."""
     app.add_config_value('confluence_publish_postfix', None, False)
     """Prefix to apply to published pages."""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -437,7 +437,13 @@ class ConfluenceBuilder(Builder):
             else:
                 baseid = self.parent_id
 
-            if self.config.confluence_adv_aggressive_search is True:
+            # if no base identifier and dry running, ignore legeacy page
+            # searching as there is no initial master document to reference
+            # against
+            if (conf.confluence_purge_from_master and
+                    conf.confluence_publish_dryrun and not baseid):
+                self.legacy_pages = []
+            elif self.config.confluence_adv_aggressive_search is True:
                 self.legacy_pages = self.publisher.getDescendantsCompat(baseid)
             else:
                 self.legacy_pages = self.publisher.getDescendants(baseid)


### PR DESCRIPTION
When publishing, a user may be curious to observe what this extension maybe modified on a target Confluence instance. With the dry run feature (e.g. adding a command line option
`-Dconfluence_dryrun=1`), this extension will log where pages will be published and other changes without actually performing the actions.