### PR TITLE
math improvements

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -976,6 +976,8 @@ class ConfluenceBuilder(Builder):
                     uri=path.join(self.outdir, mf))
                 if not isinstance(node, nodes.math):
                     new_node['align'] = 'center'
+                if node.get('number'):
+                    new_node['math_number'] = node['number']
                 node.replace_self(new_node)
             except imgmath.MathExtError as exc:
                 ConfluenceLogger.warn('inline latex {}: {}'.format(

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -15,6 +15,7 @@ from sphinx.builders import Builder
 from sphinx.errors import ExtensionError
 from sphinx.locale import __
 from sphinx.util import status_iterator
+from sphinx.util.math import wrap_displaymath
 from sphinx.util.osutil import ensuredir
 from sphinxcontrib.confluencebuilder.assets import ConfluenceAssetManager
 from sphinxcontrib.confluencebuilder.assets import ConfluenceSupportedImages
@@ -958,8 +959,15 @@ class ConfluenceBuilder(Builder):
         for node in itertools.chain(doctree.traverse(nodes.math),
                 doctree.traverse(nodes.math_block)):
             try:
-                mf, _ = imgmath.render_math(mock_translator,
-                    '$' + node.astext() + '$')
+                if not isinstance(node, nodes.math):
+                    if node['nowrap']:
+                        latex = node.astext()
+                    else:
+                        latex = wrap_displaymath(node.astext(), None, False)
+                else:
+                    latex = '$' + node.astext() + '$'
+
+                mf, _ = imgmath.render_math(mock_translator, latex)
                 if not mf:
                     continue
 

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1264,6 +1264,14 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         uri = node['uri']
         uri = self._escape_sf(uri)
 
+        if node.get('math_number'):
+            math_number = node['math_number']
+
+            self.body.append(self._start_tag(node, 'div',
+                **{'style': 'float: right'}))
+            self.body.append('({})'.format(math_number))
+            self.body.append(self._end_tag(node))
+
         attribs = {}
 
         alignment = None


### PR DESCRIPTION
This pull request improves how it handles various math nodes. Specifically, this includes two changes:

1. Properly handles wrapping for displaymath nodes where equations with more than one line would result in a LaTeX error.
2. Support adding label entries for nodes (which assign a label and are referenced via `:math:numref:`).