### PR TITLE
publisher: introduce the only-new feature

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -778,6 +778,23 @@ See also
 
 --------------------------------------------------------------------------------
 
+confluence_publish_onlynew
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A publish event will from this extension will typically upload new pages or
+update existing pages on future attempts. In select cases, a user may not wish
+to modify existing pages and only permit adding new content to a Confluence
+space. To achieve this, a user can enable a "only-new" flag which prevents the
+modification of existing content. This includes the restriction of updating
+existing pages/attachments as well as deleting content as well. By default, the
+only-new feature is disabled with a value of ``False``.
+
+.. code-block:: python
+
+   confluence_publish_onlynew = True
+
+--------------------------------------------------------------------------------
+
 .. _confluence_publish_subset:
 
 confluence_publish_subset

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -122,6 +122,8 @@ def setup(app):
     app.add_config_value('confluence_parent_page', None, False)
     """Perform a dry run of publishing to inspect what publishing will do."""
     app.add_config_value('confluence_publish_dryrun', None, '')
+    """Publish only new content (no page updates, etc.)."""
+    app.add_config_value('confluence_publish_onlynew', None, '')
     """Postfix to apply to title of published pages."""
     app.add_config_value('confluence_publish_postfix', None, False)
     """Prefix to apply to published pages."""


### PR DESCRIPTION
Adding a new feature which allows users to configure this extension to restrict changing existing content on a Confluence space. When `confluence_publish_onlynew` is set to `True`, only new pages/attachments can be added to a target space.