### PR TITLE
tests: always include sphinx.ext.imgmath extension for tests

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -104,7 +104,11 @@ def prepare_conf():
     a Sphinx application instance.
     """
     config = {}
-    config['extensions'] = [EXT_NAME]
+    config['extensions'] = [
+        EXT_NAME,
+        # include any forced-injected extensions (config support)
+        'sphinx.ext.imgmath',
+    ]
     config['confluence_publish'] = False
 
     # support pre-Sphinx v2.0 installations which default to 'contents'


### PR DESCRIPTION
Injecting the `sphinx.ext.imgmath` extension into the validation testing as the configuration preloading will generate a warning (which will fail the validation test) since imgmath is now loaded at a later stage \[1\].

\[1\]: 32af6a9c6b206878a64c65a80829b9fec7c1deca