### PR TITLE
force docname on singlebuilder asset fetching

### DIFF
--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -99,7 +99,7 @@ class ConfluenceAssetManager:
                 data.append(entry)
         return data
 
-    def fetch(self, node):
+    def fetch(self, node, docname=None):
         """
         return key and target document name for provided asset
 
@@ -111,11 +111,11 @@ class ConfluenceAssetManager:
 
         Args:
             node: the node to interpret
+            docname (optional): force the document name for this asset
 
         Returns:
             the key and document name
         """
-        docname = None
         key = None
 
         path = self._interpretAssetPath(node)
@@ -127,10 +127,11 @@ class ConfluenceAssetManager:
             # If a node's asset cannot be found, this image node may have been
             # created after pre-processing occurred. Attempt to re-process the
             # node as a standalone image.
-            if not asset and node.document:
+            if not asset and not docname and node.document:
                 docname = canon_path(
                     self.env.path2doc(node.document['source']))
 
+            if not asset and docname:
                 if isinstance(node, nodes.image):
                     self.processImageNode(node, docname, standalone=True)
                 elif isinstance(node, addnodes.download_reference):

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1346,7 +1346,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 suffix=self.nl, empty=True, **{'ri:value': uri}))
             self.body.append(self._end_ac_image(node))
         else:
-            image_key, hosting_docname = self.assets.fetch(node)
+            asset_docname = None
+            if self.builder.name == 'singleconfluence':
+                asset_docname = self._docnames[-1]
+
+            image_key, hosting_docname = self.assets.fetch(node,
+                docname=asset_docname)
             if not image_key:
                 self.warn('unable to find image: ' '{}'.format(node['uri']))
                 raise nodes.SkipNode
@@ -1396,7 +1401,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._start_tag(node, 'a', **{'href': uri}))
             self.context.append(self._end_tag(node, suffix=''))
         else:
-            file_key, hosting_docname = self.assets.fetch(node)
+            asset_docname = None
+            if self.builder.name == 'singleconfluence':
+                asset_docname = self._docnames[-1]
+
+            file_key, hosting_docname = self.assets.fetch(node,
+                docname=asset_docname)
             if not file_key:
                 self.warn('unable to find download: ' '{}'.format(
                     node['reftarget']))


### PR DESCRIPTION
When processing runtime generated image nodes, the asset management will attempt to track newly created assets when preparing a node's translation. This requires determining the document which the image will be attached on, which uses the `document` attribute populated through a Sphinx run. When assembling documents using the `singleconfluence` builder, this attribute is not provided and injected image nodes will be ignored. To avoid this, when `singleconfluence` is being invoked, explicitly pass in the docname to be used to ensure an asset entry can be fetched.