### PR TITLE
support publishing to root page

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -392,6 +392,10 @@ Publishing configuration
 
 .. confval:: confluence_parent_page
 
+    .. note::
+
+        This option cannot be used with |confluence_publish_root|_.
+
     The root page found inside the configured space (|confluence_space_name|_)
     where published pages will be a descendant of. The parent page value is used
     to match with the title of an existing page. If this option is not provided,
@@ -407,6 +411,8 @@ Publishing configuration
     If a parent page is not set, consider using the
     |confluence_master_homepage|_ option as well. Note that the page's name can
     be case-sensitive in most (if not all) versions of Confluence.
+
+    See also |confluence_publish_root|_.
 
 .. |confluence_publish_postfix| replace:: ``confluence_publish_postfix``
 .. _confluence_publish_postfix:
@@ -460,6 +466,28 @@ Publishing configuration
     - |confluence_ignore_titlefix_on_index|_
     - |confluence_publish_postfix|_
 
+.. |confluence_publish_root| replace:: ``confluence_publish_root``
+.. _confluence_publish_root:
+
+.. confval:: confluence_publish_root
+
+    .. note::
+
+        This option cannot be used with |confluence_parent_page|_.
+
+    The page identifier to publish the root document to. The root identifier
+    value is used to find an existing page on the configured Confluence
+    instance. When found, the root document of the documentation set being
+    published will replace the content of the page found on the Confluence
+    instance. If the root page cannot be found, the publish attempt will stop
+    with an error message.
+
+    .. code-block:: python
+
+       confluence_publish_root = 123456
+
+    See also |confluence_parent_page|_.
+
 .. |confluence_purge| replace:: ``confluence_purge``
 .. _confluence_purge:
 
@@ -507,7 +535,8 @@ Publishing configuration
     can be set to ``True``. When generating legacy pages to be removed, this
     extension will only attempt to populate legacy pages based off the children of
     the master_doc_ page. This option requires |confluence_purge|_ to be set to
-    ``True`` before taking effect.
+    ``True`` before taking effect. If |confluence_publish_root|_ is set, this
+    option is implicitly enabled.
 
     .. code-block:: python
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -103,7 +103,7 @@ def setup(app):
     app.add_config_value('confluence_global_labels', None, False)
     """Enablement of configuring master as space's homepage."""
     app.add_config_value('confluence_master_homepage', None, False)
-    """Root/parent page's name to publish documents into."""
+    """Parent page's name to publish documents under."""
     app.add_config_value('confluence_parent_page', None, False)
     """Perform a dry run of publishing to inspect what publishing will do."""
     app.add_config_value('confluence_publish_dryrun', None, '')
@@ -143,7 +143,7 @@ def setup(app):
     app.add_config_value('confluence_disable_ssl_validation', None, False)
     """Ignore adding a titlefix on the index document."""
     app.add_config_value('confluence_ignore_titlefix_on_index', None, False)
-    """Root/parent page's identifier to publish documents into."""
+    """Parent page's identifier to publish documents under."""
     app.add_config_value('confluence_parent_page_id_check', None, False)
     """Proxy server needed to communicate with Confluence server."""
     app.add_config_value('confluence_proxy', None, False)

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -113,6 +113,8 @@ def setup(app):
     app.add_config_value('confluence_publish_postfix', None, False)
     """Prefix to apply to published pages."""
     app.add_config_value('confluence_publish_prefix', None, False)
+    """Root page's identifier to publish documents into."""
+    app.add_config_value('confluence_publish_root', None, '')
     """Enablement of purging legacy child pages from a parent page."""
     app.add_config_value('confluence_purge', None, False)
     """Enablement of purging legacy child pages from a master page."""

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -462,7 +462,7 @@ class ConfluenceBuilder(Builder):
             else:
                 baseid = self.parent_id
 
-            # if no base identifier and dry running, ignore legeacy page
+            # if no base identifier and dry running, ignore legacy page
             # searching as there is no initial master document to reference
             # against
             if (conf.confluence_purge_from_master and

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -429,6 +429,7 @@ class ConfluenceBuilder(Builder):
     def publish_doc(self, docname, output):
         conf = self.config
         title = ConfluenceState.title(docname)
+        is_root_doc = self.config.master_doc == docname
 
         parent_id = None
         if self.config.master_doc and self.config.confluence_page_hierarchy:
@@ -450,14 +451,22 @@ class ConfluenceBuilder(Builder):
         if 'labels' in metadata:
             data['labels'].extend([v for v in metadata['labels']])
 
-        uploaded_id = self.publisher.storePage(title, data, parent_id)
+        if conf.confluence_publish_root and is_root_doc:
+            uploaded_id = self.publisher.storePageById(title,
+                conf.confluence_publish_root, data)
+        else:
+            uploaded_id = self.publisher.storePage(title, data, parent_id)
         ConfluenceState.registerUploadId(docname, uploaded_id)
 
         if self.config.master_doc == docname:
             self.master_doc_page_id = uploaded_id
 
+        # if purging is enabled and we have yet to populate a list of legacy
+        # pages to cache, populate pages in our target scope now
         if conf.confluence_purge and self.legacy_pages is None:
-            if conf.confluence_purge_from_master and self.master_doc_page_id:
+            if conf.confluence_publish_root:
+                baseid = conf.confluence_publish_root
+            elif conf.confluence_purge_from_master and self.master_doc_page_id:
                 baseid = self.master_doc_page_id
             else:
                 baseid = self.parent_id

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -197,6 +197,7 @@ def report_main(args_parser):
         sensitive_config('confluence_parent_page')
         sensitive_config('confluence_parent_page_id_check')
         sensitive_config('confluence_proxy')
+        sensitive_config('confluence_publish_root')
         sensitive_config('confluence_server_auth')
         sensitive_config('confluence_server_cookies')
         sensitive_config('confluence_server_user')

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -406,6 +406,11 @@ names are relative to the documentation's source directory.
 
     # ##################################################################
 
+    validator.conf('confluence_publish_root') \
+             .int_(positive=True)
+
+    # ##################################################################
+
     # confluence_purge
     validator.conf('confluence_purge') \
              .bool()
@@ -552,6 +557,16 @@ When a parent page identifier check has been configured with the option
 'confluence_parent_page_id_check', no parent page name has been provided with
 the 'confluence_parent_page' option. Ensure the name of the parent page name
 is provided as well.
+""")
+
+        if config.confluence_publish_root:
+            if config.confluence_parent_page:
+                raise ConfluenceConfigurationError(
+"""conflicting publish point configurations
+
+When configuring for a publishing container, a user can configure for either
+'confluence_parent_page' or 'confluence_publish_root'; however, both cannot be
+configured at the same time.
 """)
 
     # ##################################################################

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -75,6 +75,7 @@ def apply_defaults(conf):
     config2int = [
         'confluence_max_doc_depth',
         'confluence_parent_page_id_check',
+        'confluence_publish_root',
         'confluence_timeout',
     ]
     for key in config2int:

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -80,6 +80,18 @@ class ConfluenceCertificateError(ConfluenceError):
 class ConfluenceConfigurationError(ConfluenceError, ConfigError):
     pass
 
+class ConfluenceMissingPageIdError(ConfluenceError):
+    def __init__(self, space_name, page_id):
+        SphinxError.__init__(self,
+            """---\n"""
+            """A request to publish to a specific Confluence page identifier """
+            """has failed as the identifier could not be found.\n\n"""
+            """    Space: {}\n"""
+            """  Page Id: {}\n"""
+            """\n"""
+            """---\n""".format(space_name, page_id)
+        )
+
 class ConfluencePermissionError(ConfluenceError):
     def __init__(self, details):
         SphinxError.__init__(self,

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -169,7 +169,7 @@ class Rest:
         return json_data
 
     def put(self, key, value, data):
-        restUrl = self.url + API_REST_BIND_PATH + '/' + key + '/' + value
+        restUrl = self.url + API_REST_BIND_PATH + '/' + key + '/' + str(value)
         try:
             rsp = self.session.put(restUrl, json=data)
         except requests.exceptions.Timeout:
@@ -203,7 +203,7 @@ class Rest:
         return json_data
 
     def delete(self, key, value):
-        restUrl = self.url + API_REST_BIND_PATH + '/' + key + '/' + value
+        restUrl = self.url + API_REST_BIND_PATH + '/' + key + '/' + str(value)
         try:
             rsp = self.session.delete(restUrl)
         except requests.exceptions.Timeout:

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -550,6 +550,34 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_publish_prefix'] = 'dummy'
         self._try_config()
 
+    def test_config_check_publish_root(self):
+        # enable publishing enabled checks
+        self._prepare_valid_publish()
+
+        self.config['confluence_publish_root'] = 123456
+        self._try_config()
+
+        self.config['confluence_publish_root'] = '123456'
+        self._try_config()
+
+        self.config['confluence_publish_root'] = 0
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_publish_root'] = -123456
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+    def test_config_check_publish_target_conflicts(self):
+        # enable publishing enabled checks
+        self._prepare_valid_publish()
+
+        # confluence_parent_page and confluence_publish_root conflict
+        self.config['confluence_parent_page'] = 'dummy'
+        self.config['confluence_publish_root'] = 123456
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
     def test_config_check_secnumber_suffix(self):
         self.config['confluence_secnumber_suffix'] = ''
         self._try_config()


### PR DESCRIPTION
Provides the ability for a user to publish documentation into a target root page on a Confluence instance. Where `confluence_parent_page` provides the ability to publish under a target page, the newly added `confluence_publish_root` option will instead replace the target root document with the root document's content of the documentation set being published.