### PR TITLE
implements stub columns (re-do of #341)

### DIFF
--- a/tests/unit-tests/common/dataset-common/list-table.rst
+++ b/tests/unit-tests/common/dataset-common/list-table.rst
@@ -35,3 +35,16 @@ list table
    * - 7
      - 8
      - 9
+
+.. list-table:: name3
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - key
+     - value
+   * - 1
+     - 2
+   * - 3
+     - 4
+   * - 5
+     - 6

--- a/tests/unit-tests/common/expected/list-table.conf
+++ b/tests/unit-tests/common/expected/list-table.conf
@@ -78,3 +78,35 @@
         </tr>
     </tbody>
 </table>
+<p><strong>name3</strong>
+</p>
+<table>
+    <thead>
+        <tr>
+            <th><p>key</p>
+            </th>
+            <th><p>value</p>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th><p>1</p>
+            </th>
+            <td><p>2</p>
+            </td>
+        </tr>
+        <tr>
+            <th><p>3</p>
+            </th>
+            <td><p>4</p>
+            </td>
+        </tr>
+        <tr>
+            <th><p>5</p>
+            </th>
+            <td><p>6</p>
+            </td>
+        </tr>
+    </tbody>
+</table>

--- a/tests/validation-sets/standard/lists.rst
+++ b/tests/validation-sets/standard/lists.rst
@@ -264,6 +264,21 @@ Another example of a list table with multiple header rows:
       - 8
       - 9
 
+Another example of a list table with one header row and one stub column:
+
+.. list-table:: Table with stub columns
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - key
+     - value
+   * - 1
+     - 2
+   * - 3
+     - 4
+   * - 5
+     - 6
+
 Option lists
 ------------
 


### PR DESCRIPTION
implements #341 (accidentally closed); pasting some of original issue summary for clarity:

- implemented support for `:stub-columns:` option in `.. list-table::` directives
- updated tests
- currently using in production instance running confuence 7.6.0

feedback implemented:

- removed experimental flag (https://github.com/sphinx-contrib/confluencebuilder/pull/341#discussion_r531221837)
- removed comments; added link to ref implementation to commit msg (https://github.com/sphinx-contrib/confluencebuilder/pull/341#discussion_r531226811)
- moved `node.parent.column += 1` outside of `if` block (https://github.com/sphinx-contrib/confluencebuilder/pull/341#discussion_r531227401)

@jdknight please take a look; thank you!