### PR TITLE
tox: allow generic validation environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
     {envpython} -m tests.test_sandbox {posargs}
 passenv = *
 
-[testenv:py{27,36,37,38,39}-validation]
+[testenv:{,py27-,py36-,py37-,py38-,py39-}validation]
 deps = -r{toxinidir}/requirements_dev.txt
 commands =
     {envpython} -m tests.test_validation {posargs}


### PR DESCRIPTION
With changes \[1\] to tox's environment list to support specific Python interpreters in a validation test, the previous change now prevents the flexibility of a developer wanting to do a validation test without caring which interpreter is being used:

    tox -e validation

This commit restores the ability to run the above command.

\[1\]: 74095765382851975d3a06a5467b919752db2e65