### PR TITLE
define builder type via class attribute

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -17,7 +17,6 @@ from sphinxcontrib.confluencebuilder.nodes import jira
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
 from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
-from sphinxcontrib.confluencebuilder.translator.storage import ConfluenceStorageFormatTranslator
 
 # load autosummary extension if available to add additional nodes
 try:
@@ -40,10 +39,6 @@ def setup(app):
     app.add_builder(ConfluenceBuilder)
     app.add_builder(ConfluenceReportBuilder)
     app.add_builder(SingleConfluenceBuilder)
-    app.registry.add_translator(
-        ConfluenceBuilder.name, ConfluenceStorageFormatTranslator)
-    app.registry.add_translator(
-        SingleConfluenceBuilder.name, ConfluenceStorageFormatTranslator)
 
     # Images defined by data uri schemas can be resolved into generated images
     # after a document's post-transformation stage. After a document's doctree

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -28,6 +28,7 @@ from sphinxcontrib.confluencebuilder.nodes import ConfluenceNavigationNode
 from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
+from sphinxcontrib.confluencebuilder.translator.storage import ConfluenceStorageFormatTranslator
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
 from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import first
@@ -63,6 +64,7 @@ if graphviz:
 
 class ConfluenceBuilder(Builder):
     allow_parallel = True
+    default_translator_class = ConfluenceStorageFormatTranslator
     name = 'confluence'
     format = 'confluence_storage'
     supported_image_types = ConfluenceSupportedImages()


### PR DESCRIPTION
Sphinx defines the translators to be used for builders via a `default_translator_class` class attribute. Instead of using `add_translator` on the Sphinx registry, use the class attribute instead.