### PR TITLE
additional math support for depth/numfigs

### DIFF
--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -70,6 +70,17 @@ content can use the ``confluence_publish_prefix``
 See also the :ref:`dry run capability <confluence_publish_dryrun>` and the
 :ref:`title overrides capability <confluence_title_overrides>`.
 
+Recommended options for math
+----------------------------
+
+The following are recommended options to use when using `sphinx.ext.imgmath`_:
+
+.. code-block:: python
+
+    imgmath_font_size = 14
+    imgmath_use_preview = True
+    imgmath_image_format = 'svg'
+
 Setting a publishing timeout
 ----------------------------
 
@@ -127,3 +138,7 @@ report, run the following command from the documentation directory:
     (confluence instance)
      ...
     ------------[ cut here ]------------
+
+.. references ------------------------------------------------------------------
+
+.. _sphinx.ext.imgmath: https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.imgmath

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -973,13 +973,13 @@ class ConfluenceBuilder(Builder):
 
                 new_node = nodes.image(
                     candidates={'?'},
-                    uri=path.join(self.outdir, mf))
+                    uri=path.join(self.outdir, mf),
+                    **node.attributes)
+                new_node['from_math'] = True
                 if not isinstance(node, nodes.math):
                     new_node['align'] = 'center'
                 if depth is not None:
                     new_node['math_depth'] = depth
-                if node.get('number'):
-                    new_node['math_number'] = node['number']
                 node.replace_self(new_node)
             except imgmath.MathExtError as exc:
                 ConfluenceLogger.warn('inline latex {}: {}'.format(

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -967,7 +967,7 @@ class ConfluenceBuilder(Builder):
                 else:
                     latex = '$' + node.astext() + '$'
 
-                mf, _ = imgmath.render_math(mock_translator, latex)
+                mf, depth = imgmath.render_math(mock_translator, latex)
                 if not mf:
                     continue
 
@@ -976,6 +976,8 @@ class ConfluenceBuilder(Builder):
                     uri=path.join(self.outdir, mf))
                 if not isinstance(node, nodes.math):
                     new_node['align'] = 'center'
+                if depth is not None:
+                    new_node['math_depth'] = depth
                 if node.get('number'):
                     new_node['math_number'] = node['number']
                 node.replace_self(new_node)

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1264,18 +1264,29 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         uri = node['uri']
         uri = self._escape_sf(uri)
 
-        if node.get('math_depth'):
+        if node.get('from_math') and node.get('math_depth'):
             math_depth = node['math_depth']
             self.body.append(self._start_tag(node, 'span',
                 **{'style': 'vertical-align: {}px'.format(-1 * math_depth)}))
             self.context.append(self._end_tag(node))
 
-        if node.get('math_number'):
-            math_number = node['math_number']
+        if node.get('from_math') and node.get('number'):
+            if self.builder.config.math_numfig and self.builder.config.numfig:
+                figtype = 'displaymath'
+                if self.builder.name == 'singleconfluence':
+                    key = '%s/%s' % (self._docnames[-1], figtype)
+                else:
+                    key = figtype
+
+                id = node['ids'][0]
+                number = self.builder.fignumbers.get(key, {}).get(id, ())
+                number = '.'.join(map(str, number))
+            else:
+                number = node['number']
 
             self.body.append(self._start_tag(node, 'div',
                 **{'style': 'float: right'}))
-            self.body.append('({})'.format(math_number))
+            self.body.append('({})'.format(number))
             self.body.append(self._end_tag(node))
 
         attribs = {}
@@ -1353,7 +1364,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._end_ac_image(node))
 
     def depart_image(self, node):
-        if node.get('math_depth'):
+        if node.get('from_math') and node.get('math_depth'):
             self.body.append(self.context.pop()) # span
 
     def visit_legend(self, node):

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1264,6 +1264,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         uri = node['uri']
         uri = self._escape_sf(uri)
 
+        if node.get('math_depth'):
+            math_depth = node['math_depth']
+            self.body.append(self._start_tag(node, 'span',
+                **{'style': 'vertical-align: {}px'.format(-1 * math_depth)}))
+            self.context.append(self._end_tag(node))
+
         if node.get('math_number'):
             math_number = node['math_number']
 
@@ -1346,7 +1352,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._end_ri_attachment(node))
             self.body.append(self._end_ac_image(node))
 
-        raise nodes.SkipNode
+    def depart_image(self, node):
+        if node.get('math_depth'):
+            self.body.append(self.context.pop()) # span
 
     def visit_legend(self, node):
         attribs = {}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -40,7 +40,9 @@ class TestConfluenceValidation(unittest.TestCase):
         cls.config['confluence_server_url'] = DEFAULT_TEST_URL
         cls.config['confluence_server_user'] = DEFAULT_TEST_USER
         cls.config['confluence_timeout'] = 1
+        cls.config['imgmath_font_size'] = 14
         cls.config['imgmath_image_format'] = 'svg'
+        cls.config['imgmath_use_preview'] = True
         cls.config['manpages_url'] = 'https://example.org/{path}'
         cls.test_desc = os.getenv(TESTDESC_ENV_KEY, DEFAULT_TEST_DESC)
         cls.test_key = os.getenv(TESTKEY_ENV_KEY, DEFAULT_TEST_KEY)

--- a/tests/validation-sets/standard/math.rst
+++ b/tests/validation-sets/standard/math.rst
@@ -20,6 +20,11 @@ The mass–energy equivalence formula:
 
     E = mc^2
 
+Euler's identity is outline in :math:numref:`euler` below:
+
+.. math:: e^{i\pi} + 1 = 0
+    :label: euler
+
 .. references ------------------------------------------------------------------
 
 .. _math directive: https://docutils.sourceforge.io/docs/ref/rst/directives.html#math


### PR DESCRIPTION
# support math depth

When a configuration sets `imgmath_use_preview`, the math rendering request will provide a depth offset which can be used to apply around math images for improved visual alignment. When a depth is generated from `render_math`, track this depth into the newly created image node.

For storage format, when an image is assigned with a math-depth value, include a span wrapper with a vertical alignment offset set.

# improve math numfig for singleconfluence builder

When building both references to equations and equation labels, an invoke with a `singleconfluence` builder can result in the builder failing. This is a combination of the following:

- This extension pre-populates TOC figure/section numbers to help build a desired list of '<docname>/<id>' mappings for various nodes. However, by doing this stage early, references targeting equations will break when assembling the doctree. This is corrected by tracking the original figure/section mappings along with the full mapping aliases for this extension's writers.
- A built aliased assumed the numerical value tracked in the math node was the end value to use for a figure label; however, for the `singleconfluence` builder, equation labels can be changed when merging multiple equations into a single document. Changes have been introduced to ensure when numerical figures are enabled for math entries that the labels are built with the tracked figure number determined during document assembly.
