### PR TITLE
storage: introduce support for the centered directive

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/__init__.py
+++ b/sphinxcontrib/confluencebuilder/translator/__init__.py
@@ -235,13 +235,6 @@ class ConfluenceBaseTranslator(BaseTranslator):
     def visit_acks(self, node):
         raise nodes.SkipNode
 
-    def visit_centered(self, node):
-        # centered is deprecated; ignore
-        pass
-
-    def depart_centered(self, node):
-        pass
-
     def visit_comment(self, node):
         raise nodes.SkipNode
 

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1506,6 +1506,17 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     # sphinx -- miscellaneous
     # -----------------------
 
+    def visit_centered(self, node):
+        self.body.append(self._start_tag(node, 'h2',
+            **{'style': 'text-align: center'}))
+        self.context.append(self._end_tag(node))
+        self.body.append(self._start_tag(node, 'strong'))
+        self.context.append(self._end_tag(node, suffix=''))
+
+    def depart_centered(self, node):
+        self.body.append(self.context.pop()) # strong
+        self.body.append(self.context.pop()) # h2
+
     def visit_rubric(self, node):
         self.body.append(self._start_tag(node, 'h{}'.format(self._title_level)))
         self.context.append(self._end_tag(node))


### PR DESCRIPTION
While `centered` is a deprecated directive, there may be a chance that a legacy documentation set is still using it. To help be more flexible for these documentation sets, emulate the expected output for when using this directive.