### PR TITLE
test: correct output container

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -118,7 +118,8 @@ def prepareDirectories(container):
     directories are removed before returning.
     """
     assert container
-    base_dir = os.path.dirname(os.path.realpath(__file__))
+    lib_dir = os.path.dirname(os.path.realpath(__file__))
+    base_dir = os.path.join(lib_dir, os.pardir)
     output_dir = os.path.join(base_dir, 'output')
     container_dir = os.path.join(output_dir, container)
     doc_dir = os.path.join(container_dir, 'build')


### PR DESCRIPTION
Various testing uses a `prepareDirectories` call to provide an interim "doc_dir" and "doctree_dir" locations for Sphinx processing. When this and other utility calls were moving into a lib namespace, directory building broke since its assumption of the base folder ("tests") was the same location as the helper call.

This commit corrects the utility call by taking into consideration of the recently added `lib` directory.