### PR TITLE
assets: provided fallback for asset paths

### DIFF
--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -53,13 +53,15 @@ class ConfluenceAssetManager:
     Args:
         master: the master document
         env: the build environment
+        outdir: configured output directory (where assets may be stored)
     """
-    def __init__(self, master, env):
+    def __init__(self, master, env, outdir):
         self.assets = []
         self.env = env
         self.hash2asset = {}
         self.keys = set()
         self.master = master
+        self.outdir = outdir
         self.path2asset = {}
 
     def build(self):
@@ -260,6 +262,16 @@ class ConfluenceAssetManager:
         abspath = None
         if path:
             path = os.path.normpath(path)
-            abspath = os.path.join(self.env.srcdir, path)
+            if os.path.isabs(path):
+                abspath = path
+            else:
+                abspath = os.path.join(self.env.srcdir, path)
+
+                # a third party extension may dump a generated asset in the
+                # output directory; if the absolute mapping to the source
+                # directory does not find the asset, attempt to bind the path
+                # based on the output directory
+                if not os.path.isfile(abspath):
+                    abspath = os.path.join(self.outdir, path)
 
         return abspath

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -104,7 +104,8 @@ class ConfluenceBuilder(Builder):
                 if not self.config.confluence_server_pass:
                     raise ConfluenceConfigurationError('no password provided')
 
-        self.assets = ConfluenceAssetManager(self.config.master_doc, self.env)
+        self.assets = ConfluenceAssetManager(self.config.master_doc, self.env,
+            self.outdir)
         self.writer = ConfluenceWriter(self)
         self.config.sphinx_verbosity = self.app.verbosity
         self.publisher.init(self.config)


### PR DESCRIPTION
Asset-based nodes processed by this extension will either provide a URI to a relative or absolute path. Part of the asset manager's process will attempt to determine the absolute path of a resource for future work. In the case for a relative path, a relative path is assumed to be located alongside the source content; however, this is not always the case for extensions which generate assets into the build output directory but only provide a relative path to the asset. To help deal with this case, when a relative path based off a documentation's source directory cannot be found, the process will fallback to a path based off the user-defined output directory.