### PR TITLE
moving flake8 ignores into setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,18 @@
 [bdist_wheel]
 # build a universal wheel (Python 2 and 3 supported)
 universal=1
+
+[flake8]
+ignore =
+    E122
+    E124
+    E127
+    E128
+    E241
+    E261
+    E302
+    E305
+    E306
+    E501
+    W503
+    W504

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -773,11 +773,11 @@ class ConfluenceBuilder(Builder):
         from `sphinx.ext.inheritance_diagram` would be added to the builder;
         however, this extension renders graphs during the translation phase
         (which is not ideal for how assets are managed in this extension).
-        
+
         Instead, this implementation just traverses for inheritance diagrams,
         generates renderings and replaces the nodes with image nodes (which in
         turn will be handled by the existing image-based implementation).
-        
+
         Note that the interactive image map is not handled in this
         implementation since Confluence does not support image maps (without
         external extensions).

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -194,8 +194,8 @@ should be a dictionary of (str, str) entries.
                         ConfluenceLogger.error(
 """missing certificate authority
 
-The option 'confluence_ca_cert' has been provided to find a certificate 
-authority file or path from a relative location. Ensure the value is set to a 
+The option 'confluence_ca_cert' has been provided to find a certificate
+authority file or path from a relative location. Ensure the value is set to a
 proper file path.
 """)
             if c.confluence_client_cert:
@@ -222,9 +222,9 @@ or a tuple for the certificate and key in different files.
                             ConfluenceLogger.error(
 """missing certificate file
 
-The option 'confluence_client_cert' has been provided to find a client 
-certificate file from a relative location, but the file %s was not found. 
-Ensure the value is set to a proper file path and the file exists. 
+The option 'confluence_client_cert' has been provided to find a client
+certificate file from a relative location, but the file %s was not found.
+Ensure the value is set to a proper file path and the file exists.
 """ % cert_file
                             )
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,6 @@ deps =
     flake8
 commands =
     flake8 \
-    --ignore E122,E124,E127,E128,E241,E261,E302,E305,E306,E501,W \
     --exclude tests/sandbox*/ \
     sphinxcontrib \
     tests


### PR DESCRIPTION
Moving all existing flake8 ignore entries from the `tox.ini` configuration into `setup.cfg`. This allows an easier way to maintain a set of ignore entries (line per ignore versus a full line) as well as allows users to invoke `flake8` with project-configuration settings without having to rely on invoking tox (if desired).