### PR TITLE
storage: handle anchor-specific targets flagged as internal

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -785,8 +785,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             pass
         elif 'top-reference' in node:
             self._visit_reference_top(node)
-        elif (('internal' not in node or not node['internal'])
-                and 'refuri' in node):
+        elif 'refuri' in node:
             # If a document provides an anchor target directly in the reference,
             # attempt to extract the anchor value and pass it into the internal
             # reference processing instead.
@@ -794,12 +793,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 node['refid'] = node['refuri'][1:]
                 del node['refuri']
                 self._visit_reference_intern_id(node)
-            else:
+            elif 'internal' not in node or not node['internal']:
                 self._visit_reference_extern(node)
+            else:
+                self._visit_reference_intern_uri(node)
         elif 'refid' in node:
             self._visit_reference_intern_id(node)
-        elif 'refuri' in node:
-            self._visit_reference_intern_uri(node)
 
     def _visit_reference_extern(self, node):
         uri = node['refuri']


### PR DESCRIPTION
In select cases, it has been observed that a reference node may contain a `refuri` definition which contains an anchor to the active document being processed. The existing implementation would only be able to handle this case if the reference was also not marked as internal; however, it has been observed that in select cases (such as using the `sphinx.ext.todo` extension) that local anchor entries can also be on references which have an internal flag set.

This commit re-works the process `refuri` process flow by:

1) Always checking for an local anchor reference to forward to to the internal identifier-based reference implementation (the fix).
2) If not internal, continue to forward it to the external reference     implementation.
3) Otherwise, process it as an internal URI.