### PR TITLE
inject autosummary nodes after a proper extension check

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -216,8 +216,13 @@ def setup(app):
     """Wires up the directives themselves"""
     app.add_directive('confluence_metadata', ConfluenceMetadataDirective)
 
-    if 'sphinx.ext.autosummary' in app.config.extensions:
-        add_autosummary_nodes(app)
+    # inject the compatible autosummary nodes if the extension is loaded
+    def inject_autosummary_notes_hook(app):
+        for ext in app.extensions.values():
+            if ext.name == 'sphinx.ext.autosummary':
+                add_autosummary_nodes(app)
+                break
+    app.connect('builder-inited', inject_autosummary_notes_hook)
 
     # lazy bind sphinx.ext.imgmath to provide configuration options
     #


### PR DESCRIPTION
This extension would attempt to register compatible autosummary nodes when the `sphinx.ext.autosummary` extension was loaded. This would allow a user to take advantage of the autosummary capabilities with this extension.

The problem with the check on `app.config.extensions` is that that configuration file only indicates extensions the user wishes to explicitly load, and not what extensions have been actually loaded into the Sphinx engine.

The injection process has been changed to better handle autosummary support:

1) Explicitly check against the `app.extensions` loaded extensions to determine if the nodes should be injected.
2) Only attempt to inject after the `builder-inited` event to ensure that modules loaded after the Confluence builder extension which may load `sphinx.ext.autosummary` extension themselves does not cause an missed injection.