### PR TITLE
force str cast on uri attribute values

### DIFF
--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -230,7 +230,7 @@ class ConfluenceAssetManager:
             standalone (optional): ignore hash mappings (defaults to False)
         """
 
-        uri = node['uri']
+        uri = str(node['uri'])
         if not uri.startswith('data:') and uri.find('://') == -1:
             path = self._interpretAssetPath(node)
             if path:
@@ -314,7 +314,7 @@ class ConfluenceAssetManager:
         path = None
         if isinstance(node, nodes.image):
             # uri's will be relative to documentation root.
-            path = node['uri']
+            path = str(node['uri'])
         elif isinstance(node, addnodes.download_reference):
             # reftarget will be a reference to the asset with respect to the
             # document (refdoc) holding this reference. Use reftarget and refdoc

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -26,6 +26,11 @@ import math
 import posixpath
 import sys
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     _tracked_unknown_code_lang = []
 
@@ -2228,7 +2233,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         }
 
         # first pass needs to handle ampersand
-        data = data.replace('&', '&amp;')
+        data = unicode(data).replace('&', '&amp;')
 
         for find, encoded in STORAGE_FORMAT_REPLACEMENTS:
             data = data.replace(find, encoded)


### PR DESCRIPTION
Typically, `uri` attributes processed by this extension have typically seen the values be only `str` types. However, it has been observed that some extensions (e.g. `sphinxcontrib.drawio`) that the type for `uri` attributes on images can be `pathlib` types. To be flexible on whatever type is set, always cast these entries to `str` to ensure consistent processing.