### PR TITLE
storage: only inject trailing dt tag for last term

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -345,7 +345,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self.context.pop()) # em
 
     def visit_definition(self, node):
-        self.body.append(self.context.pop()) # dt
+        if self._has_term:
+            self.body.append(self.context.pop()) # dt
+            self._has_term = False
 
         self.body.append(self._start_tag(node, 'dd', suffix=self.nl))
         self.context.append(self._end_tag(node))


### PR DESCRIPTION
When a definition inside a definition includes a term, the implementation will flag the detection of a term to ensure required closing flags are populated (as it attempts to process one or more terms). However, in the event that a following definition entry does not have a term defined, it will improperly try to pop a non-existent `dt` tag. Correct this by unmarking the has-term flag after closing the previously open term tag.