### PR TITLE
improve handling of titleless documents

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -245,21 +245,23 @@ class ConfluenceBuilder(Builder):
             else:
                 doctitle = self._parse_doctree_title(docname, doctree)
 
-            if not doctitle:
-                continue
+            # only register title/track for publishing if there is a title
+            # value that can be applied to this document
+            if doctitle:
+                secnumbers = self.env.toc_secnumbers.get(docname, {})
+                if self.add_secnumbers and secnumbers.get(''):
+                    doctitle = ('.'.join(map(str, secnumbers[''])) +
+                        self.secnumber_suffix + doctitle)
 
-            secnumbers = self.env.toc_secnumbers.get(docname, {})
-            if self.add_secnumbers and secnumbers.get(''):
-                doctitle = ('.'.join(map(str, secnumbers[''])) +
-                    self.secnumber_suffix + doctitle)
+                doctitle = ConfluenceState.registerTitle(docname, doctitle,
+                    self.config)
 
-            doctitle = ConfluenceState.registerTitle(docname, doctitle,
-                self.config)
+                # only publish documents that sphinx asked to prepare
+                if docname in docnames:
+                    self.publish_docnames.append(docname)
 
-            if docname in docnames:
-                # Only publish documents that Sphinx asked to prepare
-                self.publish_docnames.append(docname)
-
+            # track the toctree depth for a document, which a translator can
+            # use as a hint when dealing with max-depth capabilities
             toctree = first(doctree.traverse(addnodes.toctree))
             if toctree and toctree.get('maxdepth') > 0:
                 ConfluenceState.registerToctreeDepth(

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -195,13 +195,13 @@ class ConfluenceState:
         return ConfluenceState.refid2target.get(refid)
 
     @staticmethod
-    def title(docname):
+    def title(docname, default=None):
         """
         return the title value for a provided docname
 
         See `registerTitle` for more information.
         """
-        return ConfluenceState.doc2title.get(docname)
+        return ConfluenceState.doc2title.get(docname, default)
 
     @staticmethod
     def toctreeDepth(docname):

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1256,7 +1256,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._end_ac_image(node))
         else:
             image_key, hosting_docname = self.assets.fetch(node)
-            hosting_doctitle = ConfluenceState.title(hosting_docname)
+            hosting_doctitle = ConfluenceState.title(
+                hosting_docname, hosting_docname)
             hosting_doctitle = self._escape_sf(hosting_doctitle)
 
             self.body.append(self._start_ac_image(node, **attribs))


### PR DESCRIPTION
This extension includes a requirement that in order for a document to be published to a Confluence instance, a title value must be determined for a given document in order to know where to publish a document's contents. While there have been changes in this extension over time to auto-generated a title or provide a user's option to configure title mappings, there are configuration states which can still result in a processed document to not have a title value (and will be ignored during the publishing phase).

A problem that exists with the initial implementation is that if a document is detected to not being able to be published, it would stop pre-processing these documents immediately. While this can be valid for some pre-processor actions, skipping all the pre-processor actions can cause issues for users. For example, a pre-processor step will convert math nodes into images; however, if this pre-processor stage is skipped, the writing phase will break since the translator cannot handle the unknown node type.

This commit adjusts the prepare-writing stage to only skip title-related and publish tracking when an invalid title state is detected (i.e. all documents can go through various pre-processing steps, even though they will not be published). For the implementation dependent on know title values during the translation phase (e.g. image attachment building for storage format), changes are also included to prevent a user from experiencing an undesired error (see also #235).
