### PR TITLE
storage: introduce support for hlist

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/__init__.py
+++ b/sphinxcontrib/confluencebuilder/translator/__init__.py
@@ -245,10 +245,6 @@ class ConfluenceBaseTranslator(BaseTranslator):
     def visit_comment(self, node):
         raise nodes.SkipNode
 
-    def visit_hlist(self, node):
-        # unsupported
-        raise nodes.SkipNode
-
     def visit_line(self, node):
         # ignoring; no need to handle specific line entries
         pass

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1333,6 +1333,28 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         raise nodes.SkipNode
 
+    # ---------------
+    # sphinx -- hlist
+    # ---------------
+
+    def visit_hlist(self, node):
+        self.body.append(self._start_tag(node, 'table', suffix=self.nl))
+        self.context.append(self._end_tag(node))
+        self.body.append(self._start_tag(node, 'tr', suffix=self.nl))
+        self.context.append(self._end_tag(node))
+
+    def depart_hlist(self, node):
+        self.body.append(self.context.pop()) # tr
+        self.body.append(self.context.pop()) # table
+
+    def visit_hlistcol(self, node):
+        self.body.append(self._start_tag(node, 'td',
+            **{'style': 'border: none'}))
+        self.context.append(self._end_tag(node))
+
+    def depart_hlistcol(self, node):
+        self.body.append(self.context.pop()) # td
+
     # -----------------
     # sphinx -- manpage
     # -----------------


### PR DESCRIPTION
The hlist was never initially supported since it was assumed that the rendering/style requirements would not be possible on a Confluence instance. After addition investigation, it turns out that is not true (and support is not that complex).