### PR TITLE
handle internal document references with refdocname set

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -845,10 +845,11 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 node['refid'] = node['refuri'][1:]
                 del node['refuri']
                 self._visit_reference_intern_id(node)
-            elif 'internal' not in node or not node['internal']:
-                self._visit_reference_extern(node)
-            else:
+            elif 'refdocname' in node or (
+                    'internal' in node and node['internal']):
                 self._visit_reference_intern_uri(node)
+            else:
+                self._visit_reference_extern(node)
         elif 'refid' in node:
             self._visit_reference_intern_id(node)
 


### PR DESCRIPTION
Typically, when a reference for a document is found pointing to another document in the same project, an `internal` flag is set. This is used in the reference processing to build a macro link to another page in Confluence. It has recently been observed that some extensions also build internal document references with a `refdocname` value specified. This commit tweaks the reference building operation by accepting either the `internal` flag or `refdocname` attribute as an indication that the reference is an internal link, and build accordingly.