### PR TITLE
support link titles

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -833,7 +833,15 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         uri = node['refuri']
         uri = self._escape_sf(uri)
 
-        self.body.append(self._start_tag(node, 'a', **{'href': uri}))
+        attribs = {}
+        attribs['href'] = uri
+
+        if 'reftitle' in node:
+            title = node['reftitle']
+            title = self._escape_sf(title)
+            attribs['title'] = title
+
+        self.body.append(self._start_tag(node, 'a', **attribs))
         self._reference_context.append(self._end_tag(node, suffix=''))
 
     def _visit_reference_intern_id(self, node):


### PR DESCRIPTION
Confluence's storage format supports the `title` attribute in `a` tags. Take advantage of this by adding the attribute when a reference node has `reftitle` defined.