### PR TITLE
consistent intermediate files base folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,18 +3,20 @@ __pycache__/
 *.py[cod]
 
 # building, packaging, etc.
-*.egg-info/
-build/
-dist/
+/*.egg-info/
+/build/
+/dist/
 
 # documentation
-doc/_build/
+/doc/_build/
 
 # platform-specific
 .DS_Store
 
 # testing
-.tox*/
+/.tox*/
+/output/
+/sandbox-*/
 validation_test_overrides.py
 
 # misc

--- a/sandbox/.gitignore
+++ b/sandbox/.gitignore
@@ -3,4 +3,4 @@
 
 # with the exceptions below
 !.gitignore
-!README
+!README.rst

--- a/sandbox/README.rst
+++ b/sandbox/README.rst
@@ -7,4 +7,4 @@ invoking with the following command:
 
 .. code-block:: shell
 
-   tox -e sandbox
+    tox -e sandbox

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,5 +1,0 @@
-# testing output directory
-output/
-
-# duplicate sandbox environments (development environment)
-sandbox-*/

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -122,7 +122,8 @@ def prepareDirectories(container):
     """
     assert container
     lib_dir = os.path.dirname(os.path.realpath(__file__))
-    base_dir = os.path.join(lib_dir, os.pardir)
+    test_dir = os.path.join(lib_dir, os.pardir)
+    base_dir = os.path.join(test_dir, os.pardir)
     output_dir = os.path.join(base_dir, 'output')
     container_dir = os.path.join(output_dir, container)
     doc_dir = os.path.join(container_dir, 'build')

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -16,7 +16,8 @@ import sys
 
 def process_sandbox(target_sandbox, builder=None, defines=None):
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    sandbox_dir = os.path.join(test_dir, target_sandbox)
+    base_dir = os.path.join(test_dir, os.pardir)
+    sandbox_dir = os.path.join(base_dir, target_sandbox)
 
     doc_dir, doctree_dir = prepareDirectories('sandbox-test')
     buildSphinx(sandbox_dir, doc_dir, doctree_dir, builder=builder,
@@ -24,7 +25,8 @@ def process_sandbox(target_sandbox, builder=None, defines=None):
 
 def process_raw_upload(target_sandbox):
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    sandbox_dir = os.path.join(test_dir, target_sandbox)
+    base_dir = os.path.join(test_dir, os.pardir)
+    sandbox_dir = os.path.join(base_dir, target_sandbox)
     raw_file = os.path.join(sandbox_dir, 'raw.conf')
 
     if not os.path.exists(raw_file):


### PR DESCRIPTION
Builds and tox generated output is typically stored inside a developer's root repository directory. Some testing output (e.g. Sphinx generated output in unit testing) is stored in temporary folders found inside the `tests` folder. It may be ideal to have a consistent location for intermediate folders/files, in the base directory, to:

- Avoid the need to navigate into the tests folder when constantly inspecting output.
- When manually inspecting the repository, knowing that only intermediate files will be found in the root.