### PR TITLE
storage: only render todo when configured

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -46,6 +46,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.numfig = config.numfig
         self.numfig_format = config.numfig_format
         self.secnumber_suffix = config.confluence_secnumber_suffix
+        self.todo_include_todos = getattr(config, 'todo_include_todos', None)
         self._building_footnotes = False
         self._figure_context = []
         self._manpage_url = getattr(config, 'manpages_url', None)
@@ -677,6 +678,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self._visit_admonition(node, 'tip')
 
     def _visit_todo_node(self, node):
+        if not self.todo_include_todos:
+            raise nodes.SkipNode
+
         if 'ids' in node and node['ids'] and self.can_anchor:
             self.body.append(self._start_ac_macro(node, 'anchor'))
             self.body.append(self._build_ac_parameter(node, '', node['ids'][0]))


### PR DESCRIPTION
While this extension attempts to support todo entries provided by the `sphinx.ext.todo` extension, these entries should not be rendered in a document unless the configuration `todo_include_todos` is configured to `True`. However, the initial implementation for todo support would always render these entries. This commit corrects this by explicitly checking the option before processing a todo node.