### PR TITLE
inject newlines for non-wrapped content

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1810,6 +1810,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     def depart_acronym(self, node):
         self.body.append(self.context.pop()) # acronym
 
+    def depart_line(self, node):
+        next_sibling = first(node.traverse(
+            include_self=False, descend=False, siblings=True))
+        if isinstance(next_sibling, nodes.line):
+            self.body.append('<br />')
+
     def visit_line_block(self, node):
         self.body.append(self._start_tag(node, 'p'))
         self.context.append(self._end_tag(node))


### PR DESCRIPTION
When Sphinx provides line nodes through a translator, there is most likely a desire to ensure that each line node help represent text on their own individual lines. The previous translator would only group line block entries into paragraphs -- which work for the most part, but not for all documentation cases. When multiple line nodes are detected, inject a newline (`<br />`).