### PR TITLE
promote ask password

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -701,6 +701,11 @@ Advanced publishing configuration
 
 .. confval:: confluence_client_cert_pass
 
+    .. caution::
+
+        It is never recommended to store a certificate's passphrase into a
+        committed/shared repository holding documentation.
+
     Provide a passphrase for |confluence_client_cert|_. This prevents a user
     from being prompted to enter a passphrase for a private key when publishing.
     If a configured private key is not protected by a passphrase, this value

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -100,6 +100,18 @@ Essential configuration
 
 .. confval:: confluence_server_pass
 
+    .. caution::
+
+        It is never recommended to store an API token or raw password into a
+        committed/shared repository holding documentation.
+
+        A documentation's configuration can modified various ways with Python
+        to pull an authentication token for a publishing event such as
+        :ref:`reading from an environment variable <tip_manage_publish_subset>`,
+        reading from a local file or acquiring a password from ``getpass``. If
+        desired, this extension provides a method for prompting for a
+        password (see |confluence_ask_password|_).
+
     The password value used to authenticate with the Confluence instance. If
     using Confluence Cloud, it is recommended to use an API token for the
     configured username value (see `API tokens`_):
@@ -114,19 +126,6 @@ Essential configuration
     .. code-block:: python
 
         confluence_server_pass = 'myawesomepassword'
-
-    .. caution::
-
-        It is never recommended to store an API token or raw password into a
-        committed/shared repository holding documentation.
-
-
-        A documentation's  configuration can modified various ways with Python
-        to pull an authentication token for a publishing event such as
-        :ref:`reading from an environment variable <tip_manage_publish_subset>`,
-        reading from a local file or acquiring a password from ``getpass``. If
-        desired, this extension provides a method for prompting for a
-        password (see |confluence_ask_password|_).
 
 Generic configuration
 ---------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -12,7 +12,7 @@ Confluence generation and publishing:
     confluence_parent_page = 'Documentation'
     confluence_server_url = 'https://intranet-wiki.example.com/'
     confluence_server_user = 'myawesomeuser'
-    confluence_server_pass = 'myapikey'
+    confluence_ask_password = True
     confluence_page_hierarchy = True
 
 All configurations introduced by this extension are prefixed with

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -112,7 +112,8 @@ applying a secret key is through an environment variable. For example:
     confluence_server_pass = os.getenv('SECRET_KEY')
 
 The above will read an environment variable ``SECRET_KEY`` prepared by a CI
-script which will be set on the ``confluence_server_pass`` configuration.
+script which will be set on the ``confluence_server_pass``
+(:ref:`ref<confluence_server_pass>`) configuration.
 
 Asking for help
 ---------------

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -86,14 +86,13 @@ Next, include a series of publish-related settings to the configuration file:
 
     confluence_publish = True
     confluence_space_name = 'TEST'
+    confluence_ask_password = True
     # (for Confluence Cloud)
     confluence_server_url = 'https://example.atlassian.net/wiki/'
     confluence_server_user = 'myawesomeuser@example.com'
-    confluence_server_pass = 'myapikey'
     # (or, for Confluence Server)
     confluence_server_url = 'https://intranet-wiki.example.com/'
     confluence_server_user = 'myawesomeuser'
-    confluence_server_pass = 'mypassword'
 
 Make appropriate changes to the above configuration for the environment being
 targeted.


### PR DESCRIPTION
Adjusting the documentation to promote the `confluence_ask_password` option over `confluence_server_pass`. User feedback has mentioned multiple times that the documentation appears to be promoting the storing of secret in shared repositories. To help alleviate these concerns (in part with changes \[1\] to `confluence_ask_password` to better support MSYS/MinGW environments), areas of the documentation which hint to specify a password value will be replaced with the ask/prompt option. Users who want to explicitly set password options will find the options when browsing the documentation and observe the cautions associated with the configurations (which may help reduce users from storing secrets in a shared repository).

This merge request also introduces changes to the configuration section where the caution on the `confluence_server_pass` option to be presented before the configuration's example as well as adding a caution for the certificate paraphrase option.

\[1\]: 20ac6a9ee026021eada92bc0d2b820a840b1fe58