### PR TITLE
support expand macro

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -7,6 +7,7 @@
 from .builder import ConfluenceBuilder
 from .directives import JiraDirective
 from .directives import JiraIssueDirective
+from .directives import ConfluenceExpandDirective
 from .directives import ConfluenceMetadataDirective
 from .logger import ConfluenceLogger
 from .nodes import jira
@@ -214,6 +215,7 @@ def setup(app):
     if not docutils.is_node_registered(confluence_metadata):
         app.add_node(confluence_metadata)
     """Wires up the directives themselves"""
+    app.add_directive('confluence_expand', ConfluenceExpandDirective)
     app.add_directive('confluence_metadata', ConfluenceMetadataDirective)
 
     # inject the compatible autosummary nodes if the extension is loaded

--- a/sphinxcontrib/confluencebuilder/directives.py
+++ b/sphinxcontrib/confluencebuilder/directives.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2016-2019 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2016-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
 from .nodes import jira
@@ -9,6 +9,7 @@ from .nodes import jira_issue
 from .nodes import confluence_metadata
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
+from sphinxcontrib.confluencebuilder.nodes import confluence_expand
 from uuid import UUID
 
 def string_list(argument):
@@ -33,6 +34,23 @@ def string_list(argument):
                     data.append(label)
 
     return data
+
+class ConfluenceExpandDirective(Directive):
+    has_content = True
+    option_spec = {
+        'title': directives.unchanged,
+    }
+
+    def run(self):
+        self.assert_has_content()
+        text = '\n'.join(self.content)
+
+        node = confluence_expand(rawsource=text)
+        if 'title' in self.options:
+            node['title'] = self.options['title']
+
+        self.state.nested_parse(self.content, self.content_offset, node)
+        return [node]
 
 class ConfluenceMetadataDirective(Directive):
     has_content = False

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2019 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2019-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
 from docutils import nodes
@@ -24,6 +24,14 @@ class ConfluenceNavigationNode(nodes.General, nodes.Element):
 
         self.bottom = False
         self.top = False
+
+class confluence_expand(nodes.Element):
+    """
+    confluence expand node
+
+    A Confluence builder defined expand node serves as a hint to wrap content
+    using Confluence's expand macro.
+    """
 
 class confluence_metadata(nodes.Element):
     """

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -61,6 +61,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.can_anchor = 'anchor' not in restricted
         self.can_children = 'children' not in restricted
         self.can_code = 'code' not in restricted
+        self.can_expand = 'expand' not in restricted
         self.can_jira = 'jira' not in restricted
         self.can_viewfile = 'viewfile' not in restricted
 
@@ -1641,6 +1642,21 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                     'clear: both; padding-top: 10px; margin-bottom: 30px'}))
         else:
             self.body.append('<div style="clear: both"> </div>\n')
+
+    def visit_confluence_expand(self, node):
+        if not self.can_expand:
+            raise nodes.SkipNode
+
+        self.body.append(self._start_ac_macro(node, 'expand'))
+        if 'title' in node:
+            self.body.append(
+                self._build_ac_parameter(node, 'title', node['title']))
+        self.body.append(self._start_ac_rich_text_body_macro(node))
+        self.context.append(self._end_ac_rich_text_body_macro(node) +
+            self._end_ac_macro(node))
+
+    def depart_confluence_expand(self, node):
+        self.body.append(self.context.pop()) # macro
 
     # ------------------------------------------
     # confluence-builder -- enhancements -- jira


### PR DESCRIPTION
Introduces support for Confluence's "Expand" macro \[1\].

\[1\]: https://confluence.atlassian.com/doc/expand-macro-223222352.html