### PR TITLE
improve verbose logging

### DIFF
--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -94,6 +94,7 @@ class ConfluenceLogger():
          https://docs.python.org/3/library/logging.html#logging.Logger.debug
         """
         if ConfluenceLogger.logger:
+            msg = '[confluence] ' + msg
             ConfluenceLogger.logger.verbose(msg, *args, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
### builder: fold info lines when in a verbose mode

Status logging on an iterator will not generate newlines to a better user experience for log message; however, when an instance is configured for a more verbose logging state, these status messages may be stacked with verbose messages that may be printed. To avoid this, always set to fold lines when a verbose mode is set.

### logger: prefix verbose message with confluence tag

For all verbose messages generated by this extension, add a `[confluence]` prefix to help easily distinguish builder-generated log messages over other verbose messages that may be generated.