### PR TITLE
maintenance 2020-12-09

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -510,7 +510,7 @@ class ConfluenceBuilder(Builder):
     def publish_finalize(self):
         if self.master_doc_page_id:
             if self.config.confluence_master_homepage is True:
-                self.info('updating space\'s homepage... ', nonl=0)
+                self.info('updating space\'s homepage... ', nonl=True)
                 self.publisher.updateSpaceHome(self.master_doc_page_id)
                 self.info('done\n')
 
@@ -534,7 +534,7 @@ class ConfluenceBuilder(Builder):
             if self.legacy_pages:
                 n = len(self.legacy_pages)
                 self.info('removing legacy pages... (total: {}) '.format(n),
-                    nonl=0)
+                    nonl=True)
                 for legacy_page_id in self.legacy_pages:
                     self.publisher.removePage(legacy_page_id)
                     # remove any pending assets to remove from the page (as they
@@ -547,7 +547,7 @@ class ConfluenceBuilder(Builder):
                 n += len(legacy_asset_info.keys())
             if n > 0:
                 self.info('removing legacy assets... (total: {}) '.format(n),
-                    nonl=0)
+                    nonl=True)
                 for legacy_asset_info in self.legacy_assets.values():
                     for id in legacy_asset_info.keys():
                         self.publisher.removeAttachment(id)
@@ -602,7 +602,7 @@ class ConfluenceBuilder(Builder):
             self.publish_purge()
             self.publish_finalize()
 
-            self.info('building intersphinx... ', nonl=0)
+            self.info('building intersphinx... ', nonl=True)
             build_intersphinx(self)
             self.info('done\n')
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -73,6 +73,7 @@ class ConfluenceBuilder(Builder):
 
         self.add_secnumbers = self.config.confluence_add_secnumbers
         self.cache_doctrees = {}
+        self.cloud = False
         self.file_suffix = '.conf'
         self.link_suffix = None
         self.master_doc_page_id = None
@@ -138,6 +139,10 @@ class ConfluenceBuilder(Builder):
             ConfluenceLogger.warn('normalizing confluence url from '
                 '{} to {} '.format(old_url, new_url))
             self.config.confluence_server_url = new_url
+
+        # detect if Confluence Cloud if using the Atlassian domain
+        if new_url:
+            self.cloud = new_url.endswith('.atlassian.net/wiki/')
 
         if self.config.confluence_file_suffix is not None:
             self.file_suffix = self.config.confluence_file_suffix
@@ -508,9 +513,15 @@ class ConfluenceBuilder(Builder):
                 self.publisher.updateSpaceHome(self.master_doc_page_id)
                 ConfluenceLogger.info('done\n')
 
+            if self.cloud:
+                point_url = '{0}spaces/{1}/pages/{2}'
+            else:
+                point_url = '{0}pages/viewpage.action?pageId={2}'
+
             ConfluenceLogger.info(
-                'Publish point: {}spaces/TEST/pages/{}'.format(
+                'Publish point: ' + point_url.format(
                     self.config.confluence_server_url,
+                    self.config.confluence_space_name,
                     self.master_doc_page_id))
 
     def publish_purge(self):

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -75,6 +75,7 @@ class ConfluenceBuilder(Builder):
         self.cache_doctrees = {}
         self.cloud = False
         self.file_suffix = '.conf'
+        self.info = ConfluenceLogger.info
         self.link_suffix = None
         self.master_doc_page_id = None
         self.metadata = {}
@@ -509,20 +510,19 @@ class ConfluenceBuilder(Builder):
     def publish_finalize(self):
         if self.master_doc_page_id:
             if self.config.confluence_master_homepage is True:
-                ConfluenceLogger.info('updating space\'s homepage... ', nonl=0)
+                self.info('updating space\'s homepage... ', nonl=0)
                 self.publisher.updateSpaceHome(self.master_doc_page_id)
-                ConfluenceLogger.info('done\n')
+                self.info('done\n')
 
             if self.cloud:
                 point_url = '{0}spaces/{1}/pages/{2}'
             else:
                 point_url = '{0}pages/viewpage.action?pageId={2}'
 
-            ConfluenceLogger.info(
-                'Publish point: ' + point_url.format(
-                    self.config.confluence_server_url,
-                    self.config.confluence_space_name,
-                    self.master_doc_page_id))
+            self.info('Publish point: ' + point_url.format(
+                self.config.confluence_server_url,
+                self.config.confluence_space_name,
+                self.master_doc_page_id))
 
     def publish_purge(self):
         if self.config.confluence_purge:
@@ -533,25 +533,25 @@ class ConfluenceBuilder(Builder):
 
             if self.legacy_pages:
                 n = len(self.legacy_pages)
-                ConfluenceLogger.info(
-                    'removing legacy pages... (total: {}) '.format(n), nonl=0)
+                self.info('removing legacy pages... (total: {}) '.format(n),
+                    nonl=0)
                 for legacy_page_id in self.legacy_pages:
                     self.publisher.removePage(legacy_page_id)
                     # remove any pending assets to remove from the page (as they
                     # are already been removed)
                     self.legacy_assets.pop(legacy_page_id, None)
-                ConfluenceLogger.info('done\n')
+                self.info('done\n')
 
             n = 0
             for legacy_asset_info in self.legacy_assets.values():
                 n += len(legacy_asset_info.keys())
             if n > 0:
-                ConfluenceLogger.info(
-                    'removing legacy assets... (total: {}) '.format(n), nonl=0)
+                self.info('removing legacy assets... (total: {}) '.format(n),
+                    nonl=0)
                 for legacy_asset_info in self.legacy_assets.values():
                     for id in legacy_asset_info.keys():
                         self.publisher.removeAttachment(id)
-                ConfluenceLogger.info('done\n')
+                self.info('done\n')
 
     def finish(self):
         # restore environment's get_doctree if it was temporarily replaced
@@ -602,9 +602,9 @@ class ConfluenceBuilder(Builder):
             self.publish_purge()
             self.publish_finalize()
 
-            ConfluenceLogger.info('building intersphinx... ', nonl=True)
+            self.info('building intersphinx... ', nonl=0)
             build_intersphinx(self)
-            ConfluenceLogger.info('done\n')
+            self.info('done\n')
 
     def cleanup(self):
         if self.publish:

--- a/sphinxcontrib/confluencebuilder/intersphinx.py
+++ b/sphinxcontrib/confluencebuilder/intersphinx.py
@@ -5,6 +5,7 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
+from __future__ import unicode_literals
 from os import path
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
@@ -83,6 +84,6 @@ def build_intersphinx(builder):
                     entry = ('%s %s:%s %s %s %s\n' %
                              (name, domainname, typ, prio, uri, dispname))
                     ConfluenceLogger.verbose('(intersphinx) ' + entry.strip())
-                    f.write(compressor.compress(entry.encode()))
+                    f.write(compressor.compress(entry.encode('utf-8')))
 
         f.write(compressor.flush())

--- a/sphinxcontrib/confluencebuilder/intersphinx.py
+++ b/sphinxcontrib/confluencebuilder/intersphinx.py
@@ -32,6 +32,11 @@ def build_intersphinx(builder):
     def escape(string):
         return re.sub("\\s+", ' ', string)
 
+    if builder.cloud:
+        pages_part = 'pages/{}/'
+    else:
+        pages_part = 'pages/viewpage.action?pageId={}'
+
     with open(path.join(builder.outdir, INVENTORY_FILENAME), 'wb') as f:
         # header
         f.write((
@@ -70,7 +75,7 @@ def build_intersphinx(builder):
                     else:
                         anchor = ''
 
-                    uri = 'pages/{}/'.format(page_id)
+                    uri = pages_part.format(page_id)
                     if anchor:
                         uri += '#' + anchor
                     if dispname == name:

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -6,6 +6,8 @@
 
 from bs4 import BeautifulSoup
 from contextlib import contextmanager
+from pkg_resources import parse_version
+from sphinx.__init__ import __version__ as sphinx_version
 from sphinx.application import Sphinx
 from sphinx.util.console import nocolor, color_terminal
 from sphinx.util.docutils import docutils_namespace
@@ -104,7 +106,8 @@ def prepareConfiguration():
     config['confluence_publish'] = False
     config['confluence_space_name'] = 'unit-test'
     # support pre-Sphinx v2.0 installations which default to 'contents'
-    config['master_doc'] = 'index'
+    if parse_version(sphinx_version) < parse_version('2.0'):
+        config['master_doc'] = 'index'
 
     return config
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,15 +21,14 @@ usedevelop = true
 
 [testenv:pylint]
 deps = -r{toxinidir}/requirements_dev.txt
-        pylint
-
-commands = pylint \
-           --errors-only \
-           sphinxcontrib.confluencebuilder
+    pylint
+commands =
+    pylint \
+    --errors-only \
+    sphinxcontrib.confluencebuilder
 
 [testenv:flake8]
-deps =
-    -r{toxinidir}/requirements_dev.txt
+deps = -r{toxinidir}/requirements_dev.txt
     flake8
 commands =
     flake8 \
@@ -39,10 +38,12 @@ commands =
 
 [testenv:sandbox]
 deps = -r{toxinidir}/tests/sandbox/requirements.txt
-commands = python -m tests.test_sandbox {posargs}
+commands =
+    python -m tests.test_sandbox {posargs}
 passenv = *
 
 [testenv:validation]
 deps = -r{toxinidir}/requirements_dev.txt
-commands = python -m tests.test_validation {posargs}
+commands =
+    python -m tests.test_validation {posargs}
 passenv = *

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
     {envpython} -m tests.test_sandbox {posargs}
 passenv = *
 
-[testenv:validation]
+[testenv:py{27,36,37,38,39}-validation]
 deps = -r{toxinidir}/requirements_dev.txt
 commands =
     {envpython} -m tests.test_validation {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps = -r{toxinidir}/requirements_dev.txt
     sphinx32: sphinx>=3.2,<3.3
     sphinx33: sphinx>=3.3,<3.4
 commands =
-    python -m tests {posargs}
+    {envpython} -m tests {posargs}
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 usedevelop = true
@@ -39,11 +39,11 @@ commands =
 [testenv:sandbox]
 deps = -r{toxinidir}/tests/sandbox/requirements.txt
 commands =
-    python -m tests.test_sandbox {posargs}
+    {envpython} -m tests.test_sandbox {posargs}
 passenv = *
 
 [testenv:validation]
 deps = -r{toxinidir}/requirements_dev.txt
 commands =
-    python -m tests.test_validation {posargs}
+    {envpython} -m tests.test_validation {posargs}
 passenv = *


### PR DESCRIPTION
This is a generic maintenance effort to help cleanup a series of issues observed and other desired cleanup actions before attempting to do release testing. This request includes the following changes (where individual commit messages provide more details):

- builder: do not fold various info lines
- builder: generate a proper publish point
- builder: simplify info logging
- intersphinx: generate proper uri based off cloud/server instance
- intersphinx: support python 2.7
- test: only force index root document for older versions
- tox: cleanup tox configuration
- tox: explicit interpreter invoke
- tox: provide additional interpreter env for validation testing