### PR TITLE
pre-release document maintenance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,25 +1,44 @@
-master
-======
+development
+===========
 
+* (note) support for sphinx v1.[6-7] has been dropped
+* (note) support for xml-rpc has been dropped
 * conflicting titles will be automatically adjusted to prevent publishing issues
 * enable page-specific title overrides via confluence_title_overrides
 * ensure configured title postfix is not trimmed in long titles
 * extend language mappings for supported storage format language types
+* fixed a series of scenarios where titles/missing images will fail a build
 * fixed issue when building heading which reference another document
+* fixed issue when processing a download role with a url
+* fixed issue where an anchor target may not generate a proper link
 * fixed issue where ask options would fail in python 2.7
 * fixed issue where ask options would prompt when not publishing
+* fixed issue where autosummary registration may fail
 * fixed issue where default alignment did not apply to a figure's legend
 * fixed issue where literal-marked includes would fail to publish
 * fixed issue where registering this extension caused issues with other builders
+* fixed issue where todo entries would render when disabled in configuration
 * fixed issue with previous-next links not generated for nested pages
-* improve previous-next button visualization
+* improve code macros rendering a title value when a caption is set
+* improve publishing when dealing with changing page title casing
+* improved built references by including title (alt) data if set
+* improved figure/section numbering
 * improved handling unknown code languages to none-styled (instead of python)
+* improved previous-next button visualization
+* introduce the expand directive
+* promote confluence_storage over confluence for raw type
+* support disabling titlefix on an index page
 * support for assigning confluence labels for pages
-* support for sphinx v1.[6-7] has been dropped
-* support for xml-rpc has been dropped
+* support for both allow and deny lists for published documents
+* support for centered directive
+* support for graphviz extension
+* support for hlist directive
+* support for inheritance-diagram extension
 * support publish dry runs
 * support single-page builder
+* support the generation of an inventory file (for intersphinx)
 * support users overriding default alignment
+* support width hints for tables
 
 1.2.0 (2020-01-03)
 ==================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,14 +1,9 @@
-contributing
+Contributing
 ============
 
 Contributions to this extension are welcome and much appreciated.
 
-.. contents::
-   :depth: 2
-
-.. sectnum::
-
-reporting issues
+Reporting issues
 ----------------
 
 Bugs, enhancements and more can be reported to this extension's GitHub
@@ -24,7 +19,7 @@ When reporting a bug, it is recommended to include at least the following:
 Additional logs from a ``sphinx-build`` attempt can be helpful as well (if
 applicable).
 
-submitting changes
+Submitting changes
 ------------------
 
 Contributions can be provided as `pull requests`_ to this extension's GitHub
@@ -34,7 +29,7 @@ project. New contributors should familiarize themselves with the following:
   confirmed with the inclusion of ``Signed-off-by`` in submitted commit
   messages.
 - Builds are required\* to pass to be accepted (\* with some exceptions in very
-  specific scenarios). When a pull request is submitted, continues integration
+  specific scenarios). When a pull request is submitted, continuous integration
   tests will be invoked. A developer can invoke ``tox`` at the root of the
   checked out repository to validate changes before submitting a pull request.
 - Keep a narrow scope for proposed changes. Submitting multiple feature changes
@@ -60,29 +55,29 @@ While maintainers will help strive to review, merge changes and provide support
 (when possible), the process may take some time. Please be patient and happy
 coding.
 
-guidelines
+Guidelines
 ----------
 
 This extension will support various Python interpreter versions, Sphinx versions
 and Confluence versions. The goal of this extension is to include support for
 all stable Python interpreters and Confluence versions which have yet to be
-marked as end-of-life and support Sphinx versions with a suggested maximum of
-five major-minor trees.
+marked as end-of-life as well as support Sphinx versions with a suggested
+maximum of five major-minor trees.
 
 - Python interpreters that have not been marked as end-of-life will be supported
   by this extension. An exception exists for Python 2.7 at this time where
-  support _may_ extend to the RHEL's supported end-of-life date for Python 2.7
+  support *may* extend to the RHEL's supported end-of-life date for Python 2.7
   of June 2024 (see also `How is Python 2 supported in RHEL after 2020?`_). Note
   that this is the maximum date for support; however, support may be dropped
-  earlier that this date (with a notification). At minimum, Python 2.7 will be
+  earlier than this date (with a notification). At minimum, Python 2.7 will be
   supported until the end of the 2020 calendar year (a year after Python's
   end-of-life date for Python 2.7).
 - Supported Confluence versions will be supported versions listed in
   `Atlassian Support End of Life Policy`_.
 - Supported Sphinx versions include the last five major-minor versions of the
-  application (for example: 3.2.x, 3.1.x, 3.0.x, 2.4.x, 2.3.x). An exception
-  exists for Sphinx 1.8.x series, which will be supported until this extension's
-  support for Python 2.7 has been dropped.
+  application (e.g. 3.2.x, 3.1.x, 3.0.x, 2.4.x, 2.3.x). An exception exists for
+  Sphinx 1.8.x series, which will be supported until this extension's support
+  for Python 2.7 has been dropped.
 
 `PEP 8`_ is a standard styling guide for Python projects and is recommended for
 considerations when making contributions. On that note, please read the

--- a/LICENSE
+++ b/LICENSE
@@ -1,25 +1,62 @@
-Copyright (c) 2012-2019 by the contributors (see AUTHORS file).
-Some rights reserved.
+License for Atlassian Confluence Builder for Sphinx
+===================================================
+
+Copyright (c) 2012-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
 DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------
+
+Licenses for incorporated software
+==================================
+
+----------------------------------------------------------------------
+Sphinx license::
+
+    Copyright (c) 2007-2020 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -1,11 +1,11 @@
-maintainers
+Maintainers
 ===========
 
 This document serves as a reminder/guide for maintainers for this extension. For
 users wishes to contribute to this extension, please consult `CONTRIBUTING.rst`_
 instead.
 
-system testing
+System testing
 --------------
 
 When a major release is made, it is recommended to perform system testing on all
@@ -14,13 +14,14 @@ Confluence Cloud with an organization account and a user account (tilde-leading)
 as well as all Confluence supported server revisions (consult
 `Atlassian Support End of Life Policy`_ for the most recent list).
 
-release steps
+Release steps
 -------------
 
 When implementation is deemed to be ready for a stable release, ensure the
 following steps are performed:
 
-- Update ``CHANGES.rst``, replacing master with release version and date.
+- Update ``CHANGES.rst``, replacing the development title with release version
+  and date.
 - Ensure version values in the implementation are incremented and tagged
   appropriately. The tagged commit should have a "clean" version string.
 - Ensure the release tag is signed.
@@ -41,7 +42,7 @@ A release can be made with the following commands:
     ...
     $ twine upload dist/*
 
-sanity checks and cleanup
+Sanity checks and cleanup
 -------------------------
 
 After a release has been published to PyPI and a tag is available for users to
@@ -52,6 +53,7 @@ reference, ensure the following post-release tasks are performed:
   match the ``stable`` documentation. Also, ensure the newly created tag is
   listed as a valid option for users to reference.
 - Generate online validation set (examples) based off the recent release tag.
+  This includes both the version space and the ``STABLE`` space.
 
 .. _Atlassian Support End of Life Policy: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
 .. _CONTRIBUTING.rst: https://github.com/sphinx-contrib/confluencebuilder/blob/master/CONTRIBUTING.rst


### PR DESCRIPTION
A series of documents found in the root of the document have been reviewed/updated in preparation for a planned upcoming release (#362). This includes the following changes, with more details outlined in the individual commit messages:

- CHANGES.rst: adding features and cleanup
- CONTRIBUTING.rst: cleanup document
- LICENSE: update most recent license state
- MAINTAINERS.rst: cleanup document