### PR TITLE
storage: correct literal parsing newlines

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -438,7 +438,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     # -------------------------------
 
     def visit_literal_block(self, node):
-        self._literal = True
         lang = None
 
         # non-raw literal
@@ -448,6 +447,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 lang = 'none'
             # parsed literal
             else:
+                self._literal = True
                 self.body.append(self._start_tag(node, 'div', suffix=self.nl,
                     **{'class': 'panel pdl'}))
                 self.context.append(self._end_tag(node))


### PR DESCRIPTION
When processing each text node's contents, newlines are stripped to ensure horizontal view is taken advantage of. This does not apply to parsed literals which expect a matching format. The split of translator implementation introduces an issue where it would set an internal "is-parser-literal" flag when the processing nodes were not actually a parsed literal type; correcting.