### PR TITLE
test: allow passing defines in a sandbox environment

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -130,8 +130,8 @@ def prepareDirectories(container):
     return doc_dir, doctree_dir
 
 @contextmanager
-def prepareSphinx(src_dir, out_dir, doctree_dir, config=None, builder=None,
-        relax=False):
+def prepareSphinx(src_dir, out_dir, doctree_dir, config=None, extra_config=None,
+        builder=None, relax=False):
     """
     prepare a sphinx application instance
 
@@ -145,8 +145,10 @@ def prepareSphinx(src_dir, out_dir, doctree_dir, config=None, builder=None,
     if not color_terminal():
         nocolor()
 
-    conf = dict(config) if config else None
-    conf_dir = src_dir if not conf else None
+    conf = dict(config) if config else {}
+    if extra_config:
+        conf.update(extra_config)
+    conf_dir = src_dir if config is None else None
     warnerr = not relax
 
     sts = None
@@ -167,7 +169,7 @@ def prepareSphinx(src_dir, out_dir, doctree_dir, config=None, builder=None,
     with docutils_namespace():
         app = Sphinx(
             src_dir,                # output for document sources
-            conf_dir,               # ignore configuration directory
+            conf_dir,               # configuration directory
             out_dir,                # output for generated documents
             doctree_dir,            # output for doctree files
             builder,                # builder to execute
@@ -179,8 +181,8 @@ def prepareSphinx(src_dir, out_dir, doctree_dir, config=None, builder=None,
 
         yield app
 
-def buildSphinx(src_dir, out_dir, doctree_dir, config=None, builder=None,
-        relax=False):
+def buildSphinx(src_dir, out_dir, doctree_dir, config=None, extra_config=None,
+        builder=None, relax=False):
     """
     prepare a sphinx application instance
 
@@ -189,6 +191,6 @@ def buildSphinx(src_dir, out_dir, doctree_dir, config=None, builder=None,
     [1]: https://github.com/sphinx-doc/sphinx/blob/master/sphinx/application.py
     """
     with prepareSphinx(
-            src_dir, out_dir, doctree_dir, config, builder=builder,
-            relax=relax) as app:
+            src_dir, out_dir, doctree_dir, config=config,
+            extra_config=extra_config, builder=builder, relax=relax) as app:
         app.build(force_all=True)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -14,13 +14,13 @@ import argparse
 import os
 import sys
 
-def process_sandbox(target_sandbox, builder=None):
+def process_sandbox(target_sandbox, builder=None, defines=None):
     test_dir = os.path.dirname(os.path.realpath(__file__))
     sandbox_dir = os.path.join(test_dir, target_sandbox)
 
     doc_dir, doctree_dir = prepareDirectories('sandbox-test')
     buildSphinx(sandbox_dir, doc_dir, doctree_dir, builder=builder,
-        relax=True)
+        extra_config=defines, relax=True)
 
 def process_raw_upload(target_sandbox):
     test_dir = os.path.dirname(os.path.realpath(__file__))
@@ -60,6 +60,7 @@ def main():
 
     parser = argparse.ArgumentParser(prog=__name__,
         description='Atlassian Confluence Sphinx Extension Sandbox')
+    parser.add_argument('-D', action='append', default=[], dest='define')
     parser.add_argument('--builder', '-b')
     parser.add_argument('--raw-upload', '-R', action='store_true')
     parser.add_argument('--sandbox', default='sandbox')
@@ -67,6 +68,17 @@ def main():
 
     args, ___ = parser.parse_known_args(sys.argv[1:])
     parser.parse_args()
+
+    defines = {}
+    for val in args.define:
+        try:
+            key, val = val.split('=', 1)
+            defines[key] = val
+        except ValueError:
+            print('[sandbox] invalid define provided in command line')
+            return 1
+
+    print('[sandbox] target sandbox:', args.sandbox)
 
     if args.verbose:
         if 'SPHINX_VERBOSITY' not in os.environ:
@@ -77,7 +89,7 @@ def main():
         process_raw_upload(args.sandbox)
     else:
         print('[sandbox] documentation test')
-        process_sandbox(args.sandbox, args.builder)
+        process_sandbox(args.sandbox, args.builder, defines)
 
     return 0
 


### PR DESCRIPTION
In select development cases, there is a desire to pass in custom defines on the command line when invoking a specific sandbox test. This commit adds a `-D` argument (to match Sphinx's `-D` argument) which can be used to extend a local sandbox's existing configuration file.