### PR TITLE
translator: rename escape text to encode text

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/__init__.py
+++ b/sphinxcontrib/confluencebuilder/translator/__init__.py
@@ -106,7 +106,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
         text = node.astext()
         if not self._literal:
             text = text.replace(self.nl, ' ')
-        text = self._escape_text(text)
+        text = self.encode(text)
         self.body.append(text)
         raise nodes.SkipNode
 
@@ -296,5 +296,5 @@ class ConfluenceBaseTranslator(BaseTranslator):
     # #                                                                        #
     # ##########################################################################
 
-    def _escape_text(self, node):
-        raise NotImplementedError('translator does not implement text escaping')
+    def encode(self, text):
+        raise NotImplementedError('translator does not implement text encoding')

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -73,8 +73,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         else:
             self.apply_hierarchy_children_macro = False
 
-    def _escape_text(self, node):
-        return self._escape_sf(node)
+    def encode(self, text):
+        return self._encode_sf(text)
 
     # ---------
     # structure
@@ -551,7 +551,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         title = node.get('scb-caption', None)
         if title:
-            title = self._escape_sf(title)
+            title = self._encode_sf(title)
 
         if node.get('linenos', False):
             num = 'true'
@@ -585,7 +585,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._start_tag(
                 node, 'hr', suffix=self.nl, empty=True))
             self.body.append(self._start_tag(node, 'pre'))
-            self.body.append(self._escape_sf(data))
+            self.body.append(self._encode_sf(data))
             self.body.append(self._end_tag(node))
             self.body.append(self._start_tag(
                 node, 'hr', suffix=self.nl, empty=True))
@@ -620,7 +620,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._start_tag(
                 node, 'hr', suffix=self.nl, empty=True))
             self.body.append(self._start_tag(node, 'pre'))
-            self.body.append(self._escape_sf(data))
+            self.body.append(self._encode_sf(data))
             self.body.append(self._end_tag(node))
             self.body.append(self._start_tag(
                 node, 'hr', suffix=self.nl, empty=True))
@@ -777,7 +777,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         if title_node:
             self.body.append(self._start_tag(node, 'p'))
             self.body.append(self._start_tag(node, 'strong'))
-            self.body.append(self._escape_sf(title_node.astext()))
+            self.body.append(self._encode_sf(title_node.astext()))
             self.body.append(self._end_tag(node))
             self.body.append(self._end_tag(node))
 
@@ -906,14 +906,14 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
     def _visit_reference_extern(self, node):
         uri = node['refuri']
-        uri = self._escape_sf(uri)
+        uri = self._encode_sf(uri)
 
         attribs = {}
         attribs['href'] = uri
 
         if 'reftitle' in node:
             title = node['reftitle']
-            title = self._escape_sf(title)
+            title = self._encode_sf(title)
             attribs['title'] = title
 
         self.body.append(self._start_tag(node, 'a', **attribs))
@@ -935,7 +935,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         target = ConfluenceState.target(anchorname)
         if target:
             anchor_value = target
-            anchor_value = self._escape_sf(anchor_value)
+            anchor_value = self._encode_sf(anchor_value)
         elif not self.can_anchor:
             anchor_value = None
         else:
@@ -990,7 +990,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             target = ConfluenceState.target(target_name)
             if target:
                 anchor_value = target
-                anchor_value = self._escape_sf(anchor_value)
+                anchor_value = self._encode_sf(anchor_value)
             elif self.can_anchor:
                 anchor_value = anchor
 
@@ -1004,7 +1004,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         # build link to internal anchor (on another page)
         #  Note: plain-text-link body cannot have inline markup; add the node
         #        contents into body and skip processing the rest of this node.
-        doctitle = self._escape_sf(doctitle)
+        doctitle = self._encode_sf(doctitle)
         self.body.append(self._start_ac_link(node, anchor_value))
         self.body.append(self._start_tag(node, 'ri:page',
             suffix=self.nl, empty=True, **{'ri:content-title': doctitle}))
@@ -1090,10 +1090,10 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         # footnote label and back reference(s)
         if (not self.can_anchor
                 or 'backrefs' not in node or not node['backrefs']):
-            label_text = self._escape_sf(label_text)
+            label_text = self._encode_sf(label_text)
             self.body.append(label_text)
         elif len(node['backrefs']) > 1:
-            label_text = self._escape_sf(label_text)
+            label_text = self._encode_sf(label_text)
             self.body.append(label_text)
 
             self.body.append(self._start_tag(node, 'div'))
@@ -1140,7 +1140,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         if not self.can_anchor:
             self.body.append(self._start_tag(node, 'sup'))
-            self.body.append(self._escape_sf(text))
+            self.body.append(self._encode_sf(text))
             self.body.append(self._end_tag(node, suffix='')) # sup
             raise nodes.SkipNode
 
@@ -1297,7 +1297,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
     def visit_image(self, node):
         uri = node['uri']
-        uri = self._escape_sf(uri)
+        uri = self._encode_sf(uri)
 
         if node.get('from_math') and node.get('math_depth'):
             math_depth = node['math_depth']
@@ -1334,7 +1334,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         if 'alt' in node:
             alt = node['alt']
-            alt = self._escape_sf(alt)
+            alt = self._encode_sf(alt)
             attribs['ac:alt'] = alt
 
         if 'scale' in node and 'width' not in node:
@@ -1384,7 +1384,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
             hosting_doctitle = ConfluenceState.title(
                 hosting_docname, hosting_docname)
-            hosting_doctitle = self._escape_sf(hosting_doctitle)
+            hosting_doctitle = self._encode_sf(hosting_doctitle)
 
             self.body.append(self._start_ac_image(node, **attribs))
             self.body.append(self._start_ri_attachment(node, image_key))
@@ -1416,7 +1416,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
     def visit_download_reference(self, node):
         uri = node['reftarget']
-        uri = self._escape_sf(uri)
+        uri = self._encode_sf(uri)
 
         if uri.find('://') != -1:
             self.body.append(self._start_tag(node, 'strong'))
@@ -1436,7 +1436,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 raise nodes.SkipNode
 
             hosting_doctitle = ConfluenceState.title(hosting_docname)
-            hosting_doctitle = self._escape_sf(hosting_doctitle)
+            hosting_doctitle = self._encode_sf(hosting_doctitle)
 
             # If the view-file macro is permitted along with it not being an
             # explicitly referenced asset.
@@ -1527,13 +1527,13 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         for production in node:
             if production['tokenname']:
                 formatted_token = production['tokenname'].ljust(max_len)
-                formatted_token = self._escape_sf(formatted_token)
+                formatted_token = self._encode_sf(formatted_token)
                 self.body.append('{} ::='.format(formatted_token))
                 lastname = production['tokenname']
             else:
                 self.body.append('{}    '.format(' ' * len(lastname)))
             text = production.astext()
-            text = self._escape_sf(text)
+            text = self._encode_sf(text)
             self.body.append(text + self.nl)
 
         self.body.append(self._end_tag(node))
@@ -1776,7 +1776,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         attribs = {}
         if 'explanation' in node:
             title_value = node['explanation']
-            title_value = self._escape_sf(title_value)
+            title_value = self._encode_sf(title_value)
             attribs['title'] = title_value
 
         self.body.append(self._start_tag(node, 'abbr', **attribs))
@@ -2207,18 +2207,18 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         """
         return data.replace(']]>', ']]]]><![CDATA[>')
 
-    def _escape_sf(self, data):
+    def _encode_sf(self, data):
         """
-        escapes text to be inserted directly into a storage format area
+        encodes text to be inserted directly into a storage format area
 
-        A helper used to return content that has been properly escaped and can
+        A helper used to return content that has been properly encoded and can
         be directly placed inside a Confluence storage-format-prepared document.
 
         Args:
             data: the text
 
         Returns:
-            the escaped text
+            the encoded text
         """
         STORAGE_FORMAT_REPLACEMENTS = {
             ('<', '&lt;'),
@@ -2238,7 +2238,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         """
         fetch the alignment to be used on a node
 
-        A helper used to return content that has been properly escaped and can
+        A helper used to return content that has been properly encoded and can
         be directly placed inside a Confluence storage-format-prepared document.
 
         Args:
@@ -2260,6 +2260,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 alignment = self._default_alignment
 
         if alignment:
-            alignment = self._escape_sf(alignment)
+            alignment = self._encode_sf(alignment)
 
         return alignment


### PR DESCRIPTION
Renaming the escape method calls to a more proper name (encode text), to better reflect its purpose.

This change also exposes `encode` on this extension's translator instance, to better serve third-party extensions which may wish to encode text to be used for a configured translator.