### PR TITLE
introduce publish denylist

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -7,6 +7,7 @@
 from sphinx.util import docutils
 from sphinx.writers.text import STDINDENT
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
+from sphinxcontrib.confluencebuilder.config import handle_config_inited
 from sphinxcontrib.confluencebuilder.directives import ConfluenceExpandDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceMetadataDirective
 from sphinxcontrib.confluencebuilder.directives import JiraDirective
@@ -157,8 +158,10 @@ def setup(app):
     app.add_config_value('confluence_parent_page_id_check', None, False)
     """Proxy server needed to communicate with Confluence server."""
     app.add_config_value('confluence_proxy', None, False)
-    """Subset of document names to publish"""
-    app.add_config_value('confluence_publish_subset', [], False)
+    """Subset of documents which are allowed to be published."""
+    app.add_config_value('confluence_publish_allowlist', None, False)
+    """Subset of documents which are denied to be published."""
+    app.add_config_value('confluence_publish_denylist', None, False)
     """Authentication passthrough for Confluence REST interaction."""
     app.add_config_value('confluence_server_auth', None, False)
     """Cookie(s) to use for Confluence REST interaction."""
@@ -198,6 +201,10 @@ def setup(app):
     """Indent to use for generated documents."""
     app.add_config_value('confluence_indent', STDINDENT, False)
 
+    """(configuration - deprecated)"""
+    # replaced by confluence_publish_allowlist
+    app.add_config_value('confluence_publish_subset', None, False)
+
     # ##########################################################################
 
     """JIRA directives"""
@@ -217,6 +224,10 @@ def setup(app):
     """Wires up the directives themselves"""
     app.add_directive('confluence_expand', ConfluenceExpandDirective)
     app.add_directive('confluence_metadata', ConfluenceMetadataDirective)
+
+    # hook onto configuration initialization to finalize its state before
+    # passing it to the builder (e.g. handling deprecated options)
+    app.connect('config-inited', handle_config_inited)
 
     # inject the compatible autosummary nodes if the extension is loaded
     def inject_autosummary_notes_hook(app):

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -198,17 +198,24 @@ class ConfluenceBuilder(Builder):
         else:
             self.space_name = None
 
-        def prepare_subset(value):
+        def prepare_subset(option):
+            value = getattr(config, option)
+            if value is None:
+                return None
+
+            # if provided via command line, treat as a list
+            if option in config['overrides']:
+                value = value.split(',')
+
             if isinstance(value, basestring):
                 files = extract_strings_from_file(value)
             else:
                 files = value
+
             return set(files) if files else None
 
-        self.publish_allowlist = prepare_subset(
-            config.confluence_publish_allowlist)
-        self.publish_denylist = prepare_subset(
-            config.confluence_publish_denylist)
+        self.publish_allowlist = prepare_subset('confluence_publish_allowlist')
+        self.publish_denylist = prepare_subset('confluence_publish_denylist')
 
     def get_outdated_docs(self):
         """

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -28,10 +28,16 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
+from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import first
 from sphinxcontrib.confluencebuilder.writer import ConfluenceWriter
 import io
 import sys
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 # load graphviz extension if available to handle node pre-processing
 try:
@@ -82,10 +88,14 @@ class ConfluenceBuilder(Builder):
         self.nav_next = {}
         self.nav_prev = {}
         self.omitted_docnames = []
+        self.publish_allowlist = []
+        self.publish_denylist = []
         self.publish_docnames = []
         self.publisher = ConfluencePublisher()
         self.secnumber_suffix = self.config.confluence_secnumber_suffix
         self.secnumbers = {}
+        self.verbose = ConfluenceLogger.verbose
+        self.warn = ConfluenceLogger.warn
         self._original_get_doctree = None
 
         if 'graphviz_output_format' in self.config:
@@ -100,6 +110,7 @@ class ConfluenceBuilder(Builder):
     def init(self, suppress_conf_check=False):
         if not ConfluenceConfig.validate(self, not suppress_conf_check):
             raise ConfluenceConfigurationError('configuration error')
+        config = self.config
 
         if self.config.confluence_publish:
             if self.config.confluence_ask_user:
@@ -187,10 +198,17 @@ class ConfluenceBuilder(Builder):
         else:
             self.space_name = None
 
-        if self.config.confluence_publish_subset:
-            self.publish_subset = set(self.config.confluence_publish_subset)
-        else:
-            self.publish_subset = None
+        def prepare_subset(value):
+            if isinstance(value, basestring):
+                files = extract_strings_from_file(value)
+            else:
+                files = value
+            return set(files) if files else None
+
+        self.publish_allowlist = prepare_subset(
+            config.confluence_publish_allowlist)
+        self.publish_denylist = prepare_subset(
+            config.confluence_publish_denylist)
 
     def get_outdated_docs(self):
         """
@@ -526,9 +544,9 @@ class ConfluenceBuilder(Builder):
 
     def publish_purge(self):
         if self.config.confluence_purge:
-            if self.publish_subset:
-                ConfluenceLogger.warn('confluence_purge disabled due to '
-                                      'confluence_publish_subset')
+            if self.publish_allowlist or self.publish_denylist:
+                self.warn('confluence_purge disabled due to '
+                    'confluence_publish_allowlist/confluence_publish_denylist')
                 return
 
             if self.legacy_pages:
@@ -567,7 +585,8 @@ class ConfluenceBuilder(Builder):
                     self.publish_docnames, 'publishing documents... ',
                     length=len(self.publish_docnames),
                     verbosity=self.app.verbosity):
-                if self.publish_subset and docname not in self.publish_subset:
+                if self._check_publish_skip(docname):
+                    self.verbose(docname + ' skipped due to configuration')
                     continue
                 docfile = path.join(self.outdir, self.file_transform(docname))
 
@@ -588,7 +607,8 @@ class ConfluenceBuilder(Builder):
                     length=len(assets), verbosity=self.app.verbosity,
                     stringify_func=to_asset_name):
                 key, absfile, type, hash, docname = asset
-                if self.publish_subset and docname not in self.publish_subset:
+                if self._check_publish_skip(docname):
+                    self.verbose(key + ' skipped due to configuration')
                     continue
 
                 try:
@@ -648,6 +668,25 @@ class ConfluenceBuilder(Builder):
             navnode.append(reference)
 
         return navnode
+
+    def _check_publish_skip(self, docname):
+        """
+        check publishing should be skipped for the provided docname
+
+        A runner's configuration may have an explicit list of docnames to either
+        allow or deny publishing. Check if the provided docname has been flagged
+        to be skipped.
+
+        Args:
+            docname: the docname to check
+        """
+        if self.publish_denylist and docname in self.publish_denylist:
+            return True
+
+        if self.publish_allowlist and docname not in self.publish_allowlist:
+            return True
+
+        return False
 
     def _extract_metadata(self, docname, doctree):
         """

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -5,12 +5,32 @@
 """
 
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
+from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 import os.path
 
 try:
     basestring
 except NameError:
     basestring = str
+
+def handle_config_inited(app, config):
+    """
+    hook on when a configuration has been initialized
+
+    Invoked when a configuration has been initialized by the Sphinx application.
+    This event will be handled to process long term support for various options.
+
+    Args:
+        app: the application instance
+        config: the configuration
+    """
+
+    def handle_legacy(new, orig):
+        if getattr(config, new) is None and getattr(config, orig) is not None:
+            config[new] = config[orig]
+
+    # copy over deprecated configuration names to new names
+    handle_legacy('confluence_publish_allowlist', 'confluence_publish_subset')
 
 class ConfluenceConfig:
     """
@@ -20,6 +40,7 @@ class ConfluenceConfig:
     configuration to ensure the building/publishing environment is using sane
     options.
     """
+    _tracked_deprecated = []
 
     @staticmethod
     def validate(builder, log=True):
@@ -100,23 +121,66 @@ defined maximum document depth must be defined as an integer value (not a float,
 string, etc.).
 """)
 
-        if c.confluence_publish_subset:
-            if not (isinstance(c.confluence_publish_subset, (tuple, list, set))
-                    and all(isinstance(docname, basestring)
-                            for docname in c.confluence_publish_subset)):
+        # ######################################################################
+
+        publish_list_options = [
+            'confluence_publish_allowlist',
+            'confluence_publish_denylist',
+        ]
+
+        for option in publish_list_options:
+            value = getattr(c, option)
+            if value is None:
+                continue
+
+            if not (isinstance(value, (tuple, list, set, basestring))):
                 errState = True
                 if log:
                     ConfluenceLogger.error(
-"""'confluence_publish_subset' should be a collection of strings""")
-            else:
-                for docname in c.confluence_publish_subset:
-                    if not any(os.path.isfile(os.path.join(env.srcdir,
-                                                           docname + suffix))
-                               for suffix in c.source_suffix):
+"""invalid {} value
+
+The value type permitted for this publish list option can either be a list of
+document names or a string pointing to a file containing documents.
+""".format(option))
+            elif value:
+                files = []
+                if isinstance(value, basestring):
+                    if os.path.isfile(value):
+                        files = extract_strings_from_file(value)
+                    else:
                         errState = True
                         if log:
                             ConfluenceLogger.error(
-"""Document '%s' in 'confluence_publish_subset' not found""", docname)
+"""invalid {} filename
+
+The filename provided in this option cannot be found on the system.
+""".format(option))
+                elif not (isinstance(value, (tuple, list, set)) and
+                        all(isinstance(doc, basestring) for doc in value)):
+                    errState = True
+                    if log:
+                        ConfluenceLogger.error(
+"""invalid contents in {}
+
+The values provided in this option should be a collection of strings.
+""".format(option))
+                else:
+                    files = value
+
+                for docname in files:
+                    if not any(
+                            os.path.isfile(
+                                os.path.join(env.srcdir, docname + suffix))
+                            for suffix in c.source_suffix):
+                        errState = True
+                        if log:
+                            ConfluenceLogger.error(
+"""missing document in {}
+
+The document name {} provided in this option cannot be found on the system.
+""".format(option, docname))
+
+        # ######################################################################
 
         if c.confluence_publish:
             if not c.confluence_parent_page:
@@ -229,5 +293,17 @@ Ensure the value is set to a proper file path and the file exists.
                             )
 
                 c.confluence_client_cert = cert_files
+
+        # inform users of a deprecated configuration being used
+        deprecated_configs = {
+            'confluence_publish_subset':
+                'use "confluence_publish_allowlist" instead',
+        }
+
+        cls = ConfluenceConfig
+        for key, msg in deprecated_configs.items():
+            if c[key] is not None and key not in cls._tracked_deprecated:
+                cls._tracked_deprecated.append(key)
+                ConfluenceLogger.warn('config "%s" deprecated; %s' % (key, msg))
 
         return not errState

--- a/sphinxcontrib/confluencebuilder/config.py
+++ b/sphinxcontrib/confluencebuilder/config.py
@@ -133,6 +133,10 @@ string, etc.).
             if value is None:
                 continue
 
+            # if provided via command line, treat as a list
+            if option in c['overrides']:
+                value = value.split(',')
+
             if not (isinstance(value, (tuple, list, set, basestring))):
                 errState = True
                 if log:

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -6,6 +6,7 @@
 
 from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
 from hashlib import sha256
+import os
 
 class ConfluenceUtil:
     """
@@ -59,6 +60,32 @@ class ConfluenceUtil:
             elif not url.endswith('/'):
                 url += '/'
         return url
+
+def extract_strings_from_file(filename):
+    """
+    extracts strings from a provided filename
+
+    Returns the a list of extracted strings found in a provided filename.
+    Entries are stripped when processing and lines leading with a comment are
+    ignored.
+
+    Args:
+        filename: the filename
+
+    Returns:
+        the list of strings
+    """
+    filelist = []
+
+    if os.path.isfile(filename):
+        with open(filename) as f:
+            for raw_line in f:
+                line = raw_line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                filelist.append(line)
+
+    return filelist
 
 def first(it):
     """

--- a/tests/unit-tests/common/assets/sample-invalid-publish-list
+++ b/tests/unit-tests/common/assets/sample-invalid-publish-list
@@ -1,0 +1,4 @@
+# example allow/deny list with valid document names
+admonitions
+zitations
+tables

--- a/tests/unit-tests/common/assets/sample-valid-publish-list
+++ b/tests/unit-tests/common/assets/sample-valid-publish-list
@@ -1,0 +1,4 @@
+# example allow/deny list with an incorrect document name
+admonitions
+citations
+tables


### PR DESCRIPTION
This commit introduces the ability for a user to create a list of documents to not publish. This is to compliment the existing `confluence_publish_subset` configuration, where users may wish to define a list of documents not to publish, over documents to publish.

This commit also reworks the original `confluence_publish_subset` configuration to be renamed to `confluence_publish_allowlist`. The older configuration name is still supported for an interim.

For both configurations, aside from a collection of documents to register for an option, these options now also support accepting a filename (string instead of a list), which may hold a list of documents to apply to the configuration.