### PR TITLE
build: support user configuring graphviz output type

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -85,6 +85,11 @@ class ConfluenceBuilder(Builder):
         self.secnumbers = {}
         self._original_get_doctree = None
 
+        if 'graphviz_output_format' in self.config:
+            self.graphviz_output_format = self.config['graphviz_output_format']
+        else:
+            self.graphviz_output_format = 'png'
+
         # state tracking is set at initialization (not cleanup) so its content's
         # can be checked/validated on after the builder has executed (testing)
         ConfluenceState.reset()
@@ -815,7 +820,7 @@ class ConfluenceBuilder(Builder):
         for node in doctree.traverse(graphviz):
             try:
                 _, out_filename = render_dot(mock_translator, node['code'],
-                    node['options'], 'png', 'graphviz')
+                    node['options'], self.graphviz_output_format, 'graphviz')
                 if not out_filename:
                     node.parent.remove(node)
                     continue
@@ -869,8 +874,8 @@ class ConfluenceBuilder(Builder):
             dotcode = graph.generate_dot(name, {}, env=self.env)
 
             try:
-                _, out_filename = render_dot(
-                    mock_translator, dotcode, {}, 'png', 'inheritance')
+                _, out_filename = render_dot(mock_translator, dotcode, {},
+                    self.graphviz_output_format, 'inheritance')
                 if not out_filename:
                     node.parent.remove(node)
                     continue


### PR DESCRIPTION
Initial support for `sphinx.ext.graphviz` extension capabilities would force use a `png` format for all generated images. Users may wish to use an alternative output type through the `graphviz_output_format` configuration option; enabling support for this.