### PR TITLE
initial support for graphviz graphs

### DIFF
--- a/doc/markup.rst
+++ b/doc/markup.rst
@@ -82,6 +82,7 @@ The following extensions are supported:
 
  - `sphinx.ext.autodoc`_
  - `sphinx.ext.autosummary`_
+ - `sphinx.ext.graphviz`_
  - `sphinx.ext.inheritance_diagram`_
  - `sphinx.ext.todo`_
 
@@ -136,5 +137,6 @@ expected or brings up another concern, feel free to bring up an issue:
 .. _Sphinx Version Changed: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionchanged
 .. _sphinx.ext.autodoc: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 .. _sphinx.ext.autosummary: https://www.sphinx-doc.org/en/master/usage/extensions/autosummary.html
+.. _sphinx.ext.graphviz: https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html
 .. _sphinx.ext.inheritance_diagram: https://www.sphinx-doc.org/en/master/usage/extensions/inheritance.html
 .. _sphinx.ext.todo: https://www.sphinx-doc.org/en/master/usage/extensions/todo.html


### PR DESCRIPTION
This commit introduces the initial support for graphviz graphs. The implementation mimics the same implementation used to support inheritance diagrams \[1\], where graphviz nodes are converted into image nodes before being processed by a translator.

With the example documentation:

```
.. graphviz::

   digraph foo {
      "bar" -> "baz";
   }

.. graph:: foo

   "bar" -- "baz";

.. digraph:: foo

   "bar" -> "baz" -> "quux";
```

A final output renders as follows:

> ![image](https://user-images.githubusercontent.com/1834509/100682863-02f06100-3345-11eb-8761-991290f0e50d.png)

\[1\]: 01f97a67b98d598a6f5a542869f8542d08fd931b