### PR TITLE
support publish header modifications

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -943,6 +943,20 @@ Advanced publishing configuration
     See also
     :ref:`Confluence Spaces and Unique Page Names <confluence_unique_page_names>`.
 
+.. confval:: confluence_publish_headers
+
+    A dictionary value which allows a user to pass key-value header information.
+    This is useful for users who need to interact with a Confluence instance
+    which expects (in a reverse proxy or the instance itself) specific header
+    information to be set. By default, no custom header entries are added with a
+    value of ``None``.
+
+    .. code-block:: python
+
+        confluence_publish_headers = {
+            'CUSTOM_HEADER': '<some-value>',
+        }
+
 .. confval:: confluence_publish_onlynew
 
     .. versionadded:: 1.3

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -153,6 +153,8 @@ def setup(app):
     app.add_config_value('confluence_publish_allowlist', None, False)
     """Subset of documents which are denied to be published."""
     app.add_config_value('confluence_publish_denylist', None, False)
+    """Header(s) to use for Confluence REST interaction."""
+    app.add_config_value('confluence_publish_headers', None, False)
     """Authentication passthrough for Confluence REST interaction."""
     app.add_config_value('confluence_server_auth', None, False)
     """Cookie(s) to use for Confluence REST interaction."""

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -186,6 +186,7 @@ def report_main(args_parser):
 
     # always sanitize out sensitive information
     sensitive_config('confluence_client_cert_pass')
+    sensitive_config('confluence_publish_headers')
     sensitive_config('confluence_server_pass')
 
     # optional sanitization

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -388,6 +388,12 @@ names are relative to the documentation's source directory.
 
     # ##################################################################
 
+    # confluence_publish_headers
+    validator.conf('confluence_publish_headers') \
+             .dict_str_str()
+
+    # ##################################################################
+
     # confluence_publish_onlynew
     validator.conf('confluence_publish_onlynew') \
              .bool()

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -60,6 +60,10 @@ class Rest:
             'https': config.confluence_proxy,
         }
 
+        # add custom header options based off the user's configuration
+        if config.confluence_publish_headers:
+            session.headers.update(config.confluence_publish_headers)
+
         if config.confluence_disable_ssl_validation:
             session.verify = False
         elif config.confluence_ca_cert:

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -460,6 +460,28 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
+    def test_config_check_publish_headers(self):
+        self.config['confluence_publish_headers'] = {}
+        self._try_config()
+
+        self.config['confluence_publish_headers'] = {
+            'CUSTOM_HEADER': 'some-value',
+            'another-header': 'another-value',
+        }
+        self._try_config()
+
+        self.config['confluence_publish_headers'] = {
+            'good-key-bad-value': None,
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_publish_headers'] = {
+            123: 'bad-key-good-value',
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
     def test_config_check_publish_list(self):
         dataset = os.path.join(self.test_dir, 'datasets', 'publish-set')
         assets_dir = os.path.join(self.test_dir, 'assets')


### PR DESCRIPTION
Introduces a configuration option `confluence_publish_headers` which allows a user to inject custom headers to be used when interacting with a Confluence instance. This help deal with unique environments which may require header options to exist (e.g. for authentication/etc.) for API requests to succeed.