### PR TITLE
do not override docutils node-visitor's document attrib

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/__init__.py
+++ b/sphinxcontrib/confluencebuilder/translator/__init__.py
@@ -78,7 +78,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
         pass
 
     def depart_document(self, node):
-        self.document = ''
+        self.body_final = ''
 
         # prepend header (if any)
         if self.builder.config.confluence_header_file is not None:
@@ -86,11 +86,11 @@ class ConfluenceBaseTranslator(BaseTranslator):
                 self.builder.config.confluence_header_file)
             try:
                 with io.open(headerFile, encoding='utf-8') as file:
-                    self.document += file.read() + self.nl
+                    self.body_final += file.read() + self.nl
             except (IOError, OSError) as err:
                 self.warn('error reading file {}: {}'.format(headerFile, err))
 
-        self.document += ''.join(self.body)
+        self.body_final += ''.join(self.body)
 
         # append footer (if any)
         if self.builder.config.confluence_footer_file is not None:
@@ -98,7 +98,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
                 self.builder.config.confluence_footer_file)
             try:
                 with io.open(footerFile, encoding='utf-8') as file:
-                    self.document += file.read() + self.nl
+                    self.body_final += file.read() + self.nl
             except (IOError, OSError) as err:
                 self.warn('error reading file {}: {}'.format(footerFile, err))
 

--- a/sphinxcontrib/confluencebuilder/writer.py
+++ b/sphinxcontrib/confluencebuilder/writer.py
@@ -22,5 +22,5 @@ class ConfluenceWriter(writers.Writer):
     def translate(self):
         visitor = self.builder.create_translator(self.document, self.builder)
         self.document.walkabout(visitor)
-        if hasattr(visitor, 'document'):
-            self.output = visitor.document
+        if hasattr(visitor, 'body_final'):
+            self.output = visitor.body_final


### PR DESCRIPTION
This extension's base translator (`ConfluenceBaseTranslator`) is based off of docutil's `NodeVisitor` implementation. When a document finally departs, it would populate a `document` attribute which the writer implementation could fetch before writing content to a file. However, `NodeVisitor` already uses a `document` attribute for other purposes, and overriding the attribute causes issues for Sphinx/docutils calls which reference this attribute. Instead, renaming this attribute to `body_final`.