### PR TITLE
handle missing images

### DIFF
--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -157,6 +157,9 @@ class ConfluenceAssetManager:
             uri = node['uri']
             if not uri.startswith('data:') and uri.find('://') == -1:
                 path = self._interpretAssetPath(node)
+                if not path:
+                    continue
+
                 if path not in self.path2asset:
                     hash = ConfluenceUtil.hashAsset(path)
                     type = guess_mimetype(path, default=DEFAULT_CONTENT_TYPE)
@@ -170,6 +173,9 @@ class ConfluenceAssetManager:
             target = node['reftarget']
             if target.find('://') == -1:
                 path = self._interpretAssetPath(node)
+                if not path:
+                    continue
+
                 if path not in self.path2asset:
                     hash = ConfluenceUtil.hashAsset(path)
                     type = guess_mimetype(path, default=DEFAULT_CONTENT_TYPE)
@@ -272,5 +278,9 @@ class ConfluenceAssetManager:
                 # based on the output directory
                 if not os.path.isfile(abspath):
                     abspath = os.path.join(self.outdir, path)
+
+        # if no asset can be found, ensure a `None` path is returned
+        if not os.path.isfile(abspath):
+            abspath = None
 
         return abspath

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1298,6 +1298,10 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._end_ac_image(node))
         else:
             image_key, hosting_docname = self.assets.fetch(node)
+            if not image_key:
+                self.warn('unable to find image: ' '{}'.format(node['uri']))
+                raise nodes.SkipNode
+
             hosting_doctitle = ConfluenceState.title(
                 hosting_docname, hosting_docname)
             hosting_doctitle = self._escape_sf(hosting_doctitle)
@@ -1342,6 +1346,11 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.context.append(self._end_tag(node, suffix=''))
         else:
             file_key, hosting_docname = self.assets.fetch(node)
+            if not file_key:
+                self.warn('unable to find download: ' '{}'.format(
+                    node['reftarget']))
+                raise nodes.SkipNode
+
             hosting_doctitle = ConfluenceState.title(hosting_docname)
             hosting_doctitle = self._escape_sf(hosting_doctitle)
 


### PR DESCRIPTION
While many checks exist to help determine a resource's path, there can be times where a resource may be unavailable. For example, if an extension prepares image nodes with paths that do not immediately exist (e.g. if it assumes that something else will provide them, or the external extension is experiencing an issue), the node will still need to be processed by this extension. If the event that a post-build reftarget/uri points to an unknown asset, generate a warning message and skip the node (instead of hard failing).