### PR TITLE
initial intersphinx support

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -29,6 +29,7 @@ from sphinx.errors import ExtensionError
 from sphinx.locale import __
 from sphinx.util import status_iterator
 from sphinx.util.osutil import ensuredir
+from sphinxcontrib.confluencebuilder.intersphinx import build_intersphinx
 import io
 import sys
 
@@ -583,6 +584,10 @@ class ConfluenceBuilder(Builder):
 
             self.publish_purge()
             self.publish_finalize()
+
+            ConfluenceLogger.info('building intersphinx... ', nonl=True)
+            build_intersphinx(self)
+            ConfluenceLogger.info('done\n')
 
     def cleanup(self):
         if self.publish:

--- a/sphinxcontrib/confluencebuilder/intersphinx.py
+++ b/sphinxcontrib/confluencebuilder/intersphinx.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2007-2020 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from os import path
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
+from sphinxcontrib.confluencebuilder.state import ConfluenceState
+import re
+import requests
+import zlib
+
+"""
+inventory filename to hold intersphinx information
+"""
+INVENTORY_FILENAME = 'objects.inv'
+
+def build_intersphinx(builder):
+    """
+    build intersphinx information from the state of the builder
+
+    Attempt to build a series of entries for an intersphinx inventory resource
+    for Confluence builder generated content. This is only supported after
+    processing a publishing event where page identifiers are cached to build URI
+    entries.
+
+    Args:
+        builder: the builder
+    """
+    def escape(string):
+        return re.sub("\\s+", ' ', string)
+
+    with open(path.join(builder.outdir, INVENTORY_FILENAME), 'wb') as f:
+        # header
+        f.write((
+            '# Sphinx inventory version 2\n'
+            '# Project: %s\n'
+            '# Version: %s\n'
+            '# The remainder of this file is compressed using zlib.\n' % (
+                escape(builder.env.config.project),
+                escape(builder.env.config.version))).encode())
+
+        # contents
+        compressor = zlib.compressobj(9)
+
+        for domainname, domain in sorted(builder.env.domains.items()):
+            if domainname == 'std':
+                for name, dispname, typ, docname, raw_anchor, prio in sorted(
+                        domain.get_objects()):
+
+                    page_id = ConfluenceState.uploadId(docname)
+                    if not page_id:
+                        continue
+
+                    target_name = '{}#{}'.format(docname, raw_anchor)
+                    target = ConfluenceState.target(target_name)
+
+                    if raw_anchor and target:
+                        title = ConfluenceState.title(docname)
+                        anchor = 'id-' + title + '-' + target
+                        anchor = anchor.replace(' ', '')
+
+                        # confluence will convert quotes to right-quotes for
+                        # anchor values; replace and encode the anchor value
+                        anchor = anchor.replace('"', '”')
+                        anchor = anchor.replace("'", '’')
+                        anchor = requests.utils.quote(anchor)
+                    else:
+                        anchor = ''
+
+                    uri = 'pages/{}/'.format(page_id)
+                    if anchor:
+                        uri += '#' + anchor
+                    if dispname == name:
+                        dispname = '-'
+                    entry = ('%s %s:%s %s %s %s\n' %
+                             (name, domainname, typ, prio, uri, dispname))
+                    ConfluenceLogger.verbose('(intersphinx) ' + entry.strip())
+                    f.write(compressor.compress(entry.encode()))
+
+        f.write(compressor.flush())


### PR DESCRIPTION
The following adds initial support for generating an inventory file to be used by the `sphinx.ext.intersphinx` extension. This initial release will build document and various references (e.g. titles) inside an inventory file.

This file is only built when publishing occurs, as it is the only time it will know the specific page identifiers to build links for targets.