### PR TITLE
doc: only border/color literal-marked pre-span

### DIFF
--- a/doc/_themes/sphinx13b/static/sphinx13b.css
+++ b/doc/_themes/sphinx13b/static/sphinx13b.css
@@ -431,7 +431,7 @@ div.viewcode-block:target {
     margin: 0px;
 }
 
-span.pre {
+code.literal span.pre {
     border: #ccc 1px solid;
     padding: 0px 4px;
     color: #CE0000;


### PR DESCRIPTION
Documentation will style `pre` class `span` entries with a border/color/etc. to help promote/identify the literals through the documentation set. It has been noticed that `confval` entries in newer Sphinx builds will be assigned the same style, which is not desired to be added to these configuration title entries.

Adjusting the styling to only apply the style modifications if the pre-span type is contained inside a literal marked code element.