### PR TITLE
state: automatic unique title names

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -316,8 +316,6 @@ class ConfluenceBuilder(Builder):
         # images are detected during an 'doctree-resolved' hook (see __init__).
         self.assets.process(ordered_docnames)
 
-        ConfluenceState.titleConflictCheck()
-
     def process_tree_structure(self, ordered, docname, traversed, depth=0):
         omit = False
         max_depth = self.config.confluence_max_doc_depth

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -80,17 +80,22 @@ class ConfluenceState:
         If a prefix (or postfix) value is provided, it will be added to the
         beginning (or at the end) of the provided title value.
         """
+        try_max = CONFLUENCE_MAX_TITLE_LEN
+        base_tail = ''
+
         if prefix:
             title = prefix + title
 
         if postfix:
-            title += postfix
+            base_tail += postfix
+            try_max += len(postfix)
 
-        if len(title) > CONFLUENCE_MAX_TITLE_LEN:
-            title = title[0:CONFLUENCE_MAX_TITLE_LEN]
+        if len(title) > try_max:
+            title = title[0:try_max]
             ConfluenceLogger.warn("document title has been trimmed due to "
                 "length: %s" % docname)
 
+        title += base_tail
         ConfluenceState.doc2title[docname] = title
         ConfluenceLogger.verbose("mapping %s to title: %s" % (docname, title))
         return title

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -29,6 +29,7 @@ class ConfluenceState:
     doc2title = {}
     doc2ttd = {}
     refid2target = {}
+    title2doc = {}
 
     @staticmethod
     def registerParentDocname(docname, parent_docname):
@@ -95,8 +96,27 @@ class ConfluenceState:
             ConfluenceLogger.warn("document title has been trimmed due to "
                 "length: %s" % docname)
 
+        base_title = title
         title += base_tail
+
+        # check if title is already used; if so, append a new value
+        offset = 2
+        while title.lower() in ConfluenceState.title2doc:
+            if offset == 2:
+                ConfluenceLogger.warn('title conflict detected with '
+                    "'{}' and '{}'".format(
+                        ConfluenceState.title2doc[title.lower()], docname))
+
+            tail = ' ({}){}'.format(offset, base_tail)
+            try_max = CONFLUENCE_MAX_TITLE_LEN + len(tail)
+            if len(base_title) > try_max:
+                base_title = base_title[0:try_max]
+
+            title = base_title + tail
+            offset += 1
+
         ConfluenceState.doc2title[docname] = title
+        ConfluenceState.title2doc[title.lower()] = docname
         ConfluenceLogger.verbose("mapping %s to title: %s" % (docname, title))
         return title
 
@@ -146,6 +166,7 @@ class ConfluenceState:
         ConfluenceState.doc2title.clear()
         ConfluenceState.doc2ttd.clear()
         ConfluenceState.refid2target.clear()
+        ConfluenceState.title2doc.clear()
 
     @staticmethod
     def parentDocname(docname):
@@ -173,26 +194,6 @@ class ConfluenceState:
         See `registerTitle` for more information.
         """
         return ConfluenceState.doc2title.get(docname)
-
-    @staticmethod
-    def titleConflictCheck():
-        """
-        check for title conflicts with known documents
-
-        The following cycles through known documents to see if any documents are
-        using the same title name. If multiple documents have the same title
-        value, the publish operation would update the contents of a page
-        multiple times (last served wins). This check only generates a warning
-        for the user (as this should not really happen).
-        """
-        d = ConfluenceState.doc2title
-        for key_a in d:
-            for key_b in d:
-                if key_a == key_b:
-                    break
-                if (d[key_a] == d[key_b]):
-                    ConfluenceLogger.warn("title conflict detected with "
-                        "'%s' and '%s'" % (key_a, key_b))
 
     @staticmethod
     def toctreeDepth(docname):


### PR DESCRIPTION
Original title management would compile title entries and warn the publishing user of any title conflicts, but this extension did not do anything more than that. This can become an annoyance for large documentation sets where titles may be conflicting but a publisher is not that picky on the generated title values. Also, this may cause confusion on publication when select publish events may fail when publishing a child/nested page with a parent holding the original ownership of the title (API error when mapping a page identifier with itself as an ancestor).

Instead, along with warning a user of a title conflict between documents, this extension will append an incrementing numerical value to titles to allow a publishing event to progress without issue.

Note that for users who may publish subset of documents at a time, may observe oddities where the title conflict resolution may generate a different title name based on the active documents being processed.

---

Note this change also stacks a correction where postfix values may be trimmed.