### PR TITLE
storage: support new raw format

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/__init__.py
+++ b/sphinxcontrib/confluencebuilder/translator/__init__.py
@@ -85,8 +85,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
                 with io.open(headerFile, encoding='utf-8') as file:
                     self.document += file.read() + self.nl
             except (IOError, OSError) as err:
-                ConfluenceLogger.warn('error reading file '
-                    '{}: {}'.format(headerFile, err))
+                self.warn('error reading file {}: {}'.format(headerFile, err))
 
         self.document += ''.join(self.body)
 
@@ -98,8 +97,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
                 with io.open(footerFile, encoding='utf-8') as file:
                     self.document += file.read() + self.nl
             except (IOError, OSError) as err:
-                ConfluenceLogger.warn('error reading file '
-                    '{}: {}'.format(footerFile, err))
+                self.warn('error reading file {}: {}'.format(footerFile, err))
 
     def visit_Text(self, node):
         text = node.astext()

--- a/sphinxcontrib/confluencebuilder/translator/__init__.py
+++ b/sphinxcontrib/confluencebuilder/translator/__init__.py
@@ -16,6 +16,8 @@ import io
 import sys
 
 class ConfluenceBaseTranslator(BaseTranslator):
+    _tracked_deprecated_raw_type = False
+
     """
     confluence base extension translator
 
@@ -256,6 +258,11 @@ class ConfluenceBaseTranslator(BaseTranslator):
 
     def visit_raw(self, node):
         if 'confluence' in node.get('format', '').split():
+            if not self._tracked_deprecated_raw_type:
+                self._tracked_deprecated_raw_type = True
+                self.warn('the raw "confluence" type is deprecated; '
+                    'use "confluence_storage" instead')
+
             self.body.append(self.nl.join(node.astext().splitlines()))
         raise nodes.SkipNode
 

--- a/sphinxcontrib/confluencebuilder/translator/__init__.py
+++ b/sphinxcontrib/confluencebuilder/translator/__init__.py
@@ -31,6 +31,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
     def __init__(self, document, builder):
         BaseTranslator.__init__(self, document)
         self.builder = builder
+        self.warn = document.reporter.warning
         config = builder.config
 
         # acquire the active document name from the builder

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1557,6 +1557,14 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     def depart_line_block(self, node):
         self.body.append(self.context.pop()) # p
 
+    def visit_raw(self, node):
+        if 'confluence_storage' in node.get('format', '').split():
+            self.body.append(self.nl.join(node.astext().splitlines()))
+        else:
+            # support deprecated 'confluence' format for an interim
+            ConfluenceBaseTranslator.visit_raw(self, node)
+        raise nodes.SkipNode
+
     # ##########################################################################
     # #                                                                        #
     # # helpers                                                                #

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -44,7 +44,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         self.add_secnumbers = config.confluence_add_secnumbers
         self.secnumber_suffix = config.confluence_secnumber_suffix
-        self.warn = document.reporter.warning
         self._building_footnotes = False
         self._figure_context = []
         self._manpage_url = getattr(config, 'manpages_url', None)

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -227,7 +227,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             elif node['enumtype'] == 'arabic':
                 list_style_type = 'decimal'
             else:
-                ConfluenceLogger.warn(
+                self.warn(
                     'unknown enumerated list type: {}'.format(node['enumtype']))
 
         if list_style_type:
@@ -465,7 +465,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             lang = LITERAL2LANG_MAP[lang]
         else:
             if lang not in self._tracked_unknown_code_lang:
-                ConfluenceLogger.warn('unknown code language: {}'.format(lang))
+                self.warn('unknown code language: {}'.format(lang))
                 self._tracked_unknown_code_lang.append(lang)
             lang = LITERAL2LANG_MAP[FALLBACK_HIGHLIGHT_STYLE]
 
@@ -851,7 +851,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.docparent + path.splitext(node['refuri'].split('#')[0])[0])
         doctitle = ConfluenceState.title(docname)
         if not doctitle:
-            ConfluenceLogger.warn('unable to build link to document due to '
+            self.warn('unable to build link to document due to '
                 'missing title (in {}): {}'.format(self.docname, docname))
 
             # build a broken link
@@ -1182,8 +1182,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             fulluri = path.join(self.builder.srcdir, uri)
             size = get_image_size(fulluri)
             if size is None:
-                ConfluenceLogger.warn('Could not obtain image size. :scale: option is ignored for '
-                '{}'.format(fulluri))
+                self.warn('could not obtain image size; :scale: option is '
+                    'ignored for {}'.format(fulluri))
             else:
                 scale = node['scale'] / 100.0
                 node['width'] = str(int(math.ceil(size[0] * scale))) + 'px'
@@ -1481,7 +1481,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         elif node['type'] == 'versionadded':
             self._visit_info(node)
         else:
-            ConfluenceLogger.warn('unsupported version modification type: '
+            self.warn('unsupported version modification type: '
                 '{}'.format(node['type']))
             self._visit_info(node)
 

--- a/tests/unit-tests/common/dataset-common/raw.rst
+++ b/tests/unit-tests/common/dataset-common/raw.rst
@@ -5,6 +5,6 @@
 raw
 ---
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    <strong>raw content</strong>

--- a/tests/validation-sets/common/download.rst
+++ b/tests/validation-sets/common/download.rst
@@ -10,13 +10,13 @@ PDF file. When using the download directive without a label, the extension will
 generate a link to the file via Confluence's view-file macro. For example, the
 two files should appear with two view-file elements:
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    <div style="text-align: center">
 
 :download:`assets/example.py` :download:`assets/example.pdf`
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    </div>
 

--- a/tests/validation-sets/common/images.rst
+++ b/tests/validation-sets/common/images.rst
@@ -34,7 +34,7 @@ ut. Phasellus vehicula aliquam dolor vel sodales.
 
 Images are typically included inline as follows:
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    <p>
 
@@ -42,7 +42,7 @@ Images are typically included inline as follows:
    :align: center
    :alt: alternate text
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    </p>
 
@@ -50,7 +50,7 @@ Embedded images should be translated by Sphinx and this extension should handle
 these images as well. One of these five images is embedded and also one of these
 five images links to the section below:
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    <p style="text-align: center">
 
@@ -140,14 +140,14 @@ five images links to the section below:
 .. image:: assets/github.png
    :target: `figure_section`_
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    </p>
 
 The following is an example of an image found on an external server (with a
 link target):
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    <p style="text-align: center">
 
@@ -163,7 +163,7 @@ link target):
    :target: https://sphinxcontrib-confluencebuilder.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    </p>
 

--- a/tests/validation-sets/common/references-ref.rst
+++ b/tests/validation-sets/common/references-ref.rst
@@ -6,7 +6,7 @@ arbitrary location to another page's section.
 
 Long gap to easily observed anchor usage...
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    <div style="height: 1000px">&nbsp;</div>
 

--- a/tests/validation-sets/common/references.rst
+++ b/tests/validation-sets/common/references.rst
@@ -203,7 +203,7 @@ aliquam eget, congue quis magna. Phasellus tincidunt tincidunt ante.
 
 Long gap to easily observed anchor usage...
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    <div style="height: 1000px">&nbsp;</div>
 


### PR DESCRIPTION
Adjusting the storage format translate to use the `confluence_storage` format identifier over the `confluence` format type. This is to help prepare for ADF support which we want a more explicit identification between a Confluence storage-format-specific format over other possible supported formats.