### PR TITLE
anonymous publish feedback

### DIFF
--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -93,6 +93,12 @@ is recommended to provide a timeout value based on the environment being used
 Publishing with a CI secret key
 -------------------------------
 
+.. note::
+
+    If running in a ``tox``/``virtualenv`` setup, ensure any environment
+    variables used are configured to be passed through to the virtual
+    environment.
+
 For users performing automatic publishing through a CI system, they may wish to
 authenticate their publish event with a secret key. A common approach to
 applying a secret key is through an environment variable. For example:

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -179,7 +179,10 @@ def report_main(args_parser):
 
     def sensitive_config(key):
         if key in config:
-            config[key] = '(set)'
+            if config[key]:
+                config[key] = '(set)'
+            else:
+                config[key] = '(set; empty)'
 
     # always sanitize out sensitive information
     sensitive_config('confluence_client_cert_pass')

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -34,17 +34,22 @@ class ConfluenceBadApiError(ConfluenceError):
         )
 
 class ConfluenceBadSpaceError(ConfluenceError):
-    def __init__(self, space_name):
+    def __init__(self, space_name, uname, pw_set):
+        uname_value = uname if uname else '(empty)'
+        pw_value = '<set>' if pw_set else '(empty)'
         SphinxError.__init__(self,
             """---\n"""
             """The configured Confluence space does not appear to be """
-            """valid: %s\n""" % space_name +
+            """valid:\n\n"""
+            """    Space: {}\n"""
+            """ Username: {}\n"""
+            """ Password: {}\n"""
             """\n"""
             """Ensure the server is running or your Confluence URL is valid. """
             """Also ensure your authentication options are properly set.\n"""
             """\n"""
             """Note: Confluence space names are case-sensitive.\n"""
-            """---\n"""
+            """---\n""".format(space_name, uname_value, pw_value)
         )
 
 class ConfluenceBadServerUrlError(ConfluenceError):

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -47,7 +47,9 @@ class ConfluencePublisher():
             'limit': 1
         })
         if rsp['size'] == 0:
-            raise ConfluenceBadSpaceError(self.space_name)
+            pw_set = bool(self.config.confluence_server_pass)
+            raise ConfluenceBadSpaceError(self.space_name,
+                self.config.confluence_server_user, pw_set)
         self.space_display_name = rsp['results'][0]['name']
 
     def disconnect(self):


### PR DESCRIPTION
Provide users more feedback for scenarios where an anonymous configuration is (unexpectedly) set:

- provide userspace/password feedback on bad-space error
- report: indicate if a sensitive configuration is a set empty value
- doc: add note about virtual environments for ci env passing