### PR TITLE
adjust attachment no-check header to most recent value

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -14,6 +14,7 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluenceSeraphAuthentic
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceSslError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceTimeoutError
 from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
+from sphinxcontrib.confluencebuilder.std.confluence import NOCHECK
 from requests.adapters import HTTPAdapter
 import json
 import requests
@@ -133,12 +134,12 @@ class Rest:
 
             # Atlassian's documenation indicates to the security token check
             # when publishing attachments [1][2]. If adding files, set a
-            # 'nocheck' value to the token.
+            # 'no-check' value to the token (originally 'nocheck').
             #
             # [1]: https://developer.atlassian.com/cloud/confluence/rest/#api-content-id-child-attachment-post
             # [2]: https://developer.atlassian.com/server/jira/platform/form-token-handling/
             if files:
-                headers['X-Atlassian-Token'] = 'nocheck'
+                headers['X-Atlassian-Token'] = NOCHECK
 
             rsp = self.session.post(
                 restUrl, json=data, files=files, headers=headers)

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -54,6 +54,7 @@ class Rest:
         session = requests.Session()
         session.headers.update({
             'User-Agent': 'Sphinx Confluence Builder',
+            'X-Atlassian-Token': NOCHECK,
         })
         session.timeout = config.confluence_timeout
         session.proxies = {
@@ -130,19 +131,7 @@ class Rest:
     def post(self, key, data, files=None):
         restUrl = self.url + API_REST_BIND_PATH + '/' + key
         try:
-            headers = dict(self.session.headers)
-
-            # Atlassian's documenation indicates to the security token check
-            # when publishing attachments [1][2]. If adding files, set a
-            # 'no-check' value to the token (originally 'nocheck').
-            #
-            # [1]: https://developer.atlassian.com/cloud/confluence/rest/#api-content-id-child-attachment-post
-            # [2]: https://developer.atlassian.com/server/jira/platform/form-token-handling/
-            if files:
-                headers['X-Atlassian-Token'] = NOCHECK
-
-            rsp = self.session.post(
-                restUrl, json=data, files=files, headers=headers)
+            rsp = self.session.post(restUrl, json=data, files=files)
         except requests.exceptions.Timeout:
             raise ConfluenceTimeoutError(self.url)
         except requests.exceptions.SSLError as ex:

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -5,6 +5,7 @@
 """
 
 from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_HIGHLIGHT_STYLE
+import os
 
 """
 confluence trailing bind path for rest api
@@ -144,6 +145,21 @@ When provided a language type that is not supported by Confluence is detected on
 a code block, this fallback style will be applied instead.
 """
 FALLBACK_HIGHLIGHT_STYLE = 'none'
+
+"""
+no-check value to inject into a X-Atlassian-Token header
+
+Defines the no-check value to assign to the X-Atlassian-Token to handle
+attachment publishing with XSRF protections. Originally, the no-check value was
+a value of `nocheck`; however, the current promoted value is `no-check`. In all
+supported Confluence instances, the `no-check` value should work. The
+environment variable `CONFLUENCEBUILDER_LEGACY_NOCHECK` can be set for users who
+experience may experience issues with the newer value.
+"""
+if 'CONFLUENCEBUILDER_LEGACY_NOCHECK' in os.environ:
+    NOCHECK = 'nocheck'
+else:
+    NOCHECK = 'no-check'
 
 """
 supported image types


### PR DESCRIPTION
Based off some newer documentation and implementation checks, it appears that no-check value to be set for the `X-Atlassian-Token` header should be a value of `no-check` instead of `nocheck`; adjusting.

This commit also adds an undocumented `CONFLUENCEBUILDER_LEGACY_NOCHECK` environment option to use the legacy header value for users who may experience issues in their environments.

### testing

Confluence versions to be tested against:

- [x] Confluence Cloud (Organization)
- [x] Confluence Cloud (User)
- [x] Confluence Server 6.13.x
- [x] Confluence Server 6.14.x
- [x] Confluence Server 6.15.x
- [x] Confluence Server 7.0.x
- [x] Confluence Server 7.1.x
- [x] Confluence Server 7.2.x
- [x] Confluence Server 7.3.x
- [x] Confluence Server 7.4.x
- [x] Confluence Server 7.5.x
- [x] Confluence Server 7.6.x
- [x] Confluence Server 7.7.x
- [x] Confluence Server 7.8.x
- [x] Confluence Server 7.9.x
- [x] Confluence Server 7.10.x
- [x] Confluence Server 7.11.x
- [x] Confluence Server 7.12.x