### PR TITLE
storage: do not inject newline inside attachment tag

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1221,8 +1221,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._start_ac_image(node, **attribs))
             self.body.append(self._start_ri_attachment(node, image_key))
             if hosting_docname != self.docname:
-                self.body.append(self._start_tag(node, 'ri:page',
-                   suffix=self.nl, empty=True,
+                self.body.append(self._start_tag(node, 'ri:page', empty=True,
                    **{'ri:content-title': hosting_doctitle}))
             self.body.append(self._end_ri_attachment(node))
             self.body.append(self._end_ac_image(node))
@@ -1270,8 +1269,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 attachment.append(self._start_ri_attachment(node, file_key))
                 if hosting_docname != self.docname:
                     attachment.append(self._start_tag(node, 'ri:page',
-                       suffix=self.nl, empty=True,
-                       **{'ri:content-title': hosting_doctitle}))
+                       empty=True, **{'ri:content-title': hosting_doctitle}))
                 attachment.append(self._end_ri_attachment(node))
 
                 self.body.append(self._start_ac_macro(node, 'view-file'))
@@ -1283,8 +1281,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 self.body.append(self._start_ri_attachment(node, file_key))
                 if hosting_docname != self.docname:
                     self.body.append(self._start_tag(node, 'ri:page',
-                       suffix=self.nl, empty=True,
-                       **{'ri:content-title': hosting_doctitle}))
+                       empty=True, **{'ri:content-title': hosting_doctitle}))
                 self.body.append(self._end_ri_attachment(node))
                 self.body.append(
                     self._start_ac_plain_text_link_body_macro(node))

--- a/test/unit-tests/common/expected-center/figure.conf
+++ b/test/unit-tests/common/expected-center/figure.conf
@@ -40,8 +40,7 @@
     <ac:parameter ac:name="icon">false</ac:parameter>
     <ac:rich-text-body>
         <ac:image ac:align="right" ac:style="float: right;">
-            <ri:attachment ri:filename="image03.png"><ri:page ri:content-title="table of contents" />
-            </ri:attachment>
+            <ri:attachment ri:filename="image03.png"><ri:page ri:content-title="table of contents" /></ri:attachment>
         </ac:image><p style="clear: both;text-align: right;">caption</p>
         <div style="text-align: right;"><p>legend</p>
         </div>

--- a/test/unit-tests/common/expected/figure.conf
+++ b/test/unit-tests/common/expected/figure.conf
@@ -40,8 +40,7 @@
     <ac:parameter ac:name="icon">false</ac:parameter>
     <ac:rich-text-body>
         <ac:image ac:align="right" ac:style="float: right;">
-            <ri:attachment ri:filename="image03.png"><ri:page ri:content-title="table of contents" />
-            </ri:attachment>
+            <ri:attachment ri:filename="image03.png"><ri:page ri:content-title="table of contents" /></ri:attachment>
         </ac:image><p style="clear: both;text-align: right;">caption</p>
         <div style="text-align: right;"><p>legend</p>
         </div>

--- a/test/unit-tests/common/expected/image.conf
+++ b/test/unit-tests/common/expected/image.conf
@@ -5,6 +5,5 @@
 </ac:image><ac:image ac:width="58px">
     <ri:attachment ri:filename="image01.png"></ri:attachment>
 </ac:image><ac:image ac:align="right" ac:style="float: right;">
-    <ri:attachment ri:filename="image03.png"><ri:page ri:content-title="table of contents" />
-    </ri:attachment>
+    <ri:attachment ri:filename="image03.png"><ri:page ri:content-title="table of contents" /></ri:attachment>
 </ac:image>


### PR DESCRIPTION
It has been observed that (in at least) Confluence Cloud that when a newline is injected in the `ri:attachment` tag, typically only when `ri:content-title` is used, that Confluence will report a 500 error when publishing. This commit removes the suffix injection (from an explicit newline to an implicit empty/none) and publish events appear to work as expected.

See also #317.