### PR TITLE
warn about unreconciled pages

### DIFF
--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -136,3 +136,28 @@ class ConfluenceTimeoutError(ConfluenceError):
             """    %s\n""" % server_url +
             """---\n"""
         )
+
+class ConfluenceUnreconciledPageError(ConfluenceError):
+    def __init__(self, page_name, page_id, url, ex):
+        SphinxError.__init__(self,
+            """---\n"""
+            """Unable to update unreconciled page: %s """ % page_name +
+            """(id: %s)\n""" % str(page_id) +
+            """\n"""
+            """Unable to update the target page due to the Confluence """
+            """instance reporting an unreconciled page. A workaround for """
+            """this is to manually browse the page using a browser which """
+            """will force Confluence to reconcile the page. A link to the """
+            """page is a follows:\n"""
+            """\n"""
+            """   %spages/viewpage.action?pageId=%s""" % (url, str(page_id)) +
+            """\n\n"""
+            """If this is observed on Confluence v6.x, v7.3.3 or higher, """
+            """please report this issue to the developers of the Confluence """
+            """builder extension.\n"""
+            """\n"""
+            """See also: https://jira.atlassian.com/browse/CONFSERVER-59196\n"""
+            """\n(details: %s""" % ex +
+            """)\n"""
+            """---\n"""
+        )

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -12,6 +12,7 @@ from .exceptions import ConfluenceBadApiError
 from .exceptions import ConfluenceBadSpaceError
 from .exceptions import ConfluenceConfigurationError
 from .exceptions import ConfluencePermissionError
+from .exceptions import ConfluenceUnreconciledPageError
 from .logger import ConfluenceLogger
 from .rest import Rest
 import json
@@ -462,6 +463,10 @@ class ConfluencePublisher():
                 try:
                     self.rest_client.put('content', page['id'], updatePage)
                 except ConfluenceBadApiError as ex:
+                    if str(ex).find('unreconciled'):
+                        raise ConfluenceUnreconciledPageError(
+                            page_name, page['id'], self.server_url, ex)
+
                     # Confluence Cloud may (rarely) fail to complete a
                     # content request with an OptimisticLockException/
                     # StaleObjectStateException exception. It is suspected


### PR DESCRIPTION
This commit introduces a new exception type `ConfluenceUnreconciledPageError` to help provide users a more detailed description when they experience publishing a page which Confluence reports is unreconciled.

This is a result of a Confluence issue observed between a 7.0 release and a 7.3.2 release where a Confluence upgrade can result in unreconciled pages (unknown if recent micro version of 7.0.x, 7.1.x or 7.2.x have ported a hotfix for this). More details can be found in CONFSERVER-59196 \[1\] (thanks Nicholas Bollweg for reporting this; see #314).

A workaround to this issue is to have a user refresh an unreconciled page, which is not* possible from this extension (*since we limit configurations to use API credentials and the request needs to happen outside the API endpoint). This should be less of a concern recently since any user experiencing an upgrade now would be using a more recent version (e.g. v7.9.x series); however, capturing this error case to help the odd user in a unique environment.

\[1\]: https://jira.atlassian.com/browse/CONFSERVER-59196