### PR TITLE
storage: correct table width hint type

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -808,7 +808,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                     has_colspec = True
 
                 self.body.append(self._start_tag(node, 'col', empty=True,
-                    **{'style': 'width: {}px'.format(colspec['colwidth'])}))
+                    **{'style': 'width: {}%'.format(colspec['colwidth'])}))
 
             if has_colspec:
                 self.body.append(self._end_tag(node))

--- a/tests/validation-sets/standard/tables.rst
+++ b/tests/validation-sets/standard/tables.rst
@@ -140,7 +140,7 @@ An example of a `csv-table`_ with explicit width values:
 
 .. csv-table:: Frozen Delights!
     :header: "Treat", "Quantity", "Description"
-    :widths: 150, 30, 500
+    :widths: 15, 10, 30
 
     "Albatross", 2.99, "On a stick!"
     "Crunchy Frog", 1.49, "If we took the bones out, it wouldn't be


### PR DESCRIPTION
The `widths` attribute used in various table directives will be integer values hinting at percentages \[1\] (when integer values are provided). The initial implementation to support a `widths` attribute incorrectly set values to pixel lengths; correcting.

\[1\]: https://docutils.sourceforge.io/docs/ref/rst/directives.html#table