### PR TITLE
doc: add versionadded for recently added configurations

### DIFF
--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -20,6 +20,8 @@ Release steps
 When implementation is deemed to be ready for a stable release, ensure the
 following steps are performed:
 
+- Ensure newly added/changed configuration options are properly reflecting a
+  ``versionadded`` or equivalent hint.
 - Update ``CHANGES.rst``, replacing the development title with release version
   and date.
 - Ensure version values in the implementation are incremented and tagged
@@ -53,7 +55,20 @@ reference, ensure the following post-release tasks are performed:
   match the ``stable`` documentation. Also, ensure the newly created tag is
   listed as a valid option for users to reference.
 - Generate online validation set (examples) based off the recent release tag.
-  This includes both the version space and the ``STABLE`` space.
+  This includes both the version space and the ``STABLE`` space. Overrides for
+  consideration:
+
+  .. code-block:: python
+
+      # version space
+      config_overrides['confluence_space_name'] = 'V010X00'
+      config_test_key = 'v1.x'
+      config_test_desc = 'v1.x release'
+
+      # stable space
+      config_overrides['confluence_space_name'] = 'STABLE'
+      config_test_key = 'Stable'
+      config_test_desc = 'stable release (v1.x)'
 
 .. _Atlassian Support End of Life Policy: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
 .. _CONTRIBUTING.rst: https://github.com/sphinx-contrib/confluencebuilder/blob/master/CONTRIBUTING.rst

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -471,6 +471,8 @@ Publishing configuration
 
 .. confval:: confluence_publish_root
 
+    .. versionadded:: 1.5
+
     .. note::
 
         This option cannot be used with |confluence_parent_page|_.
@@ -944,6 +946,8 @@ Advanced publishing configuration
     :ref:`Confluence Spaces and Unique Page Names <confluence_unique_page_names>`.
 
 .. confval:: confluence_publish_headers
+
+    .. versionadded:: 1.5
 
     A dictionary value which allows a user to pass key-value header information.
     This is useful for users who need to interact with a Confluence instance


### PR DESCRIPTION
Adding `versionadded` to newly added configurations from the v1.5 release.

In addition, adding notes on the `MAINTAINERS` document to ensure they are not missed during a release.