### PR TITLE
skip image nodes without a uri

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1312,6 +1312,10 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self.context.pop()) # <dynamic>
 
     def visit_image(self, node):
+        if 'uri' not in node or not node['uri']:
+            ConfluenceLogger.verbose('skipping image with no uri')
+            raise nodes.SkipNode
+
         uri = node['uri']
         uri = self._encode_sf(uri)
 


### PR DESCRIPTION
If an `image` node type is provided to a translator which does not have a valid `uri` attribute value, ignore it. This is to gracefully deal with extensions which may produce an incomplete image node in for a non-fatal condition.