### PR TITLE
Support :scale: parameter for images

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -24,7 +24,10 @@ from sphinx.locale import _
 from sphinx.locale import admonitionlabels
 from sphinx.util.osutil import SEP
 from sphinx.util.osutil import canon_path
+from sphinx.util.images import get_image_size
 import io
+import os
+import math
 import posixpath
 import sys
 
@@ -1282,6 +1285,16 @@ class ConfluenceTranslator(BaseTranslator):
             alt = node['alt']
             alt = self._escape_sf(alt)
             attribs['ac:alt'] = alt
+
+        if 'scale' in node and 'width' not in node:
+            fulluri = os.path.join(self.builder.srcdir, uri)
+            size = get_image_size(fulluri)
+            if size is None:
+                ConfluenceLogger.warn('Could not obtain image size. :scale: option is ignored for '
+                '{}'.format(fulluri))
+            else:
+                scale = node['scale'] / 100.0
+                node['width'] = str(math.ceil(size[0] * scale)) + 'px'
 
         if 'height' in node:
             self.warn('height value for image is unsupported in confluence')

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -1294,7 +1294,7 @@ class ConfluenceTranslator(BaseTranslator):
                 '{}'.format(fulluri))
             else:
                 scale = node['scale'] / 100.0
-                node['width'] = str(math.ceil(size[0] * scale)) + 'px'
+                node['width'] = str(int(math.ceil(size[0] * scale))) + 'px'
 
         if 'height' in node:
             self.warn('height value for image is unsupported in confluence')

--- a/test/unit-tests/common/dataset-common/image.rst
+++ b/test/unit-tests/common/dataset-common/image.rst
@@ -9,11 +9,16 @@ image
 
 .. image:: https://www.example.com/image.png
 
-.. internal image with using a series of attributes
+.. internal image using a series of attributes
 
 .. image:: ../assets/image01.png
    :width: 200px
    :alt: alt text
+
+.. internal image with scaling
+
+.. image:: ../assets/image01.png
+   :scale: 20%
 
 .. internal image shared with other pages (see figure); asset stored on master
 

--- a/test/unit-tests/common/expected/image.conf
+++ b/test/unit-tests/common/expected/image.conf
@@ -2,6 +2,8 @@
     <ri:url ri:value="https://www.example.com/image.png" />
 </ac:image><ac:image ac:alt="alt text" ac:width="200px">
     <ri:attachment ri:filename="image01.png"></ri:attachment>
+</ac:image><ac:image ac:width="58px">
+    <ri:attachment ri:filename="image01.png"></ri:attachment>
 </ac:image><ac:image ac:align="right" ac:style="float: right;">
     <ri:attachment ri:filename="image03.png"><ri:page ri:content-title="table of contents" />
     </ri:attachment>

--- a/test/validation-sets/common/images.rst
+++ b/test/validation-sets/common/images.rst
@@ -200,6 +200,14 @@ Another figure but with a right-aligned image:
 
    This is the caption of the figure.
 
+Another figure but scaled down:
+
+.. figure:: assets/confluence.png
+   :alt: Confluence Logo
+   :scale: 20%
+
+   This is the caption of the figure.
+
 .. _figure directive: http://docutils.sourceforge.net/docs/ref/rst/directives.html#figure
 .. _image directive: http://docutils.sourceforge.net/docs/ref/rst/directives.html#image
 .. _image-based directives: http://docutils.sourceforge.net/docs/ref/rst/directives.html#images


### PR DESCRIPTION
This PR adds support for the `:scale:` parameter for images. It is similar to what Sphinx 2.4+ does (https://github.com/sphinx-doc/sphinx/pull/6985) and similarly needs imagesize 1.2.0+ to support scaling SVG.