### PR TITLE
build: support both graphviz and inheritance-diagram

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -292,11 +292,12 @@ class ConfluenceBuilder(Builder):
         # extract metadata information
         self._extract_metadata(docname, doctree)
 
+        # replace inheritance diagram with images
+        # (always invoke before _replace_graphviz_nodes)
+        self._replace_inheritance_diagram(doctree)
+
         # replace graphviz nodes with images
         self._replace_graphviz_nodes(doctree)
-
-        # replace inheritance diagram with images
-        self._replace_inheritance_diagram(doctree)
 
         # replace math blocks with images
         self._replace_math_blocks(doctree)


### PR DESCRIPTION
This extension originally supported the use of inheritance diagrams via the `sphinx.ext.inheritance_diagram` extension, and later on supported more graph capabilities via the `sphinx.ext.graphviz` extension. Both extensions are handled in the builder which the respective nodes are converted into images to be included on a Confluence page. When introducing support for graphviz, inheritance_diagram support broke; this is a result of the replacement of `graphviz` nodes inside `inheritance_diagram` nodes.

To correct this issue, `inheritance_diagram` nodes will be always replaced before attempting to replace `graphviz` nodes. With this change, the use of either extension in a documentation set will work as expected.