### PR TITLE
storage: only apply default alignment on figure entities

### DIFF
--- a/tests/unit-tests/datasets/common/image.rst
+++ b/tests/unit-tests/datasets/common/image.rst
@@ -18,4 +18,5 @@ image
 .. internal image with scaling
 
 .. image:: ../../assets/image01.png
+    :align: right
     :scale: 20%

--- a/tests/unit-tests/test_rst_image.py
+++ b/tests/unit-tests/test_rst_image.py
@@ -37,6 +37,7 @@ class TestConfluenceRstImage(unittest.TestCase):
             self.assertTrue(url.has_attr('ri:value'))
             self.assertEqual(url['ri:value'],
                 'https://www.example.com/image.png')
+            self.assertFalse(image.has_attr('ac:align'))
 
             # ##########################################################
             # image with attributes
@@ -47,18 +48,21 @@ class TestConfluenceRstImage(unittest.TestCase):
             self.assertEqual(image['ac:alt'], 'alt text')
             self.assertTrue(image.has_attr('ac:width'))
             self.assertEqual(image['ac:width'], '200px')
+            self.assertFalse(image.has_attr('ac:align'))
 
             attachment = image.find('ri:attachment')
             self.assertTrue(attachment.has_attr('ri:filename'))
             self.assertEqual(attachment['ri:filename'], 'image01.png')
 
             # ##########################################################
-            # image with scaling
+            # image with alignment and scaling
             # ##########################################################
             image = images.pop(0)
 
             self.assertTrue(image.has_attr('ac:width'))
             self.assertIsNotNone(image['ac:width'])
+            self.assertTrue(image.has_attr('ac:align'))
+            self.assertEqual(image['ac:align'], 'right')
 
             attachment = image.find('ri:attachment')
             self.assertTrue(attachment.has_attr('ri:filename'))


### PR DESCRIPTION
With a previous change helping manage new alignment hints in Sphinx \[1\], these changes would apply default alignment hints to nodes which should not be using them. For example, table of contents captions and raw images (outside of figures) would apply a default alignment of `center`, where no implicit alignment is applied when using the `html` builder.

To correct this, only attempt to apply alignments to captions, legends and images if their parent is a figure node.

\[1\]: 50fd9ca636c54ab8fb272fe489154a3dcdf0ca73 