### PR TITLE
improve configuration check for booleans/integers

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -426,7 +426,7 @@ names are relative to the documentation's source directory.
 
     # confluence_secnumber_suffix
     validator.conf('confluence_secnumber_suffix') \
-             .string()
+             .string(permit_empty=True)
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -37,9 +37,57 @@ def validate_configuration(builder):
 
     # ##################################################################
 
+    # confluence_add_secnumbers
+    validator.conf('confluence_add_secnumbers') \
+             .bool()
+
+    # ##################################################################
+
     # confluence_additional_mime_types
     validator.conf('confluence_additional_mime_types') \
              .strings(no_space=True)
+
+    # ##################################################################
+
+    # confluence_adv_aggressive_search
+    validator.conf('confluence_adv_aggressive_search') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_adv_hierarchy_child_macro
+    validator.conf('confluence_adv_hierarchy_child_macro') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_adv_trace_data
+    validator.conf('confluence_adv_trace_data') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_adv_writer_no_section_cap
+    validator.conf('confluence_adv_writer_no_section_cap') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_ask_password
+    validator.conf('confluence_ask_password') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_ask_user
+    validator.conf('confluence_ask_user') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_asset_force_standalone
+    validator.conf('confluence_asset_force_standalone') \
+             .bool()
 
     # ##################################################################
 
@@ -97,6 +145,24 @@ The option 'confluence_default_alignment' has been provided to override the
 default alignment for tables, figures, etc. Accepted values include 'left',
 'center' and 'right'.
 """ % str(e))
+
+    # ##################################################################
+
+    # confluence_disable_autogen_title
+    validator.conf('confluence_disable_autogen_title') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_disable_notifications
+    validator.conf('confluence_disable_notifications') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_disable_ssl_validation
+    validator.conf('confluence_disable_ssl_validation') \
+             .bool()
 
     # ##################################################################
 
@@ -159,6 +225,12 @@ to a proper file path.
 
     # ##################################################################
 
+    # confluence_ignore_titlefix_on_index
+    validator.conf('confluence_ignore_titlefix_on_index') \
+             .bool()
+
+    # ##################################################################
+
     # confluence_jira_servers
     if config.confluence_jira_servers is not None:
         issue = False
@@ -212,6 +284,12 @@ dictionaries with keys 'id' and 'name' which identify the JIRA instances.
 
     # ##################################################################
 
+    # confluence_master_homepage
+    validator.conf('confluence_master_homepage') \
+             .bool()
+
+    # ##################################################################
+
     # confluence_max_doc_depth
     try:
         validator.conf('confluence_max_doc_depth') \
@@ -236,6 +314,12 @@ If planning to use a depth of zero, it is recommended to use the
 
     validator.conf('confluence_parent_page_id_check') \
              .int_(positive=True)
+
+    # ##################################################################
+
+    # confluence_page_hierarchy
+    validator.conf('confluence_page_hierarchy') \
+             .bool()
 
     # ##################################################################
 
@@ -298,6 +382,18 @@ names are relative to the documentation's source directory.
 
     # ##################################################################
 
+    # confluence_publish_dryrun
+    validator.conf('confluence_publish_dryrun') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_publish_onlynew
+    validator.conf('confluence_publish_onlynew') \
+             .bool()
+
+    # ##################################################################
+
     # confluence_publish_postfix
     validator.conf('confluence_publish_postfix') \
              .string()
@@ -307,6 +403,24 @@ names are relative to the documentation's source directory.
     # confluence_publish_prefix
     validator.conf('confluence_publish_prefix') \
              .string()
+
+    # ##################################################################
+
+    # confluence_purge
+    validator.conf('confluence_purge') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_purge_from_master
+    validator.conf('confluence_purge_from_master') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_remove_title
+    validator.conf('confluence_remove_title') \
+             .bool()
 
     # ##################################################################
 
@@ -380,6 +494,12 @@ A configured timeout should be set to a value, in seconds, before any network
 request to timeout after inactivity. This should be set to a positive integer
 value (e.g. 2).
 """ % str(e))
+
+    # ##################################################################
+
+    # confluence_watch
+    validator.conf('confluence_watch') \
+             .bool()
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -69,7 +69,7 @@ def apply_defaults(conf):
     ]
     for key in config2bool:
         if getattr(conf, key) is not None:
-            if not isinstance(getattr(conf, key), bool):
+            if not isinstance(getattr(conf, key), bool) and conf[key]:
                 conf[key] = str2bool(conf[key])
 
     config2int = [
@@ -79,5 +79,5 @@ def apply_defaults(conf):
     ]
     for key in config2int:
         if getattr(conf, key) is not None:
-            if not isinstance(getattr(conf, key), int):
+            if not isinstance(getattr(conf, key), int) and conf[key]:
                 conf[key] = int(conf[key])

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -4,6 +4,8 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
+from sphinxcontrib.confluencebuilder.util import str2bool
+
 def apply_defaults(conf):
     """
     applies default values for select configurations
@@ -42,3 +44,40 @@ def apply_defaults(conf):
 
     if conf.confluence_secnumber_suffix is None:
         conf.confluence_secnumber_suffix = '. '
+
+    config2bool = [
+        'confluence_add_secnumbers',
+        'confluence_adv_aggressive_search',
+        'confluence_adv_hierarchy_child_macro',
+        'confluence_adv_trace_data',
+        'confluence_adv_writer_no_section_cap',
+        'confluence_ask_password',
+        'confluence_ask_user',
+        'confluence_asset_force_standalone',
+        'confluence_disable_autogen_title',
+        'confluence_disable_notifications',
+        'confluence_disable_ssl_validation',
+        'confluence_ignore_titlefix_on_index',
+        'confluence_master_homepage',
+        'confluence_page_hierarchy',
+        'confluence_publish_dryrun',
+        'confluence_publish_onlynew',
+        'confluence_purge',
+        'confluence_purge_from_master',
+        'confluence_remove_title',
+        'confluence_watch',
+    ]
+    for key in config2bool:
+        if getattr(conf, key) is not None:
+            if not isinstance(getattr(conf, key), bool):
+                conf[key] = str2bool(conf[key])
+
+    config2int = [
+        'confluence_max_doc_depth',
+        'confluence_parent_page_id_check',
+        'confluence_timeout',
+    ]
+    for key in config2int:
+        if getattr(conf, key) is not None:
+            if not isinstance(getattr(conf, key), int):
+                conf[key] = int(conf[key])

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -40,6 +40,30 @@ class ConfigurationValidation():
         self.key = None
         self._translate = None
 
+    def bool(self):
+        """
+        checks if a configuration is a boolean
+
+        After an instance has been set a configuration key (via `conf`), this
+        method can be used to check if the value (if any) configured with this
+        key is a boolean. If not, an `ConfluenceConfigurationError` exception
+        will be thrown.
+
+        In the event that the configuration is not set (e.g. a value of `None`),
+        this method will have no effect.
+
+        Returns:
+            the validator instance
+        """
+        value = self._value()
+
+        if value is not None:
+            if not isinstance(value, bool) and not isinstance(value, int):
+                raise ConfluenceConfigurationError(
+                    '%s is not a boolean type' % self.key)
+
+        return self
+
     def callable_(self):
         """
         checks if a configuration is a callable

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -6,6 +6,7 @@
 
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
+from sphinxcontrib.confluencebuilder.util import str2bool
 import os
 
 try:
@@ -58,7 +59,13 @@ class ConfigurationValidation():
         value = self._value()
 
         if value is not None:
-            if not isinstance(value, bool) and not isinstance(value, int):
+            if isinstance(value, basestring):
+                try:
+                    str2bool(value)
+                except ValueError:
+                    raise ConfluenceConfigurationError(
+                        '%s is not a boolean string' % self.key)
+            elif not isinstance(value, bool) and not isinstance(value, int):
                 raise ConfluenceConfigurationError(
                     '%s is not a boolean type' % self.key)
 
@@ -249,6 +256,13 @@ class ConfigurationValidation():
         value = self._value()
 
         if value is not None:
+            if isinstance(value, basestring):
+                try:
+                    value = int(value)
+                except ValueError:
+                    raise ConfluenceConfigurationError(
+                        '%s is not an integer string' % self.key)
+
             if positive:
                 if not isinstance(value, int) or value <= 0:
                     raise ConfluenceConfigurationError(

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -102,3 +102,30 @@ def first(it):
         the first element
     """
     return next(iter(it), None)
+
+def str2bool(value):
+    """
+    returns the boolean value for a string
+
+    Returns the boolean value for a provided string. Acceptable values for a
+    ``True`` case includes ``y``, ``yes``, ``t``, ``true``, ``on`` and ``1``;
+    for a ``False`` case includes ``n``, ``no``, ``f``, ``false``, ``off`` and
+    ``0``. Raises ``ValueError`` on error.
+
+    Args:
+        value: the raw value
+
+    Returns:
+        the boolean interpretation
+
+    Raises:
+        ``ValueError`` is raised if the string value is not an accepted string
+    """
+
+    value = value.lower()
+    if value in ['y', 'yes', 't', 'true', 'on', '1']:
+        return True
+    elif value in ['n', 'no', 'f', 'false', 'off', '0']:
+        return False
+    else:
+        raise ValueError

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -339,8 +339,7 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self._try_config()
 
         self.config['confluence_max_doc_depth'] = '2'
-        with self.assertRaises(ConfluenceConfigurationError):
-            self._try_config()
+        self._try_config()
 
         self.config['confluence_max_doc_depth'] = -1
         with self.assertRaises(ConfluenceConfigurationError):
@@ -355,18 +354,6 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self._try_config()
 
     def test_config_check_parent_page_id_check(self):
-        self.config['confluence_parent_page_id_check'] = '123456'
-        with self.assertRaises(ConfluenceConfigurationError):
-            self._try_config()
-
-        self.config['confluence_parent_page_id_check'] = 0
-        with self.assertRaises(ConfluenceConfigurationError):
-            self._try_config()
-
-        self.config['confluence_parent_page_id_check'] = -123456
-        with self.assertRaises(ConfluenceConfigurationError):
-            self._try_config()
-
         # enable publishing enabled checks
         self._prepare_valid_publish()
 
@@ -377,6 +364,17 @@ class TestConfluenceConfigChecks(unittest.TestCase):
 
         self.config['confluence_parent_page'] = 'dummy'
         self._try_config()
+
+        self.config['confluence_parent_page_id_check'] = '123456'
+        self._try_config()
+
+        self.config['confluence_parent_page_id_check'] = 0
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_parent_page_id_check'] = -123456
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
 
     def test_config_check_prev_next_buttons_location(self):
         self.config['confluence_prev_next_buttons_location'] = 'bottom'
@@ -618,8 +616,7 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self._try_config()
 
         self.config['confluence_timeout'] = '2'
-        with self.assertRaises(ConfluenceConfigurationError):
-            self._try_config()
+        self._try_config()
 
         self.config['confluence_timeout'] = -1
         with self.assertRaises(ConfluenceConfigurationError):


### PR DESCRIPTION
Provides the ability to check and be flexible with boolean/integer configuration values for this extension. This pull request includes:

- config: sanity check boolean options
- config: permit string values for booleans/integers (for command line)
- config: handle empty strings as unset cases