### PR TITLE
storage: support width options in tables

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -746,7 +746,20 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self._thead_context.pop()
 
     def visit_tgroup(self, node):
-        pass
+        # if column widths are explicitly given, apply specific column widths
+        table_classes = node.parent.get('classes', [])
+        if 'colwidths-given' in table_classes:
+            has_colspec = False
+            for colspec in node.traverse(nodes.colspec):
+                if not has_colspec:
+                    self.body.append(self._start_tag(node, 'colgroup'))
+                    has_colspec = True
+
+                self.body.append(self._start_tag(node, 'col', empty=True,
+                    **{'style': 'width: {}px'.format(colspec['colwidth'])}))
+
+            if has_colspec:
+                self.body.append(self._end_tag(node))
 
     def depart_tgroup(self, node):
         pass


### PR DESCRIPTION
When a table is created, no width hints are provided to the markup. This allows Confluence to attempt to manage these tables in a flexible manner. However, reStructuredText does provide a `widths` option for tables which a user may wish to take advantage of. Since Confluence does allow width style events to be applied in storage format, attempt to take advantage of this to help better space columns based off the hints provided in a documentation's source.