### PR TITLE
tox: ensure flake8 runs by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{27,35,36,37,38}-sphinx{18}
     py{35,36,37,38}-sphinx{23,24,30,31,32}
-    lint
+    flake8
     pylint
 
 [testenv]


### PR DESCRIPTION
A previous commit made some changes to the flake8 usage \[1\] to ensure the linter was invoked correctly. With this change, the tox environment name was changed from `lint` to `flake8`; however, the default environment list was not updated as well. This commit corrects this.

\[1\]: 1a73ce8223c25a5816e1a153c7dfbba17a96bfdc