### PR TITLE
support raw html injection

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -185,6 +185,8 @@ def setup(app):
     app.add_config_value('confluence_adv_ignore_nodes', None, False)
     """Unknown node handler dictionary for advanced integrations."""
     app.add_config_value('confluence_adv_node_handler', None, '')
+    """Enablement of permitting raw html blocks to be used in storage format."""
+    app.add_config_value('confluence_adv_permit_raw_html', None, False)
     """List of optional features/macros/etc. restricted for use."""
     app.add_config_value('confluence_adv_restricted', None, False)
     """Enablement of tracing processed data."""

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -61,6 +61,12 @@ def validate_configuration(builder):
 
     # ##################################################################
 
+    # confluence_adv_permit_raw_html
+    validator.conf('confluence_adv_permit_raw_html') \
+             .bool()
+
+    # ##################################################################
+
     # confluence_adv_trace_data
     validator.conf('confluence_adv_trace_data') \
              .bool()

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -49,6 +49,7 @@ def apply_defaults(conf):
         'confluence_add_secnumbers',
         'confluence_adv_aggressive_search',
         'confluence_adv_hierarchy_child_macro',
+        'confluence_adv_permit_raw_html',
         'confluence_adv_trace_data',
         'confluence_adv_writer_no_section_cap',
         'confluence_ask_password',

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1815,6 +1815,18 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self.context.pop()) # p
 
     def visit_raw(self, node):
+        # providing an advanced option to allow raw html injection in the output
+        #
+        # This is not always guaranteed to work; the raw html content may not
+        # be compatible with Atlassian's storage format. Results may fail to
+        # publish or contents may be suppressed on the Confluence instance. This
+        # is provided to help users wanted to somewhat support raw HTML content
+        # generated from Markdown sources.
+        if self.builder.config.confluence_adv_permit_raw_html:
+            if 'html' in node.get('format', '').split():
+                self.body.append(self.nl.join(node.astext().splitlines()))
+                raise nodes.SkipNode
+
         if 'confluence_storage' in node.get('format', '').split():
             self.body.append(self.nl.join(node.astext().splitlines()))
         else:


### PR DESCRIPTION
This commit provides an advanced option to allow raw html injection in the output of a storage-format generated document. This is to help users wanting to somewhat support raw HTML content generated from Markdown sources.

This is not always guaranteed to work; the raw html content may not be compatible with Atlassian's storage format. Results may fail to publish or contents may be suppressed on the Confluence instance.