### PR TITLE
builder: allow title overrides

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -325,6 +325,9 @@ By default, this option is disabled with a value of ``False``.
 
 --------------------------------------------------------------------------------
 
+.. |confluence_disable_autogen_title| replace:: ``confluence_disable_autogen_title``
+.. _confluence_disable_autogen_title:
+
 confluence_disable_autogen_title
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -340,6 +343,11 @@ option can be set to ``True``. By default, this option is set to ``False``.
 .. code-block:: python
 
    confluence_disable_autogen_title = True
+
+See also:
+
+- |confluence_remove_title|_
+- |confluence_title_overrides|_
 
 --------------------------------------------------------------------------------
 
@@ -501,6 +509,40 @@ to ``True`` before taking effect.
 .. code-block:: python
 
    confluence_purge_from_master = False
+
+--------------------------------------------------------------------------------
+
+.. |confluence_title_overrides| replace:: ``confluence_title_overrides``
+.. _confluence_title_overrides:
+
+confluence_title_overrides
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.3
+
+Allows a user to override the title value for a specific document. When
+documents are parsed for title values, the first title element's content will be
+used as the publish page's title. Select documents name not include a title and
+are ignored; or, documents may conflict with each other but there is a desire to
+keep them the same name in reStructuredText form. With
+``confluence_title_overrides``, a user can define a dictionary which will map a
+given docname into a title element instead of the title element (if any) found
+in the respective document. By default, documents will give assigned titles
+values based off the first detected title element with a value of ``None``.
+
+.. code-block:: python
+
+    confluence_title_overrides = {
+        'index': 'Index Override',
+    }
+
+See also:
+
+- :ref:`Confluence Spaces and Unique Page Names <confluence_unique_page_names>`
+- |confluence_disable_autogen_title|_
+- |confluence_publish_postfix|_
+- |confluence_publish_prefix|_
+- |confluence_remove_title|_
 
 --------------------------------------------------------------------------------
 
@@ -901,6 +943,9 @@ get_relative_uri_ method. The default translation will be the combination of
 
 --------------------------------------------------------------------------------
 
+.. |confluence_remove_title| replace:: ``confluence_remove_title``
+.. _confluence_remove_title:
+
 confluence_remove_title
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -914,6 +959,11 @@ option is enabled with a value of ``True``.
 .. code-block:: python
 
    confluence_remove_title = True
+
+See also:
+
+- |confluence_disable_autogen_title|_
+- |confluence_title_overrides|_
 
 
 .. references ------------------------------------------------------------------

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -70,7 +70,8 @@ content can use the ``confluence_publish_prefix``
 (:ref:`jump<confluence_publish_prefix>`) or ``confluence_publish_postfix``
 (:ref:`jump<confluence_publish_postfix>`) options.
 
-See also the :ref:`dry run capability <confluence_publish_dryrun>`.
+See also the :ref:`dry run capability <confluence_publish_dryrun>` and the
+:ref:`title overrides capability <confluence_title_overrides>`.
 
 setting a publishing timeout
 ----------------------------

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -120,6 +120,8 @@ def setup(app):
     app.add_config_value('confluence_purge', None, False)
     """Enablement of purging legacy child pages from a master page."""
     app.add_config_value('confluence_purge_from_master', None, False)
+    """docname-2-title dictionary for title overrides."""
+    app.add_config_value('confluence_title_overrides', None, 'env')
     """Timeout for network-related calls (publishing)."""
     app.add_config_value('confluence_timeout', None, False)
     """Whether or not new content should be watched."""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -226,7 +226,13 @@ class ConfluenceBuilder(Builder):
         for docname in ordered_docnames:
             doctree = self.env.get_doctree(docname)
 
-            doctitle = self._parse_doctree_title(docname, doctree)
+            # acquire title from override (if any), or parse first title entity
+            if (self.config.confluence_title_overrides and
+                    docname in self.config.confluence_title_overrides):
+                doctitle = self.config.confluence_title_overrides[docname]
+            else:
+                doctitle = self._parse_doctree_title(docname, doctree)
+
             if not doctitle:
                 continue
 

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -160,6 +160,17 @@ however, no username has been configured. Ensure 'confluence_server_user' is
 properly set with the publisher's Confluence username.
 """)
 
+            if c.confluence_title_overrides is not None:
+                if not isinstance(c.confluence_title_overrides, dict):
+                    errState = True
+                    if log:
+                        ConfluenceLogger.error(
+"""invalid type for confluence title overrides
+
+While providing title overrides using 'confluence_title_overrides', the option
+should be a dictionary of (str, str) entries.
+""")
+
             if c.confluence_ca_cert:
                 if not os.path.exists(c.confluence_ca_cert):
                     errState = True


### PR DESCRIPTION
This extension will pull the content for the first detected title element as the title value to use for a Confluence page. This detection may not always be the ideal choice for select documentation sets. In a scenario where a user cannot or does not watch to explicitly adjust a document for a title entry, they may opt to use an override option to explicitly configure the builder to use a title value for a given document. For example, if a user wishes to override the title value for the `index` page, the following configuration can be used:

```
    confluence_title_overrides = {
        'index': 'Index Override',
    }
```