### PR TITLE
tests: fail-fast when running the validator

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -171,4 +171,4 @@ class TestConfluenceValidation(unittest.TestCase):
         build_sphinx(dataset, config=config, out_dir=doc_dir)
 
 if __name__ == '__main__':
-    sys.exit(unittest.main(verbosity=0))
+    sys.exit(unittest.main(failfast=True, verbosity=0))


### PR DESCRIPTION
Validation executions are expected to be all or nothing. When invoking a validation run, hint that the tests should fail-fast when an error occurs (to stop any other validation tests from running).