### PR TITLE
builder: write empty pages

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -429,11 +429,12 @@ class ConfluenceBuilder(Builder):
 
         self.writer.write(doctree, destination)
         outfilename = path.join(self.outdir, self.file_transform(docname))
-        if self.writer.output:
+        if self.writer.output is not None:
             ensuredir(path.dirname(outfilename))
             try:
                 with io.open(outfilename, 'w', encoding='utf-8') as file:
-                    file.write(self.writer.output)
+                    if self.writer.output:
+                        file.write(self.writer.output)
             except (IOError, OSError) as err:
                 ConfluenceLogger.warn("error writing file "
                     "%s: %s" % (outfilename, err))


### PR DESCRIPTION
In the event where a document entry only contains a title reference and is removed via the `confluence_remove_title` option, the resulting page will be empty. While this should be fine, the existing builder implementation would not generate an output document which was empty. This would leave to an error such as the following:

    WARNING: error reading file<filename>.conf: [Errno 2] No such file or directory: ...

If a documentation set has an empty page, this extension should still be creating/publishing it. Correcting this in the builder to write content if even an empty string is set.