### PR TITLE
cleanup imports/copyright statements for consistency

### DIFF
--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -1,13 +1,3 @@
 # -*- coding: utf-8 -*-
-"""
-    sphinxcontrib
-    ~~~~~~~~~~~~~
-
-    This package is a namespace package that contains all extensions
-    distributed in the ``sphinx-contrib`` distribution.
-
-    :copyright: Copyright 2007-2009 by the Sphinx team, see AUTHORS.
-    :license: BSD, see LICENSE for details.
-"""
 
 __import__('pkg_resources').declare_namespace(__name__)

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -4,18 +4,18 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from .builder import ConfluenceBuilder
-from .directives import JiraDirective
-from .directives import JiraIssueDirective
-from .directives import ConfluenceExpandDirective
-from .directives import ConfluenceMetadataDirective
-from .logger import ConfluenceLogger
-from .nodes import jira
-from .nodes import jira_issue
-from .nodes import confluence_metadata
-from .singlebuilder import SingleConfluenceBuilder
 from sphinx.util import docutils
 from sphinx.writers.text import STDINDENT
+from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
+from sphinxcontrib.confluencebuilder.directives import ConfluenceExpandDirective
+from sphinxcontrib.confluencebuilder.directives import ConfluenceMetadataDirective
+from sphinxcontrib.confluencebuilder.directives import JiraDirective
+from sphinxcontrib.confluencebuilder.directives import JiraIssueDirective
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
+from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
+from sphinxcontrib.confluencebuilder.nodes import jira
+from sphinxcontrib.confluencebuilder.nodes import jira_issue
+from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
 from sphinxcontrib.confluencebuilder.translator.storage import ConfluenceStorageFormatTranslator
 import argparse
 

--- a/sphinxcontrib/confluencebuilder/__main__.py
+++ b/sphinxcontrib/confluencebuilder/__main__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2017-2018 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2017-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
 import sphinxcontrib.confluencebuilder

--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -4,11 +4,11 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from .std.confluence import INVALID_CHARS
-from .util import ConfluenceUtil
 from docutils import nodes
 from sphinx import addnodes
 from sphinx.util.images import guess_mimetype
+from sphinxcontrib.confluencebuilder.std.confluence import INVALID_CHARS
+from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
 import os
 
 """

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -7,17 +7,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
-from .assets import ConfluenceAssetManager
-from .config import ConfluenceConfig
-from .exceptions import ConfluenceConfigurationError
-from .logger import ConfluenceLogger
-from .nodes import ConfluenceNavigationNode
-from .nodes import confluence_metadata
-from .publisher import ConfluencePublisher
-from .state import ConfluenceState
-from .util import ConfluenceUtil
-from .util import first
-from .writer import ConfluenceWriter
 from docutils import nodes
 from docutils.io import StringOutput
 from getpass import getpass
@@ -29,7 +18,18 @@ from sphinx.errors import ExtensionError
 from sphinx.locale import __
 from sphinx.util import status_iterator
 from sphinx.util.osutil import ensuredir
+from sphinxcontrib.confluencebuilder.assets import ConfluenceAssetManager
+from sphinxcontrib.confluencebuilder.config import ConfluenceConfig
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.intersphinx import build_intersphinx
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
+from sphinxcontrib.confluencebuilder.nodes import ConfluenceNavigationNode
+from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
+from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
+from sphinxcontrib.confluencebuilder.state import ConfluenceState
+from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
+from sphinxcontrib.confluencebuilder.util import first
+from sphinxcontrib.confluencebuilder.writer import ConfluenceWriter
 import io
 import sys
 

--- a/sphinxcontrib/confluencebuilder/compat.py
+++ b/sphinxcontrib/confluencebuilder/compat.py
@@ -4,9 +4,9 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from .logger import ConfluenceLogger
 from sphinx.locale import __
 from sphinx.util.console import bold # pylint: disable=no-name-in-module
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 
 # load sphinx's progress_message or use a compatible instance
 try:

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -4,7 +4,7 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from .logger import ConfluenceLogger
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 import os.path
 
 try:

--- a/sphinxcontrib/confluencebuilder/directives.py
+++ b/sphinxcontrib/confluencebuilder/directives.py
@@ -4,12 +4,12 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from .nodes import jira
-from .nodes import jira_issue
-from .nodes import confluence_metadata
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 from sphinxcontrib.confluencebuilder.nodes import confluence_expand
+from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
+from sphinxcontrib.confluencebuilder.nodes import jira
+from sphinxcontrib.confluencebuilder.nodes import jira_issue
 from uuid import UUID
 
 def string_list(argument):

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2017-2020 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2017-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
 from sphinx.errors import ConfigError

--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2017 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2017-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
 from sphinx.util import logging

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -8,13 +8,13 @@ See also:
     https://docs.atlassian.com/confluence/REST/latest/
 """
 
-from .exceptions import ConfluenceBadApiError
-from .exceptions import ConfluenceBadSpaceError
-from .exceptions import ConfluenceConfigurationError
-from .exceptions import ConfluencePermissionError
-from .exceptions import ConfluenceUnreconciledPageError
-from .logger import ConfluenceLogger
-from .rest import Rest
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadApiError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadSpaceError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluencePermissionError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceUnreconciledPageError
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
+from sphinxcontrib.confluencebuilder.rest import Rest
 import json
 import time
 

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -4,16 +4,16 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from .exceptions import ConfluenceAuthenticationFailedUrlError
-from .exceptions import ConfluenceBadApiError
-from .exceptions import ConfluenceBadServerUrlError
-from .exceptions import ConfluenceCertificateError
-from .exceptions import ConfluencePermissionError
-from .exceptions import ConfluenceProxyPermissionError
-from .exceptions import ConfluenceSeraphAuthenticationFailedUrlError
-from .exceptions import ConfluenceSslError
-from .exceptions import ConfluenceTimeoutError
-from .std.confluence import API_REST_BIND_PATH
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceAuthenticationFailedUrlError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadApiError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadServerUrlError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceCertificateError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluencePermissionError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceProxyPermissionError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceSeraphAuthenticationFailedUrlError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceSslError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceTimeoutError
+from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
 from requests.adapters import HTTPAdapter
 import json
 import requests

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -5,14 +5,14 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from .builder import ConfluenceBuilder
-from .compat import progress_message
-from .logger import ConfluenceLogger
-from .state import ConfluenceState
 from docutils import nodes
 from sphinx.locale import __
 from sphinx.util.console import darkgreen # pylint: disable=no-name-in-module
 from sphinx.util.nodes import inline_all_toctrees
+from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
+from sphinxcontrib.confluencebuilder.compat import progress_message
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
+from sphinxcontrib.confluencebuilder.state import ConfluenceState
 
 class SingleConfluenceBuilder(ConfluenceBuilder):
     name = 'singleconfluence'

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2017-2018 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2017-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
-from .logger import ConfluenceLogger
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 
 """
 maximum length for a confluence page title

--- a/sphinxcontrib/confluencebuilder/std/__init__.py
+++ b/sphinxcontrib/confluencebuilder/std/__init__.py
@@ -1,7 +1,3 @@
 # -*- coding: utf-8 -*-
-"""
-    :copyright: Copyright 2018 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
-"""
 
 __import__('pkg_resources').declare_namespace(__name__)

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2017-2020 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2017-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
-from .sphinx import DEFAULT_HIGHLIGHT_STYLE
+from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_HIGHLIGHT_STYLE
 
 """
 confluence trailing bind path for rest api

--- a/sphinxcontrib/confluencebuilder/std/sphinx.py
+++ b/sphinxcontrib/confluencebuilder/std/sphinx.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2018-2019 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2018-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
 from __future__ import absolute_import

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2018-2020 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2018-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
-from .std.confluence import API_REST_BIND_PATH
+from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
 from hashlib import sha256
 
 class ConfluenceUtil:

--- a/sphinxcontrib/confluencebuilder/writer.py
+++ b/sphinxcontrib/confluencebuilder/writer.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 """
-    :copyright: Copyright 2016-2018 by the contributors (see AUTHORS file).
-    :license: BSD-2-Clause, see LICENSE for details.
+:copyright: Copyright 2016-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
 """
 
-from __future__ import (absolute_import, print_function, unicode_literals)
-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 from docutils import writers
-
 
 class ConfluenceWriter(writers.Writer):
     supported = ('text',)


### PR DESCRIPTION
Adjust all relative based imports into absolute imports to use a consistent importing style across all implementation files. This change also tweaks the respective copyright statements to be consistent as well.