### PR TITLE
provide msystem-environment getpass override

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/__init__.py
+++ b/sphinxcontrib/confluencebuilder/config/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/config/__init__.py
+++ b/sphinxcontrib/confluencebuilder/config/__init__.py
@@ -5,8 +5,8 @@
 """
 
 from sphinxcontrib.confluencebuilder import compat
+from sphinxcontrib.confluencebuilder import util
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
-import getpass
 import sys
 
 def handle_config_inited(app, config):
@@ -63,6 +63,6 @@ def process_ask_configs(config):
             print('     User: ' + config.confluence_server_user)
         sys.stdout.write(' Password: ')
         sys.stdout.flush()
-        config.confluence_server_pass = getpass.getpass('')
+        config.confluence_server_pass = util.getpass2('')
         if not config.confluence_server_pass:
             raise ConfluenceConfigurationError('no password provided')

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2018-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2018-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -13,7 +13,7 @@ from sphinx.util.console import color_terminal
 from sphinx.util.console import nocolor
 from sphinx.util.docutils import docutils_namespace
 from sphinxcontrib.confluencebuilder import compat
-import getpass
+from sphinxcontrib.confluencebuilder import util
 import inspect
 import os
 import shutil
@@ -48,11 +48,11 @@ def mock_getpass(mock):
         return mock
 
     try:
-        original = getpass.getpass
-        getpass.getpass = _
+        original = util.getpass2
+        util.getpass2 = _
         yield
     finally:
-        getpass.getpass = original
+        util.getpass2 = original
 
 @contextmanager
 def mock_input(mock):


### PR DESCRIPTION
If `getpass` is invoked in an msystem-environment (MSYS, MinGW) with a Windows console Python interpreter, password input cannot be captured on the console and the interpreter needs to be manually closed with a CTRL-BREAK call. While users can avoid this scenario by wrapping their invoke of Sphinx with a `winpty` call, it is not obvious to new users and an annoyance to users who may forget to add the command in an invoke.

This commit attempts to alleviate this undesired user experience by attempting to detect the situation where this may occur, and provide an alternative means to acquire a password value. This initial implementation will check for three key hints:

### `os.name == 'nt'`
    
This issue can only occur in a Windows environment. This check helps exclude all other OS-types. Note that this can also (desirably) exclude some Cygwin and MSYS calls where the invoked Python interpreter is not a Windows console-based program.
        
### `MSYSTEM` environment flag
    
Checks if the shell is an MSYS/MinGW shell. A user can invoke a Windows console program in a Cygwin shell and not experience this issue.

### `TERM` environment flag
    
In most calls, the TERM environment flag will be set when running in an MSYS/MinGW environment. However, if a call is wrapped with a winpty session, the Python interpreter can invoke `getpass` function with no issue. winpty (2016+) will by default unset any TERM environment call, which helps this call exclude winpty invokes from attempting to use this alternative approach.

---

When the above scenario is detected, the `getpass` call is replaced with a `input` call and attempts to suppress echoing on the console.

While this override is expected to work for most (if not all users), there may be scenarios where this can cause issues. Therefore, an undocumented `CONFLUENCEBUILDER_NO_GETPASS_HOOK` environment flag has been added to help select users avoid triggering this override.