### PR TITLE
improve support for section/figure numbering

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -352,6 +352,7 @@ class ConfluenceBuilder(Builder):
                 doctree.append(navnode)
 
         self.secnumbers = self.env.toc_secnumbers.get(docname, {})
+        self.fignumbers = self.env.toc_fignumbers.get(docname, {})
 
         # remove title from page contents (if any)
         if self.config.confluence_remove_title:

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -81,12 +81,17 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
             return
 
         with progress_message(__('assembling single confluence document')):
-            doctree = self.assemble_doctree()
-            self._prepare_doctree_writing(self.config.master_doc, doctree)
-
             self.env.toc_secnumbers = self.assemble_toc_secnumbers()
             self.env.toc_fignumbers = self.assemble_toc_fignumbers()
 
+            # register title targets for references before assembling doc
+            # re-works them into a single document
+            for docname in docnames:
+                doctree = self.env.get_doctree(docname)
+                self._register_doctree_title_targets(docname, doctree)
+
+            doctree = self.assemble_doctree()
+            self._prepare_doctree_writing(self.config.master_doc, doctree)
             self.assets.processDocument(doctree, self.config.master_doc)
 
         with progress_message(__('writing single confluence document')):
@@ -151,3 +156,45 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         self.publish_docnames.append(docname)
 
         return doctitle
+
+    def _register_doctree_title_targets(self, docname, doctree):
+        """
+        register title targets for a doctree
+
+        Compiles a list of title targets which references can link against. This
+        tracked expected targets for sections which are automatically generated
+        in a rendered Confluence instance.
+
+        Args:
+            docname: the docname of the doctree
+            doctree: the doctree to search for targets
+        """
+
+        doc_used_names = {}
+        secnumbers = self.env.toc_secnumbers.get(self.config.master_doc, {})
+
+        for node in doctree.traverse(nodes.title):
+            if isinstance(node.parent, nodes.section):
+                section_node = node.parent
+                if 'ids' in section_node:
+                    title_name = ''.join(node.astext().split())
+
+                    for id in section_node['ids']:
+                        target = title_name
+
+                        anchorname = '%s/#%s' % (docname, id)
+                        if anchorname not in secnumbers:
+                            anchorname = '%s/' % id
+
+                        if self.add_secnumbers:
+                            secnumber = secnumbers.get(anchorname)
+                            if secnumber:
+                                target = ('.'.join(map(str, secnumber)) +
+                                    self.secnumber_suffix + target)
+
+                        section_id = doc_used_names.get(target, 0)
+                        doc_used_names[target] = section_id + 1
+                        if section_id > 0:
+                            target = '{}.{}'.format(target, section_id)
+
+                        ConfluenceState.registerTarget(anchorname, target)

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -33,17 +33,6 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         return tree
 
     def assemble_toc_secnumbers(self):
-        #
-        # Assemble toc_secnumbers to resolve section numbers on SingleHTML.
-        # Merge all secnumbers to single secnumber.
-        #
-        # Note: current Sphinx has refid confliction in singlehtml mode.
-        #       To avoid the problem, it replaces key of secnumbers to
-        #       tuple of docname and refid.
-        #
-        #       There are related codes in inline_all_toctres() and
-        #       HTMLTranslter#add_secnumber().
-        #
         new_secnumbers = {}
 
         for docname, secnums in self.env.toc_secnumbers.items():
@@ -54,23 +43,8 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         return {self.config.master_doc: new_secnumbers}
 
     def assemble_toc_fignumbers(self):
-        #
-        # Assemble toc_fignumbers to resolve figure numbers on SingleHTML.
-        # Merge all fignumbers to single fignumber.
-        #
-        # Note: current Sphinx has refid confliction in singlehtml mode.
-        #       To avoid the problem, it replaces key of secnumbers to
-        #       tuple of docname and refid.
-        #
-        #       There are related codes in inline_all_toctres() and
-        #       HTMLTranslter#add_fignumber().
-        #
         new_fignumbers = {}
 
-        #
-        # {'foo': {'figure': {'id2': (2,), 'id1': (1,)}},
-        #  'bar': {'figure': {'id1': (3,)}}}
-        #
         for docname, fignumlist in self.env.toc_fignumbers.items():
             for figtype, fignums in fignumlist.items():
                 alias = '{}/{}'.format(docname, figtype)

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -847,7 +847,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 anchorname = '%s/' % raw_anchor
         else:
             anchorname = '{}#{}'.format(self.docname, raw_anchor)
-  
+
         # check if this target is reachable without an anchor; if so, use the
         # identifier value instead
         target = ConfluenceState.target(anchorname)

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 :copyright: Copyright 2016-2020 Sphinx Confluence Builder Contributors (AUTHORS)
-:copyright: Copyright 2018 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
+:copyright: Copyright 2018-2020 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
@@ -75,29 +75,32 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     # structure
     # ---------
 
-    def add_secnumber(self, node):
-        # type: (nodes.Element) -> None
-        # From sphinx.writers.HTML5Translator.add_secnumber
+    def get_secnumber(self, node):
         if node.get('secnumber'):
-            self.body.append('.'.join(map(str, node['secnumber'])) +
-                             self.secnumber_suffix)
-        elif isinstance(node.parent, nodes.section):
+            return node['secnumber']
+
+        if isinstance(node.parent, nodes.section):
             if self.builder.name == 'singleconfluence':
                 docname = self._docnames[-1]
-                anchorname = "%s/#%s" % (docname, node.parent['ids'][0])
-                # try first heading which has no anchor
+                raw_anchor = node.parent['ids'][0]
+                anchorname = '%s/#%s' % (docname, node.parent['ids'][0])
                 if anchorname not in self.builder.secnumbers:
-                    anchorname = "%s/" % docname
+                    anchorname = '%s/' % raw_anchor
             else:
                 anchorname = '#' + node.parent['ids'][0]
-                # try first heading which has no anchor
                 if anchorname not in self.builder.secnumbers:
                     anchorname = ''
 
             if self.builder.secnumbers.get(anchorname):
-                numbers = self.builder.secnumbers[anchorname]
-                self.body.append('.'.join(map(str, numbers)) +
-                                 self.secnumber_suffix)
+                return self.builder.secnumbers[anchorname]
+
+        return None
+
+    def add_secnumber(self, node):
+        secnumber = self.get_secnumber(node)
+        if secnumber:
+            self.body.append('.'.join(map(str, secnumber)) +
+                self.secnumber_suffix)
 
     def visit_title(self, node):
         if isinstance(node.parent, (nodes.section, nodes.topic)):

--- a/tests/unit-tests/single-page/dataset-contents-numbered/index.rst
+++ b/tests/unit-tests/single-page/dataset-contents-numbered/index.rst
@@ -1,0 +1,7 @@
+toctree
+=======
+
+.. toctree::
+   :numbered:
+
+   sub

--- a/tests/unit-tests/single-page/dataset-contents-numbered/sub.rst
+++ b/tests/unit-tests/single-page/dataset-contents-numbered/sub.rst
@@ -1,0 +1,14 @@
+sub
+===
+
+.. contents::
+
+section
+-------
+
+first second
+
+section
+-------
+
+second second with same name

--- a/tests/unit-tests/single-page/dataset-contents/index.rst
+++ b/tests/unit-tests/single-page/dataset-contents/index.rst
@@ -1,0 +1,6 @@
+toctree
+=======
+
+.. toctree::
+
+   sub

--- a/tests/unit-tests/single-page/dataset-contents/sub.rst
+++ b/tests/unit-tests/single-page/dataset-contents/sub.rst
@@ -1,0 +1,14 @@
+sub
+===
+
+.. contents::
+
+section
+-------
+
+first second
+
+section
+-------
+
+second second with same name

--- a/tests/unit-tests/single-page/expected-numbered/index.conf
+++ b/tests/unit-tests/single-page/expected-numbered/index.conf
@@ -1,14 +1,14 @@
 <p>content</p>
 <h2>1. page-a</h2>
 <p>page-a start</p>
-<p><ac:link ac:anchor="page-b">
+<p><ac:link ac:anchor="2. page-b">
     <ac:link-body>page-b</ac:link-body>
 </ac:link></p>
 <h3>1.1. section</h3>
 <p>page-a end</p>
 <h2>2. page-b</h2>
 <p>page-b start</p>
-<p><ac:link ac:anchor="page-a">
+<p><ac:link ac:anchor="1. page-a">
     <ac:link-body>page-a</ac:link-body>
 </ac:link></p>
 <p>page-b end</p>

--- a/tests/unit-tests/single-page/test_singlepage.py
+++ b/tests/unit-tests/single-page/test_singlepage.py
@@ -6,6 +6,7 @@
 
 from tests.lib import assertExpectedWithOutput
 from tests.lib import buildSphinx
+from tests.lib import parse
 from tests.lib import prepareConfiguration
 from tests.lib import prepareDirectories
 import os
@@ -16,6 +17,32 @@ class TestConfluenceSinglePage(unittest.TestCase):
     def setUpClass(self):
         self.config = prepareConfiguration()
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
+
+    def test_singlepage_contents_default(self):
+        dataset = os.path.join(self.test_dir, 'dataset-contents')
+        doc_dir, doctree_dir = prepareDirectories('singlepage-contents')
+        buildSphinx(dataset, doc_dir, doctree_dir, self.config,
+            builder='singleconfluence')
+
+        with parse('index', doc_dir) as data:
+            links = data.find_all('ac:link')
+            self.assertEqual(len(links), 3)
+            self.assertEqual(links[0]['ac:anchor'], 'sub')
+            self.assertEqual(links[1]['ac:anchor'], 'section')
+            self.assertEqual(links[2]['ac:anchor'], 'section.1')
+
+    def test_singlepage_contents_numbered(self):
+        dataset = os.path.join(self.test_dir, 'dataset-contents-numbered')
+        doc_dir, doctree_dir = prepareDirectories('singlepage-contents-numberd')
+        buildSphinx(dataset, doc_dir, doctree_dir, self.config,
+            builder='singleconfluence')
+
+        with parse('index', doc_dir) as data:
+            links = data.find_all('ac:link')
+            self.assertEqual(len(links), 3)
+            self.assertEqual(links[0]['ac:anchor'], '1. sub')
+            self.assertEqual(links[1]['ac:anchor'], '1.1. section')
+            self.assertEqual(links[2]['ac:anchor'], '1.2. section')
 
     def test_singlepage_default(self):
         dataset = os.path.join(self.test_dir, 'dataset')

--- a/tests/unit-tests/single-page/test_singlepage.py
+++ b/tests/unit-tests/single-page/test_singlepage.py
@@ -12,26 +12,25 @@ import os
 import unittest
 
 class TestConfluenceSinglePage(unittest.TestCase):
-    def test_singlepage(self):
-        config = prepareConfiguration()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
+    @classmethod
+    def setUpClass(self):
+        self.config = prepareConfiguration()
+        self.test_dir = os.path.dirname(os.path.realpath(__file__))
 
-        dataset = os.path.join(test_dir, 'dataset')
-        expected = os.path.join(test_dir, 'expected')
+    def test_singlepage_default(self):
+        dataset = os.path.join(self.test_dir, 'dataset')
+        expected = os.path.join(self.test_dir, 'expected')
         doc_dir, doctree_dir = prepareDirectories('singlepage')
-        buildSphinx(dataset, doc_dir, doctree_dir, config,
+        buildSphinx(dataset, doc_dir, doctree_dir, self.config,
             builder='singleconfluence')
 
         assertExpectedWithOutput(self, 'index', expected, doc_dir)
 
     def test_singlepage_numbered(self):
-        config = prepareConfiguration()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-
-        dataset = os.path.join(test_dir, 'dataset-numbered')
-        expected = os.path.join(test_dir, 'expected-numbered')
+        dataset = os.path.join(self.test_dir, 'dataset-numbered')
+        expected = os.path.join(self.test_dir, 'expected-numbered')
         doc_dir, doctree_dir = prepareDirectories('singlepage-numbered')
-        buildSphinx(dataset, doc_dir, doctree_dir, config,
+        buildSphinx(dataset, doc_dir, doctree_dir, self.config,
             builder='singleconfluence')
 
         assertExpectedWithOutput(self, 'index', expected, doc_dir)

--- a/tests/unit-tests/toctree/dataset-contents/index.rst
+++ b/tests/unit-tests/toctree/dataset-contents/index.rst
@@ -1,0 +1,7 @@
+toctree
+=======
+
+.. toctree::
+   :numbered:
+
+   sub

--- a/tests/unit-tests/toctree/dataset-contents/sub.rst
+++ b/tests/unit-tests/toctree/dataset-contents/sub.rst
@@ -1,0 +1,7 @@
+sub
+===
+
+.. contents::
+
+section
+-------

--- a/tests/unit-tests/toctree/expected-numbered-default/index.conf
+++ b/tests/unit-tests/toctree/expected-numbered-default/index.conf
@@ -5,7 +5,7 @@
         <ac:link-body>1. doc1</ac:link-body>
         </ac:link><ul>
             <li>
-                <ac:link ac:anchor="section">
+                <ac:link ac:anchor="1.1. section">
                 <ri:page ri:content-title="1. doc1" />
                 <ac:link-body>1.1. section</ac:link-body>
                 </ac:link></li>
@@ -17,12 +17,12 @@
         <ac:link-body>2. doc2</ac:link-body>
         </ac:link><ul>
             <li>
-                <ac:link ac:anchor="section">
+                <ac:link ac:anchor="2.1. section">
                 <ri:page ri:content-title="2. doc2" />
                 <ac:link-body>2.1. section</ac:link-body>
                 </ac:link><ul>
                     <li>
-                        <ac:link ac:anchor="subsection">
+                        <ac:link ac:anchor="2.1.1. subsection">
                         <ri:page ri:content-title="2. doc2" />
                         <ac:link-body>2.1.1. subsection</ac:link-body>
                     </ac:link></li>

--- a/tests/unit-tests/toctree/expected-numbered-depth/index.conf
+++ b/tests/unit-tests/toctree/expected-numbered-depth/index.conf
@@ -5,7 +5,7 @@
         <ac:link-body>1. doc1</ac:link-body>
         </ac:link><ul>
             <li>
-                <ac:link ac:anchor="section">
+                <ac:link ac:anchor="1.1. section">
                 <ri:page ri:content-title="1. doc1" />
                 <ac:link-body>1.1. section</ac:link-body>
                 </ac:link></li>
@@ -17,7 +17,7 @@
         <ac:link-body>2. doc2</ac:link-body>
         </ac:link><ul>
             <li>
-                <ac:link ac:anchor="section">
+                <ac:link ac:anchor="2.1. section">
                 <ri:page ri:content-title="2. doc2" />
                 <ac:link-body>2.1. section</ac:link-body>
                 </ac:link><ul>

--- a/tests/unit-tests/toctree/expected-numbered-suffix/index.conf
+++ b/tests/unit-tests/toctree/expected-numbered-suffix/index.conf
@@ -5,7 +5,7 @@
         <ac:link-body>1!Z /+4doc1</ac:link-body>
         </ac:link><ul>
             <li>
-                <ac:link ac:anchor="section">
+                <ac:link ac:anchor="1.1!Z /+4section">
                 <ri:page ri:content-title="1!Z /+4doc1" />
                 <ac:link-body>1.1!Z /+4section</ac:link-body>
                 </ac:link></li>
@@ -17,12 +17,12 @@
         <ac:link-body>2!Z /+4doc2</ac:link-body>
         </ac:link><ul>
             <li>
-                <ac:link ac:anchor="section">
+                <ac:link ac:anchor="2.1!Z /+4section">
                 <ri:page ri:content-title="2!Z /+4doc2" />
                 <ac:link-body>2.1!Z /+4section</ac:link-body>
                 </ac:link><ul>
                     <li>
-                        <ac:link ac:anchor="subsection">
+                        <ac:link ac:anchor="2.1.1!Z /+4subsection">
                         <ri:page ri:content-title="2!Z /+4doc2" />
                         <ac:link-body>2.1.1!Z /+4subsection</ac:link-body>
                     </ac:link></li>

--- a/tests/unit-tests/toctree/test_toctree.py
+++ b/tests/unit-tests/toctree/test_toctree.py
@@ -52,11 +52,10 @@ class TestConfluenceToctreeMarkup(unittest.TestCase):
         assertExpectedWithOutput(self, 'index', expected, doc_dir)
 
     def test_toctree_numbered_default(self):
-        config = dict(self.config)
         dataset = os.path.join(self.test_dir, 'dataset-numbered')
         expected = os.path.join(self.test_dir, 'expected-numbered-default')
         doc_dir, doctree_dir = prepareDirectories('toctree-markup-numbered-default')
-        buildSphinx(dataset, doc_dir, doctree_dir, config)
+        buildSphinx(dataset, doc_dir, doctree_dir, self.config)
 
         assertExpectedWithOutput(self, 'index', expected, doc_dir)
         assertExpectedWithOutput(self, 'doc1', expected, doc_dir)
@@ -65,6 +64,7 @@ class TestConfluenceToctreeMarkup(unittest.TestCase):
     def test_toctree_numbered_disable(self):
         config = dict(self.config)
         config['confluence_add_secnumbers'] = False
+
         dataset = os.path.join(self.test_dir, 'dataset-numbered')
         expected = os.path.join(self.test_dir, 'expected-numbered-disabled')
         doc_dir, doctree_dir = prepareDirectories('toctree-markup-numbered-disabled')
@@ -76,8 +76,8 @@ class TestConfluenceToctreeMarkup(unittest.TestCase):
 
     def test_toctree_numbered_secnumbers_suffix(self):
         config = dict(self.config)
-        config['confluence_add_secnumbers'] = True
         config['confluence_secnumber_suffix'] = '!Z /+4'
+
         dataset = os.path.join(self.test_dir, 'dataset-numbered')
         expected = os.path.join(self.test_dir, 'expected-numbered-suffix')
         doc_dir, doctree_dir = prepareDirectories('toctree-markup-numbered-suffix')
@@ -88,11 +88,10 @@ class TestConfluenceToctreeMarkup(unittest.TestCase):
         assertExpectedWithOutput(self, 'doc2', expected, doc_dir)
 
     def test_toctree_numbered_secnumbers_depth(self):
-        config = dict(self.config)
         dataset = os.path.join(self.test_dir, 'dataset-numbered-depth')
         expected = os.path.join(self.test_dir, 'expected-numbered-depth')
         doc_dir, doctree_dir = prepareDirectories('toctree-markup-numbered-depth')
-        buildSphinx(dataset, doc_dir, doctree_dir, config)
+        buildSphinx(dataset, doc_dir, doctree_dir, self.config)
 
         assertExpectedWithOutput(self, 'index', expected, doc_dir)
         assertExpectedWithOutput(self, 'doc1', expected, doc_dir)

--- a/tests/unit-tests/toctree/test_toctree.py
+++ b/tests/unit-tests/toctree/test_toctree.py
@@ -6,6 +6,7 @@
 
 from tests.lib import assertExpectedWithOutput
 from tests.lib import buildSphinx
+from tests.lib import parse
 from tests.lib import prepareConfiguration
 from tests.lib import prepareDirectories
 import os
@@ -16,6 +17,32 @@ class TestConfluenceToctreeMarkup(unittest.TestCase):
     def setUpClass(self):
         self.config = prepareConfiguration()
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
+
+    def test_contents_default(self):
+        dataset = os.path.join(self.test_dir, 'dataset-contents')
+        doc_dir, doctree_dir = prepareDirectories('contents-default')
+        buildSphinx(dataset, doc_dir, doctree_dir, self.config)
+
+        with parse('sub', doc_dir) as data:
+            top_link = data.find('a')
+            self.assertIsNotNone(top_link, 'unable to find first link tag (a)')
+            self.assertEqual(top_link['href'], '#top',
+                'contents root document not a top reference')
+
+    def test_contents_with_title(self):
+        config = dict(self.config)
+        config['confluence_remove_title'] = False
+
+        dataset = os.path.join(self.test_dir, 'dataset-contents')
+        doc_dir, doctree_dir = prepareDirectories('contents-with-title')
+        buildSphinx(dataset, doc_dir, doctree_dir, config)
+
+        with parse('sub', doc_dir) as data:
+            top_link = data.find('ac:link')
+            self.assertIsNotNone(top_link,
+                'unable to find first link tag (ac:link)')
+            self.assertEqual(top_link['ac:anchor'], '1. sub',
+                'contents root document has an unexpected anchor value')
 
     def test_toctree_child_macro(self):
         config = dict(self.config)


### PR DESCRIPTION
The following provides a more complete for section numbering support when used with this extension. This extension's builders never built proper targets for sections to reference against. Section names identifiers are internally managed by the Confluence instance and the target mappings never took into consideration of a section with a prefixed section number. Cached target entries will now handle when a section number is added to a section text.

In addition, the `singleconfluence` builder required implementing its own title cache list, as the section targets need to be compiled after assembling the section numbers, but before the primary doctree is built. This is a result of pre-merged doctree's which will point to page-specific targets (e.g. `sub/#target`) but the original implementation would assume only an index-based target existed (e.g. `index/#target`) -- which could result in conflicts.

In addition, Sphinx's figure numbering capability was partially ported over when section number was added. This commit attempts to complete the use of the feature by ensuring the main builder registers a fignumbers instance for the translator and add prefixes on figures (in the storage format) when configured  with the common [`numfig` option](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-numfig).