### PR TITLE
support leading title link support from toc directive

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -365,20 +365,17 @@ class ConfluenceBuilder(Builder):
             title_element = self._find_title_element(doctree)
             if title_element:
                 # If the removed title is referenced to from within the same
-                # document (i.e. a local table of contents entry), remove the
-                # entry (and parents if empty). This should, in the case of a
-                # table of contents (contents directive), remove the leading
-                # generated title link.
+                # document (i.e. a local table of contents entry), flag any
+                # references pointing to it as a "top" (anchor) reference. This
+                # can be used later in a translator to hint at what type of link
+                # to build.
                 if 'refid' in title_element:
                     for node in doctree.traverse(nodes.reference):
                         if 'ids' in node and node['ids']:
-                            if node['ids'][0] == title_element['refid']:
-                                def remove_until_has_children(node):
-                                    parent = node.parent
-                                    parent.remove(node)
-                                    if not parent.children:
-                                        remove_until_has_children(parent)
-                                remove_until_has_children(node)
+                            for id in node['ids']:
+                                if id == title_element['refid']:
+                                    node['top-reference'] = True
+                                    break
 
                 title_element.parent.remove(title_element)
 

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -784,6 +784,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         if 'iscurrent' in node:
             pass
+        elif 'top-reference' in node:
+            self._visit_reference_top(node)
         elif (('internal' not in node or not node['internal'])
                 and 'refuri' in node):
             # If a document provides an anchor target directly in the reference,
@@ -904,6 +906,10 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         if navnode:
             self._reference_context.append(self._end_tag(node))
+
+    def _visit_reference_top(self, node):
+        self.body.append(self._start_tag(node, 'a', **{'href': '#top'}))
+        self._reference_context.append(self._end_tag(node, suffix=''))
 
     def depart_reference(self, node):
         for element in self._reference_context:

--- a/tests/unit-tests/common/expected/index.conf
+++ b/tests/unit-tests/common/expected/index.conf
@@ -1,6 +1,9 @@
 <h2>title</h2>
 <ul>
     <li>
+        <p><a href="#top">table of contents</a></p>
+    </li>
+    <li>
         <p><ac:link ac:anchor="section1">
             <ac:link-body>section 1</ac:link-body>
         </ac:link></p>


### PR DESCRIPTION
When using restructuredText's table of contents directive (`contents`), the reference to the leading section page was always removed when the first section (the "title") was removed (by default) from a document. This was to prevent generating an entry point in the TOC which would not have a proper link target to reference. This causes two issues:

1) This extension would modify a possible expected output to have an anchor link to the top of a document.
2) If a table of contents had multiple child entries to display, the output would generate a nested list category for a "removed" root which would produce an empty/undesired bullet point.

Instead, this commit introduces support for the reference missing the target by detecting that a reference is now a "#top" reference in the builder. This in turn allows during the translation phase to attempt to build a proper link. In the case for the storage format translator, an anchor link to "#top" can be created.

