### PR TITLE
publisher: force v1 editor

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -477,6 +477,17 @@ class ConfluencePublisher():
             if not page:
                 newPage = self._buildPage(page_name, data)
 
+                # only the legacy editor is supported at this time; forced v1
+                # since Confluence Cloud appears to have an inconsistent default
+                # editor
+                newPage['metadata'] = {
+                    'properties': {
+                        'editor': {
+                            'value': 'v1',
+                        }
+                    }
+                }
+
                 if self.can_labels:
                     self._populate_labels(newPage, data['labels'])
 


### PR DESCRIPTION
The Sphinx Confluence Builder still only supports the legacy display with storage format content generated from the storage format translator. Recent changes show that even when publishing with a representation request of `storage`, the content will be accepted but a newer editor may be used. This is undesired at this time (until an ADF translator is introduced).

To ensure we use the legacy editor, inject the metadata for new pages to explicitly indicate that a `v1` editor must be used. This appears to work with Confluence Cloud and (at least) the oldest supported Confluence Server revision. Note that the metadata is not applied on updated pages as the forced conversion is not supported by an update request.