### PR TITLE
only inject sphinx.ext.imgmath if confluence building

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -239,7 +239,10 @@ def setup(app):
     # users will need to explicitly load 'sphinx.ext.mathbase'.
     if (imgmath is not None and
             'sphinx.ext.imgmath' not in app.config.extensions):
-        imgmath.setup(app)
+        def lazy_bind_imgmath(app):
+            if app.builder.name in ['confluence', 'singleconfluence']:
+                imgmath.setup(app)
+        app.connect('builder-inited', lazy_bind_imgmath)
 
     return {
         'version': __version__,


### PR DESCRIPTION
This extension would automatically inject the `sphinx.ext.imgmath` extension into the Sphinx application if the extension was not detected as configured by a user. This was to help users easily use the only supported math-handling extension for math directives when publishing to Confluence targets.

An issue with this approach is that this would also inject the extension for a Sphinx invoke, even when not using a Confluence builder (e.g. if a user is building an `html` builder). This would override any other math extension (e.g. `sphinx.ext.jsmath`) that may be registered. To prevent this, only lazily inject `sphinx.ext.imgmath` when using a Confluence-based builder.