### PR TITLE
storage: properly build reftarget download roles

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1336,6 +1336,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         uri = self._escape_sf(uri)
 
         if uri.find('://') != -1:
+            self.body.append(self._start_tag(node, 'strong'))
+            self.context.append(self._end_tag(node, suffix=''))
             self.body.append(self._start_tag(node, 'a', **{'href': uri}))
             self.context.append(self._end_tag(node, suffix=''))
         else:
@@ -1377,6 +1379,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
     def depart_download_reference(self, node):
         self.body.append(self.context.pop()) # a
+        self.body.append(self.context.pop()) # strong
 
     # ---------------
     # sphinx -- hlist

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1373,7 +1373,10 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 self.body.append(self._end_ac_plain_text_link_body_macro(node))
                 self.body.append(self._end_ac_link(node))
 
-        raise nodes.SkipNode
+            raise nodes.SkipNode
+
+    def depart_download_reference(self, node):
+        self.body.append(self.context.pop()) # a
 
     # ---------------
     # sphinx -- hlist


### PR DESCRIPTION
While the `:download:` role helps users link to a non-reST documents, it can sometimes be used to build a link to a target (observed in the `html` builder). The original implementation for `visit_download_reference` built the link, but never properly closed the tags (the node was skipped instead of processing inwards and eventually departing); this commit corrects.

In addition, when a user uses a `:download:` role in the `html` builder to build a reference link, the link is strong’ed. Mimic the same display style when building the same type of reference.