### PR TITLE
validator: add more target options for validator

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,15 @@ on:
         description: 'Python interpreter'
         required: true
         default: '3.9'
+      space:
+        description: 'Space'
+        default: 'DEVELOP'
+      test_key:
+        description: 'Test Key (Base Page)'
+        default: 'test-holder'
+      test_desc:
+        description: 'Test Description'
+        default: 'test state'
 
 jobs:
   build:
@@ -40,4 +49,7 @@ jobs:
     - name: tox
       env:
         CONFLUENCE_AUTH: ${{ secrets.CONFLUENCE_AUTH }}
+        CONFLUENCE_SPACE: ${{ github.event.inputs.space }}
+        CONFLUENCE_TEST_DESC: ${{ github.event.inputs.test_desc }}
+        CONFLUENCE_TEST_KEY: ${{ github.event.inputs.test_key }}
       run: tox -e validation

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -19,6 +19,9 @@ DEFAULT_TEST_SPACE = 'DEVELOP'
 DEFAULT_TEST_URL = 'https://sphinxcontrib-confluencebuilder.atlassian.net/wiki/'
 DEFAULT_TEST_USER = 'sphinxcontrib-confluencebuilder@jdknight.me'
 AUTH_ENV_KEY = 'CONFLUENCE_AUTH'
+SPACE_ENV_KEY = 'CONFLUENCE_SPACE'
+TESTDESC_ENV_KEY = 'CONFLUENCE_TEST_DESC'
+TESTKEY_ENV_KEY = 'CONFLUENCE_TEST_KEY'
 
 class TestConfluenceValidation(unittest.TestCase):
     @classmethod
@@ -31,15 +34,14 @@ class TestConfluenceValidation(unittest.TestCase):
         cls.config['confluence_page_hierarchy'] = True
         cls.config['confluence_parent_page'] = None
         cls.config['confluence_publish'] = True
-        cls.config['confluence_space_name'] = DEFAULT_TEST_SPACE
+        cls.config['confluence_space_name'] = os.getenv(
+            SPACE_ENV_KEY, DEFAULT_TEST_SPACE)
+        cls.config['confluence_server_pass'] = os.getenv(AUTH_ENV_KEY)
         cls.config['confluence_server_url'] = DEFAULT_TEST_URL
         cls.config['confluence_server_user'] = DEFAULT_TEST_USER
         cls.config['confluence_timeout'] = 1
-        cls.test_desc = DEFAULT_TEST_DESC
-        cls.test_key = DEFAULT_TEST_KEY
-
-        # configure ci authentication key (if set)
-        cls.config['confluence_server_pass'] = os.getenv(AUTH_ENV_KEY)
+        cls.test_desc = os.getenv(TESTDESC_ENV_KEY, DEFAULT_TEST_DESC)
+        cls.test_key = os.getenv(TESTDESC_ENV_KEY, DEFAULT_TEST_KEY)
 
         # overrides from user
         try:


### PR DESCRIPTION
Adding a series of options to the validator action, which include the target space name, the root page's name and the description value used on the root page.