### PR TITLE
translator: ignore meta nodes

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/__init__.py
+++ b/sphinxcontrib/confluencebuilder/translator/__init__.py
@@ -244,6 +244,9 @@ class ConfluenceBaseTranslator(BaseTranslator):
     def visit_comment(self, node):
         raise nodes.SkipNode
 
+    def visit_meta(self, node):
+        raise nodes.SkipNode
+
     def visit_line(self, node):
         # ignoring; no need to handle specific line entries
         pass


### PR DESCRIPTION
When a document defines a reStructuredText's `meta` directive, ignore the node type to prevent a translation failure.