### PR TITLE
cleanup validation warnings

### DIFF
--- a/tests/validation-sets/auto-ext/autodocs.rst
+++ b/tests/validation-sets/auto-ext/autodocs.rst
@@ -17,8 +17,10 @@ The autoclass_ directive:
 
 .. autoclass:: Hello
    :members: say_hello
+   :noindex:
 
    .. method:: foo(arg1, arg2)
+      :noindex:
 
       An overwritten description of the method ``foo``.
 

--- a/tests/validation-sets/base/index.rst
+++ b/tests/validation-sets/base/index.rst
@@ -5,7 +5,7 @@ Validation set result for sphinxcontrib-confluencebuilder |test_desc|:
 
 ----
 
-.. raw:: confluence
+.. raw:: confluence_storage
 
    <ac:structured-macro ac:name="children">
       <ac:parameter ac:name="all">true</ac:parameter>


### PR DESCRIPTION
**validation: prevent duplicate objects in autodocs example**
When processing the autodocs example, an undesired duplicate object description for the `Hello` class and method examples is set. This results in a warning message as follows:

```
sphinx.errors.SphinxWarning: ./tests/validation-sets/auto-ext/autodocs.rst:22:duplicate object description of Hello.Hello.foo, other instance in autodocs, use :noindex: for one of them
```

To remove this warning, adding the `:noindex:` option to calls which re-use the `Hello` module more than once in a document.

**validation: switch raw type identifier**
Switching from the deprecated `confluence` raw format type to the newly added `confluence_storage` type.