### PR TITLE
rest: define user agent for request calls

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -51,6 +51,9 @@ class Rest:
 
     def _setup_session(self, config):
         session = requests.Session()
+        session.headers.update({
+            'User-Agent': 'Sphinx Confluence Builder',
+        })
         session.timeout = config.confluence_timeout
         session.proxies = {
             'http': config.confluence_proxy,
@@ -122,7 +125,7 @@ class Rest:
     def post(self, key, data, files=None):
         restUrl = self.url + API_REST_BIND_PATH + '/' + key
         try:
-            headers = {}
+            headers = dict(self.session.headers)
 
             # Atlassian's documenation indicates to the security token check
             # when publishing attachments [1][2]. If adding files, set a


### PR DESCRIPTION
Define a user agent string for all request calls generated by this extension. This is solely to help prevent issues observed in CONFCLOUD-69720 \[1\] (while should already be resolved on Confluence Cloud).

\[1\]: https://jira.atlassian.com/browse/CONFCLOUD-69720