### PR TITLE
builder: handle sphinx.ext.inheritance_diagram nodes

### DIFF
--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -82,6 +82,7 @@ The following extensions are supported:
 
  - `sphinx.ext.autodoc`_
  - `sphinx.ext.autosummary`_
+ - `sphinx.ext.inheritance_diagram`_
  - `sphinx.ext.todo`_
 
 other
@@ -135,4 +136,5 @@ expected or brings up another concern, feel free to bring up an issue:
 .. _Sphinx Version Changed: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionchanged
 .. _sphinx.ext.autodoc: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 .. _sphinx.ext.autosummary: https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html
+.. _sphinx.ext.inheritance_diagram: https://www.sphinx-doc.org/en/master/usage/extensions/inheritance.html
 .. _sphinx.ext.todo: https://www.sphinx-doc.org/en/master/usage/extensions/todo.html

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -808,6 +808,7 @@ class ConfluenceBuilder(Builder):
                 _, out_filename = render_dot(
                     mock_translator, dotcode, {}, 'png', 'inheritance')
                 if not out_filename:
+                    node.parent.remove(node)
                     continue
 
                 new_node = nodes.image(candidates={'?'}, uri=out_filename)
@@ -816,6 +817,7 @@ class ConfluenceBuilder(Builder):
                 node.replace_self(new_node)
             except GraphvizError as exc:
                 ConfluenceLogger.warn('dot code {}: {}'.format(dotcode, exc))
+                node.parent.remove(node)
 
     def _replace_math_blocks(self, doctree):
         """

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -263,17 +263,8 @@ class ConfluenceBuilder(Builder):
                 ConfluenceState.registerToctreeDepth(
                     docname, toctree.get('maxdepth'))
 
-            # extract metadata information
-            self._extract_metadata(docname, doctree)
-
-            # register targets for references
-            self._register_doctree_targets(docname, doctree)
-
-            # replace math blocks with images
-            self._replace_math_blocks(doctree)
-
             # for every doctree, pick the best image candidate
-            self.post_process_images(doctree)
+            self._prepare_doctree_writing(docname, doctree)
 
         # Scan for assets that may exist in the documents to be published. This
         # will find most if not all assets in the documentation set. The
@@ -282,6 +273,19 @@ class ConfluenceBuilder(Builder):
         # images in Sphinx, which is then provided to a translator). Embedded
         # images are detected during an 'doctree-resolved' hook (see __init__).
         self.assets.process(ordered_docnames)
+
+    def _prepare_doctree_writing(self, docname, doctree):
+        # extract metadata information
+        self._extract_metadata(docname, doctree)
+
+        # register targets for references
+        self._register_doctree_targets(docname, doctree)
+
+        # replace math blocks with images
+        self._replace_math_blocks(doctree)
+
+        # for every doctree, pick the best image candidate
+        self.post_process_images(doctree)
 
     def process_tree_structure(self, ordered, docname, traversed, depth=0):
         omit = False

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -110,28 +110,12 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
                 'singleconfluence required title on master_doc')
             return
 
-        for docname in status_iterator(docnames,
-                __('preparing documents') + '... ',
-                length=len(docnames), verbosity=self.app.verbosity):
-            doctree = self.env.get_doctree(docname)
-
-            # replace math blocks with images
-            self._replace_math_blocks(doctree)
-
         with progress_message(__('assembling single confluence document')):
             doctree = self.assemble_doctree()
-            
-            # for every doctree, pick the best image candidate
-            self.post_process_images(doctree)
+            self._prepare_doctree_writing(self.config.master_doc, doctree)
 
             self.env.toc_secnumbers = self.assemble_toc_secnumbers()
             self.env.toc_fignumbers = self.assemble_toc_fignumbers()
-
-            # register targets for references
-            self._register_doctree_targets(self.config.master_doc, doctree)
-
-            # extract metadata information
-            self._extract_metadata(self.config.master_doc, doctree)
 
             self.assets.processDocument(doctree, self.config.master_doc)
 


### PR DESCRIPTION
Provide support for an internal Sphinx extension `inheritance_diagram` by pre-processing diagrams and replaced with respective images. Typically, node support from `sphinx.ext.inheritance_diagram` would be added to the builder; however, this extension renders graphs during the translation phase (which is not ideal for how assets are managed in this extension).

Instead, this implementation just traverses for inheritance diagrams, generates renderings and replaces the nodes with image nodes (which in turn will be handled by the existing image-based implementation).

This pull request also refactors some shared implementation between the standard builder and the single builder. These calls are responsible for manipulating a prepared doctree instance before processing -- such as replacing math blocks with images. Refactoring this ahead of time allows the `_replace_inheritance_diagram` call be easily be invoked by all builder types.

See also #308.