### PR TITLE
Fix section numbering in singleconfluence builder

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -59,6 +59,7 @@ class ConfluenceBuilder(Builder):
         self.cache_doctrees = {}
         self.file_suffix = '.conf'
         self.link_suffix = None
+        self.current_docname = None
         self.add_secnumbers = self.config.confluence_add_secnumbers
         self.secnumber_suffix = self.config.confluence_secnumber_suffix
         self.master_doc_page_id = None
@@ -367,6 +368,7 @@ class ConfluenceBuilder(Builder):
         # with minor changes to support :confval:`rst_file_transform`.
         destination = StringOutput(encoding='utf-8')
 
+        self.current_docname = docname
         self.writer.write(doctree, destination)
         outfilename = path.join(self.outdir, self.file_transform(docname))
         if self.writer.output:

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -59,7 +59,6 @@ class ConfluenceBuilder(Builder):
         self.cache_doctrees = {}
         self.file_suffix = '.conf'
         self.link_suffix = None
-        self.current_docname = None
         self.add_secnumbers = self.config.confluence_add_secnumbers
         self.secnumber_suffix = self.config.confluence_secnumber_suffix
         self.master_doc_page_id = None
@@ -368,7 +367,6 @@ class ConfluenceBuilder(Builder):
         # with minor changes to support :confval:`rst_file_transform`.
         destination = StringOutput(encoding='utf-8')
 
-        self.current_docname = docname
         self.writer.write(doctree, destination)
         outfilename = path.join(self.outdir, self.file_transform(docname))
         if self.writer.output:

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -67,7 +67,7 @@ class ConfluenceTranslator(BaseTranslator):
         self.secnumber_suffix = config.confluence_secnumber_suffix
         self.warn = document.reporter.warning
         self._building_footnotes = False
-        self._docnames = [self.builder.current_docname]
+        self._docnames = [self.docname]
         self._figure_context = []
         self._literal = False
         self._manpage_url = getattr(config, 'manpages_url', None)

--- a/test/unit-tests/single-page/dataset-numbered/index.rst
+++ b/test/unit-tests/single-page/dataset-numbered/index.rst
@@ -1,0 +1,12 @@
+:orphan:
+
+index
+-----
+
+content
+
+.. toctree::
+   :numbered:
+
+   page-a
+   page-b

--- a/test/unit-tests/single-page/dataset-numbered/page-a.rst
+++ b/test/unit-tests/single-page/dataset-numbered/page-a.rst
@@ -1,9 +1,11 @@
 page-a
 ------
 
-
 page-a start
 
 :doc:`page-b`
+
+section
+^^^^^^^
 
 page-a end

--- a/test/unit-tests/single-page/dataset-numbered/page-b.rst
+++ b/test/unit-tests/single-page/dataset-numbered/page-b.rst
@@ -1,0 +1,8 @@
+page-b
+------
+
+page-b start
+
+:doc:`page-a`
+
+page-b end

--- a/test/unit-tests/single-page/expected-numbered/index.conf
+++ b/test/unit-tests/single-page/expected-numbered/index.conf
@@ -1,0 +1,14 @@
+<p>content</p>
+<h2>1. page-a</h2>
+<p>page-a start</p>
+<p><ac:link ac:anchor="page-b">
+    <ac:link-body>page-b</ac:link-body>
+</ac:link></p>
+<h3>1.1. section</h3>
+<p>page-a end</p>
+<h2>2. page-b</h2>
+<p>page-b start</p>
+<p><ac:link ac:anchor="page-a">
+    <ac:link-body>page-a</ac:link-body>
+</ac:link></p>
+<p>page-b end</p>

--- a/test/unit-tests/single-page/test_singlepage.py
+++ b/test/unit-tests/single-page/test_singlepage.py
@@ -19,3 +19,15 @@ class TestConfluenceSinglePage(unittest.TestCase):
             builder='singleconfluence')
 
         _.assertExpectedWithOutput(self, 'index', expected, doc_dir)
+
+    def test_singlepage_numbered(self):
+        config = _.prepareConfiguration()
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+
+        dataset = os.path.join(test_dir, 'dataset-numbered')
+        expected = os.path.join(test_dir, 'expected-numbered')
+        doc_dir, doctree_dir = _.prepareDirectories('singlepage-numbered')
+        _.buildSphinx(dataset, doc_dir, doctree_dir, config,
+            builder='singleconfluence')
+
+        _.assertExpectedWithOutput(self, 'index', expected, doc_dir)


### PR DESCRIPTION
Numbering of sections (with `:numbered:` toctree) does not work in singleconfluence builder because the internal ids are renamed during toctree inlining to prevent collisions.

This PR adds code to `add_secnumber` for singleconfluence builder to correctly handle the renamed section numbers, in the same way that singlehtml builder does.