### PR TITLE
test additional sphinx versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,33 +13,29 @@ matrix:
   - python: "3.5"
     env: TOXENV=py35-sphinx18
   - python: "3.5"
-    env: TOXENV=py35-sphinx20
-  - python: "3.5"
-    env: TOXENV=py35-sphinx21
-  - python: "3.5"
     env: TOXENV=py35-sphinx22
   - python: "3.5"
     env: TOXENV=py35-sphinx23
+  - python: "3.5"
+    env: TOXENV=py35-sphinx24
+  - python: "3.5"
+    env: TOXENV=py35-sphinx30
+  - python: "3.5"
+    env: TOXENV=py35-sphinx31
   - python: "3.6"
     env: TOXENV=py36-sphinx18
-  - python: "3.6"
-    env: TOXENV=py36-sphinx20
-  - python: "3.6"
-    env: TOXENV=py36-sphinx21
   - python: "3.6"
     env: TOXENV=py36-sphinx22
   - python: "3.6"
     env: TOXENV=py36-sphinx23
+  - python: "3.6"
+    env: TOXENV=py36-sphinx24
+  - python: "3.6"
+    env: TOXENV=py36-sphinx30
+  - python: "3.6"
+    env: TOXENV=py36-sphinx31
   - python: "3.7"
     env: TOXENV=py37-sphinx18
-    dist: xenial
-    sudo: true
-  - python: "3.7"
-    env: TOXENV=py37-sphinx20
-    dist: xenial
-    sudo: true
-  - python: "3.7"
-    env: TOXENV=py37-sphinx21
     dist: xenial
     sudo: true
   - python: "3.7"
@@ -48,20 +44,32 @@ matrix:
   - python: "3.7"
     env: TOXENV=py37-sphinx23
     dist: xenial
+  - python: "3.7"
+    env: TOXENV=py37-sphinx24
+    dist: xenial
+  - python: "3.7"
+    env: TOXENV=py37-sphinx30
+    dist: xenial
+  - python: "3.7"
+    env: TOXENV=py37-sphinx31
+    dist: xenial
   - python: "3.8"
     env: TOXENV=py38-sphinx18
-    dist: bionic
-  - python: "3.8"
-    env: TOXENV=py38-sphinx20
-    dist: bionic
-  - python: "3.8"
-    env: TOXENV=py38-sphinx21
     dist: bionic
   - python: "3.8"
     env: TOXENV=py38-sphinx22
     dist: bionic
   - python: "3.8"
     env: TOXENV=py38-sphinx23
+    dist: bionic
+  - python: "3.8"
+    env: TOXENV=py38-sphinx24
+    dist: bionic
+  - python: "3.8"
+    env: TOXENV=py38-sphinx30
+    dist: bionic
+  - python: "3.8"
+    env: TOXENV=py38-sphinx31
     dist: bionic
   - os: osx
     env: TOXENV=py27-sphinx18
@@ -77,7 +85,7 @@ matrix:
       - choco install python2
       - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
   - os: windows
-    env: TOXENV=py38-sphinx23
+    env: TOXENV=py38-sphinx31
     language: sh
     before_install:
       - choco install python3 --params "/InstallDir:C:\Python" --version=3.8.0

--- a/test/unit-tests/common/expected-domains-legacy/c.conf
+++ b/test/unit-tests/common/expected-domains-legacy/c.conf
@@ -1,0 +1,4 @@
+<dl>
+    <dt>void* <strong><code>my_func</code></strong>(<em>void<em> *context</em></em>)</dt>
+    <dd></dd>
+</dl>

--- a/test/unit-tests/common/expected-domains/c.conf
+++ b/test/unit-tests/common/expected-domains/c.conf
@@ -1,4 +1,4 @@
 <dl>
-    <dt>void* <strong><code>my_func</code></strong>(<em>void<em> *context</em></em>)</dt>
+    <dt>void *<strong><code>my_func</code></strong>(<em>void *<em>context</em></em>)</dt>
     <dd></dd>
 </dl>

--- a/test/unit-tests/common/test_domains.py
+++ b/test/unit-tests/common/test_domains.py
@@ -4,6 +4,8 @@
     :license: BSD-2-Clause, see LICENSE for details.
 """
 
+from pkg_resources import parse_version
+from sphinx.__init__ import __version__ as sphinx_version
 from sphinxcontrib_confluencebuilder_util import ConfluenceTestUtil as _
 import os
 import unittest
@@ -28,7 +30,12 @@ class TestConfluenceDomains(unittest.TestCase):
         _.assertExpectedWithOutput(self, name, expected, self.doc_dir)
 
     def test_domains_c(self):
-        self._assertExpectedWithOutput('c')
+        if parse_version(sphinx_version) >= parse_version('3.0'):
+            self._assertExpectedWithOutput('c')
+        else:
+            # pre-v3.0 left-aligns pointer asterisk and embeds in variable
+            expected = self.expected + '-legacy'
+            self._assertExpectedWithOutput('c', expected)
 
     def test_domains_cpp(self):
         self._assertExpectedWithOutput('cpp')

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,18 @@
 [tox]
 envlist =
     py{27,35,36,37,38}-sphinx{18}
-    py{35,36,37,38}-sphinx{20,21,22,23}
+    py{35,36,37,38}-sphinx{22,23,24,30,31}
     lint
     pylint
 
 [testenv]
 deps = -r{toxinidir}/requirements_dev.txt
     sphinx18: sphinx>=1.8,<2.0
-    sphinx20: sphinx>=2.0,<2.1
-    sphinx21: sphinx>=2.1,<2.2
     sphinx22: sphinx>=2.2,<2.3
     sphinx23: sphinx>=2.3,<2.4
+    sphinx24: sphinx>=2.4,<2.5
+    sphinx30: sphinx>=3.0,<3.1
+    sphinx31: sphinx>=3.1,<3.2
 changedir = test
 commands =
     python -m test_main {posargs}


### PR DESCRIPTION
Adjusting the tox/Travis CI configuration to test for the more recent releases of Sphinx. Since this extension aims to support a least five latest releases of Sphinx, dropping tests for some older versions. 

Note that Sphinx v1.8.x series will still be tested against since it is the only version still supported on Python 2, which will continue to have support for at least a couple of more months.