### PR TITLE
test with sphinx 4.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,33 +16,33 @@ jobs:
         include:
             - { os:  ubuntu-latest, python: 2.7, toxenv: py27-sphinx18, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.6, toxenv: py36-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: 3.6, toxenv: py36-sphinx32, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.6, toxenv: py36-sphinx33, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.6, toxenv: py36-sphinx34, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.6, toxenv: py36-sphinx35, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.6, toxenv: py36-sphinx40, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: 3.6, toxenv: py36-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.7, toxenv: py37-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: 3.7, toxenv: py37-sphinx32, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.7, toxenv: py37-sphinx33, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.7, toxenv: py37-sphinx34, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.7, toxenv: py37-sphinx35, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.7, toxenv: py37-sphinx40, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: 3.7, toxenv: py37-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.8, toxenv: py38-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: 3.8, toxenv: py38-sphinx32, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.8, toxenv: py38-sphinx33, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.8, toxenv: py38-sphinx34, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.8, toxenv: py38-sphinx35, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.8, toxenv: py38-sphinx40, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: 3.8, toxenv: py38-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.9, toxenv: py39-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: 3.9, toxenv: py39-sphinx32, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.9, toxenv: py39-sphinx33, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.9, toxenv: py39-sphinx34, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.9, toxenv: py39-sphinx35, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.9, toxenv: py39-sphinx40, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: 3.9, toxenv: py39-sphinx41, cache: ~/.cache/pip }
             - { os:   macos-latest, python: 2.7, toxenv: py27-sphinx18, cache: ~/Library/Caches/pip }
-            - { os:   macos-latest, python: 3.9, toxenv: py39-sphinx40, cache: ~/Library/Caches/pip }
+            - { os:   macos-latest, python: 3.9, toxenv: py39-sphinx41, cache: ~/Library/Caches/pip }
             - { os: windows-latest, python: 2.7, toxenv: py27-sphinx18, cache: ~\AppData\Local\pip\Cache }
-            - { os: windows-latest, python: 3.9, toxenv: py39-sphinx40, cache: ~\AppData\Local\pip\Cache }
+            - { os: windows-latest, python: 3.9, toxenv: py39-sphinx41, cache: ~\AppData\Local\pip\Cache }
             - { os:  ubuntu-latest, python: 3.9, toxenv:        flake8, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: 3.9, toxenv:        pylint, cache: ~/.cache/pip }
 

--- a/tests/unit-tests/test_sphinx_domains.py
+++ b/tests/unit-tests/test_sphinx_domains.py
@@ -98,9 +98,17 @@ class TestConfluenceSphinxDomains(unittest.TestCase):
                 'param1',
                 'param2',
                 _('Throws') + ':',
-                'SomeError',
-                _('Returns') + ':',
             ]
+
+            # in sphinx v4.1+, exception are no longer strong styled
+            if parse_version(sphinx_version) < parse_version('4.1'):
+                expected_stronged.extend([
+                    'SomeError',
+                ])
+
+            expected_stronged.extend([
+                _('Returns') + ':',
+            ])
 
             stronged = desc.find_all('strong')
             self.assertEqual(len(stronged), len(expected_stronged))

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,36,37,38,39}-sphinx{18}
-    py{36,37,38,39}-sphinx{32,33,34,35,40}
+    py{36,37,38,39}-sphinx{33,34,35,40,41}
     flake8
     pylint
 
@@ -9,11 +9,11 @@ envlist =
 deps =
     -r{toxinidir}/requirements_dev.txt
     sphinx18: sphinx>=1.8,<2.0
-    sphinx32: sphinx>=3.2,<3.3
     sphinx33: sphinx>=3.3,<3.4
     sphinx34: sphinx>=3.4,<3.5
     sphinx35: sphinx>=3.5,<3.6
     sphinx40: sphinx>=4.0,<4.1
+    sphinx41: sphinx>=4.1,<4.2
 commands =
     {envpython} -m tests {posargs}
 setenv =


### PR DESCRIPTION
Sphinx provides a stable v4.1.x series; adjusting the tox configuration and workflows to support the newer revision. Following maintenance guidelines, this allows a series of legacy Sphinx revisions to be dropped as well.