### PR TITLE
intersphinx: encode anchor value before attempting to quote

### DIFF
--- a/sphinxcontrib/confluencebuilder/intersphinx.py
+++ b/sphinxcontrib/confluencebuilder/intersphinx.py
@@ -72,7 +72,7 @@ def build_intersphinx(builder):
                         # anchor values; replace and encode the anchor value
                         anchor = anchor.replace('"', '”')
                         anchor = anchor.replace("'", '’')
-                        anchor = requests.utils.quote(anchor)
+                        anchor = requests.utils.quote(anchor.encode('utf-8'))
                     else:
                         anchor = ''
 


### PR DESCRIPTION
For Python 2.7, attempting to pass a raw anchor value for quoting into requests can result in an encoding exception. To prevent an encoding failure when attempting to quote the desired anchor value, ensure it is UTF-8 encoded first.