### PR TITLE
publisher: correct unreconciled check

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -531,7 +531,7 @@ class ConfluencePublisher():
                 try:
                     self.rest_client.put('content', page['id'], updatePage)
                 except ConfluenceBadApiError as ex:
-                    if str(ex).find('unreconciled'):
+                    if str(ex).find('unreconciled') != -1:
                         raise ConfluenceUnreconciledPageError(
                             page_name, page['id'], self.server_url, ex)
 


### PR DESCRIPTION
A previous commit \[1\] introduced a user error message to help deal with a Confluence reported unreconciled page scenario. However, the conditional check added did not properly check the return value; correcting.

\[1\]: 86fd30ec12c7a15158df0a1b2e79ae8bd675eb48