### PR TITLE
correct hook with multiple builders

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -58,8 +58,10 @@ def setup(app):
     # has been resolved, re-check for any images that have been translated.
     def assetsDocTreeResolvedHook(app, doctree, docname):
         app.builder.assets.processDocument(doctree, docname, True)
-    if type(app.builder) == ConfluenceBuilder:
-        app.connect('doctree-resolved', assetsDocTreeResolvedHook)
+    def builderInitedHook(app):
+        if type(app.builder) == ConfluenceBuilder:
+            app.connect('doctree-resolved', assetsDocTreeResolvedHook)
+    app.connect('builder-inited', builderInitedHook)
 
     # remove math-node-migration post-transform as this extension manages both
     # future and legacy math implementations (removing this transform removes


### PR DESCRIPTION
For the standard builder in this extension, the `doctree-resolved` event is observed to help populate images which may be generated when a doctree has been resolved. When the single builder was introduced in this extension, the builder attribute (`app.builder`) no longer appears to be always initialized. Before type-checking the builder being used, hook on the `builder-inited` event to ensure the builder has been initialized.