### PR TITLE
workflows: ensure linters are run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,8 @@ jobs:
             - { os:   macos-latest, python: 3.9, toxenv: py39-sphinx33, cache: ~/Library/Caches/pip }
             - { os: windows-latest, python: 2.7, toxenv: py27-sphinx18, cache: ~\AppData\Local\pip\Cache }
             - { os: windows-latest, python: 3.9, toxenv: py39-sphinx33, cache: ~\AppData\Local\pip\Cache }
+            - { os:  ubuntu-latest, python: 3.9, toxenv:        flake8, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: 3.9, toxenv:        pylint, cache: ~/.cache/pip }
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
When porting over to GitHub actions, the linter checks were accidentally excluded from the original set of configurations to run; correcting.