### PR TITLE
publisher: suppress a failed page delete on missing page id

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -592,6 +592,16 @@ class ConfluencePublisher():
 
         try:
             self.rest_client.delete('content', page_id)
+        except ConfluenceBadApiError as ex:
+            # Check if Confluence reports that this content does not exist. If
+            # so, we want to suppress the API error. This is most likely a
+            # result of a Confluence instance reporting a page descendant
+            # identifier which no longer exists (possibly a caching issue).
+            if str(ex).find('No content found with id') == -1:
+                raise
+
+            ConfluenceLogger.verbose('ignore missing delete for page '
+                'identifier: {}'.format(page_id))
         except ConfluencePermissionError:
             raise ConfluencePermissionError(
                 """Publish user does not have permission to delete """


### PR DESCRIPTION
When purging is enabled, this extension will populate a list of descendant pages to delete and filter out pages that will get populated for the new publish set. With the final obsolete list of pages, they will be marked for deletion. It has been observed in some cases where Confluence reports descendant page identifiers for pages which no longer exist (assumed to be cache related). When this extension attempts to delete the non-existent page, it will generate an API error and stop the process. Instead of stopping, if a deletion event is reported to not exist on the Confluence instance, just ignore the error state.