### PR TITLE
maintenance for sphinx 4.x

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1209,12 +1209,22 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self.context.pop()) # sup
 
     def visit_inline(self, node):
+        has_added = False
+
         classes = node.get('classes', [])
         if classes in [['guilabel']]:
             self.body.append(self._start_tag(node, 'em'))
-            self.context.append(self._end_tag(node, suffix=''))
+            has_added = True
         elif classes in [['accelerator']]:
             self.body.append(self._start_tag(node, 'u'))
+            has_added = True
+        elif isinstance(node.parent, addnodes.desc_parameter):
+            # check if an identifier in signature
+            if classes in [['n']]:
+                self.body.append(self._start_tag(node, 'em'))
+                has_added = True
+
+        if has_added:
             self.context.append(self._end_tag(node, suffix=''))
         else:
             # ignoring; no special handling of other inline entries

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1260,14 +1260,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         attribs['style'] = 'clear: both;'
         self._figure_context.append('')
 
-        if 'align' in node.parent:
-            alignment = node.parent['align']
-
-            if alignment == 'default':
-                alignment = self._default_alignment
-            if alignment != 'left':
-                attribs['style'] = '{}text-align: {};'.format(
-                    attribs['style'], alignment)
+        alignment = node.parent.get('align', 'default')
+        if alignment == 'default':
+            alignment = self._default_alignment
+        if alignment != 'left':
+            attribs['style'] = '{}text-align: {};'.format(
+                attribs['style'], alignment)
 
         self.body.append(self._start_tag(node, 'p', **attribs))
         self.add_fignumber(node.parent)
@@ -1336,7 +1334,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         elif isinstance(node.parent, nodes.figure) and 'align' in node.parent:
             alignment = node.parent['align']
 
-        if alignment == 'default':
+        if not alignment or alignment == 'default':
             alignment = self._default_alignment
 
         if alignment:
@@ -1413,12 +1411,11 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
     def visit_legend(self, node):
         attribs = {}
-        if 'align' in node.parent:
-            alignment = node.parent['align']
-            if alignment == 'default':
-                alignment = self._default_alignment
-            if alignment != 'left':
-                attribs['style'] = 'text-align: {};'.format(alignment)
+        alignment = node.parent.get('align', 'default')
+        if alignment == 'default':
+            alignment = self._default_alignment
+        if alignment != 'left':
+            attribs['style'] = 'text-align: {};'.format(alignment)
 
         self.body.append(self._start_tag(node, 'div', **attribs))
         self.context.append(self._end_tag(node))

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,10 @@ commands =
     {envpython} -m sphinxcontrib.confluencebuilder {posargs}
 passenv = *
 
+[testenv:prerelease]
+deps = -r{toxinidir}/requirements_dev.txt
+pip_pre = true
+
 [testenv:pylint]
 deps = -r{toxinidir}/requirements_dev.txt
     pylint


### PR DESCRIPTION
### storage: support emphasis of identifier values in signatures

For releases of Sphinx pre-v4.x, signature descriptors could contain identifier entries wrapped in an emphasis node. In the most recent version of Sphinx (observed in 4.0.0b2), identifiers may not be wrapped in an emphasis node. Instead of relying on an emphasis node, use the class hint which identifiers an identifiers type \[1\] to build an `em` container.


### storage: handle no-alignment as default alignment

Sphinx has been refactoring \[2\]\[3\] its implementation to adjust the use of the `default` alignment back to `None`, to follow with docutils. Adjusting a series of lines which rely on the `default` assignment as a hint for default alignment, where now an unset alignment applies the default alignment as well.

---

\[1\]: https://github.com/sphinx-doc/sphinx/blob/v3.5.4/sphinx/addnodes.py#L224-L226
\[2\]: https://github.com/sphinx-doc/sphinx/issues/4550#issuecomment-760802022
\[3\]: https://github.com/sphinx-doc/sphinx/pull/8690