### PR TITLE
Fix/fix confluence ask password

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -189,7 +189,7 @@ def setup(app):
     """List of optional features/macros/etc. restricted for use."""
     app.add_config_value('confluence_adv_restricted', None, False)
     """Enablement of tracing processed data."""
-    app.add_config_value('confluence_adv_trace_data', None, False)
+    app.add_config_value('confluence_adv_trace_data', False, False)
     """Do not cap sections to a maximum of six (6) levels."""
     app.add_config_value('confluence_adv_writer_no_section_cap', None, False)
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -97,7 +97,7 @@ def setup(app):
 
     """(configuration - publishing)"""
     """Request for publish password to come from interactive session."""
-    app.add_config_value('confluence_ask_password', None, False)
+    app.add_config_value('confluence_ask_password', False, False)
     """Request for publish username to come from interactive session."""
     app.add_config_value('confluence_ask_user', None, False)
     """Explicitly prevent auto-generation of titles for titleless documents."""

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -99,7 +99,7 @@ def setup(app):
     """Request for publish password to come from interactive session."""
     app.add_config_value('confluence_ask_password', False, False)
     """Request for publish username to come from interactive session."""
-    app.add_config_value('confluence_ask_user', None, False)
+    app.add_config_value('confluence_ask_user', False, False)
     """Explicitly prevent auto-generation of titles for titleless documents."""
     app.add_config_value('confluence_disable_autogen_title', None, False)
     """Explicitly prevent page notifications on update."""

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -189,7 +189,7 @@ def setup(app):
     """List of optional features/macros/etc. restricted for use."""
     app.add_config_value('confluence_adv_restricted', None, False)
     """Enablement of tracing processed data."""
-    app.add_config_value('confluence_adv_trace_data', False, False)
+    app.add_config_value('confluence_adv_trace_data', None, False)
     """Do not cap sections to a maximum of six (6) levels."""
     app.add_config_value('confluence_adv_writer_no_section_cap', None, False)
 


### PR DESCRIPTION
Fix for #423 were command arguments are interpreted as string and no longer as booleans