### PR TITLE
remove non-space control characters

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/__init__.py
+++ b/sphinxcontrib/confluencebuilder/translator/__init__.py
@@ -14,6 +14,7 @@ from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_ALIGNMENT
 from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_HIGHLIGHT_STYLE
 import io
 import sys
+import unicodedata
 
 class ConfluenceBaseTranslator(BaseTranslator):
     _tracked_deprecated_raw_type = False
@@ -291,10 +292,9 @@ class ConfluenceBaseTranslator(BaseTranslator):
         self._docnames.pop()
 
     # ##########################################################################
-    # #                                                                        #
-    # # virtual methods                                                        #
-    # #                                                                        #
-    # ##########################################################################
 
     def encode(self, text):
-        raise NotImplementedError('translator does not implement text encoding')
+        # remove any non-space control characters that cannot be published to a
+        # confluence instance
+        return ''.join(c for c in text if c.isspace()
+            or unicodedata.category(c)[0] != 'C')

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -79,7 +79,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.apply_hierarchy_children_macro = False
 
     def encode(self, text):
-        return self._encode_sf(text)
+        text = self._encode_sf(text)
+        return ConfluenceBaseTranslator.encode(self, text)
 
     # ---------
     # structure
@@ -2221,7 +2222,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         Returns:
             the escaped text
         """
-        return data.replace(']]>', ']]]]><![CDATA[>')
+        data = data.replace(']]>', ']]]]><![CDATA[>')
+        return ConfluenceBaseTranslator.encode(self, data)
 
     def _encode_sf(self, data):
         """


### PR DESCRIPTION
When prepare text to be published to a Confluence instance, always remove any non-space control characters. This prevents publishing errors such as the following:

    An unsupported Confluence API call has been made.

    REQ: PUT
    RSP: 400
    URL: .../rest/api
    API: content
    DATA: {
      "statusCode": 400,
      "data": {
        "authorized": false,
        "valid": true,
        "errors": [],
        "successful": false
      },
      "message": "com.atlassian.confluence.api.service.exceptions.BadRequestException: Error parsing xhtml: Illegal character ((...))\n at [row,col {unknown-source}]: ...,...]"
    }