### PR TITLE
support cell alignment hints injected in the classes attribute

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -192,7 +192,17 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.depart_caption(node)
 
     def visit_paragraph(self, node):
-        self.body.append(self._start_tag(node, 'p'))
+        attribs = {}
+
+        # MyST-Parser will inject text-align hints in the node's classes
+        # attribute; if set, attempt to apply the style
+        if isinstance(node.parent, nodes.entry):
+            for class_ in node.parent.get('classes', []):
+                if class_.startswith('text-align:'):
+                    attribs['style'] = self._encode_sf(class_)
+                    break
+
+        self.body.append(self._start_tag(node, 'p', **attribs))
         self.context.append(self._end_tag(node))
 
     def depart_paragraph(self, node):


### PR DESCRIPTION
It has been observed that some extensions (e.g. MyST-Parser) will inject alignment hints for cells into a node's `classes` attribute. This would allow a styling to define a, for example, `text-align:center` class which can include a center alignment hint for formatting on a document.

In the event that a text-align style has been detected inside a class list on a node, directly inject it into the style attribute of the paragraph holding the cell data.