### PR TITLE
maintenance 2020-12-13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 
 # testing
 /.tox*/
+/_build/
 /output/
 /sandbox-*/
 validation_test_overrides.py

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -64,7 +64,7 @@ except NameError:
 class ConfluenceBuilder(Builder):
     allow_parallel = True
     name = 'confluence'
-    format = 'confluence'
+    format = 'confluence_storage'
     supported_image_types = StandaloneHTMLBuilder.supported_image_types
     supported_remote_images = True
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -19,7 +19,11 @@ def process_sandbox(target_sandbox, builder=None, defines=None):
     base_dir = os.path.join(test_dir, os.pardir)
     sandbox_dir = os.path.join(base_dir, target_sandbox)
 
-    doc_dir, doctree_dir = prepareDirectories('sandbox-test')
+    container = 'sandbox-test'
+    if builder:
+        container += '-' + builder
+
+    doc_dir, doctree_dir = prepareDirectories(container)
     buildSphinx(sandbox_dir, doc_dir, doctree_dir, builder=builder,
         extra_config=defines, relax=True)
 


### PR DESCRIPTION
This is a generic maintenance effort to help cleanup a series of issues observed and other desired cleanup actions before attempting to do release testing. This request includes the following changes (where individual commit messages provide more details):

- .gitignore: ignore _build folder
- builder: set a more specific format
- tests: different output directories for unique sandbox builders