### PR TITLE
flag max-doc-depth config as deprecated

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -44,6 +44,9 @@ def deprecated(validator):
     if config.confluence_max_doc_depth == 0:
         ConfluenceLogger.warn('%s with a value of zero is deprecated; '
             "use the 'singleconfluence' builder instead" % key)
+    elif config.confluence_max_doc_depth:
+        ConfluenceLogger.warn('%s is deprecated and will be removed; '
+            "consider using the 'singleconfluence' builder instead" % key)
 
 def warnings(validator):
     """

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -393,10 +393,12 @@ class TestConfluenceConfigChecks(unittest.TestCase):
 
     def test_config_check_max_doc_depth(self):
         self.config['confluence_max_doc_depth'] = 2
-        self._try_config()
+        with self.assertRaises(SphinxWarning):
+            self._try_config()
 
         self.config['confluence_max_doc_depth'] = '2'
-        self._try_config()
+        with self.assertRaises(SphinxWarning):
+            self._try_config()
 
         self.config['confluence_max_doc_depth'] = -1
         with self.assertRaises(ConfluenceConfigurationError):
@@ -411,7 +413,8 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         defines = {
             'confluence_max_doc_depth': '1',
         }
-        self._try_config(edefs=defines)
+        with self.assertRaises(SphinxWarning):
+            self._try_config(edefs=defines)
 
     def test_config_check_parent_page(self):
         self.config['confluence_parent_page'] = 'dummy'

--- a/tests/unit-tests/test_config_hierarchy.py
+++ b/tests/unit-tests/test_config_hierarchy.py
@@ -23,7 +23,7 @@ class TestConfluenceConfigPrevNext(unittest.TestCase):
         self.dataset = os.path.join(test_dir, 'datasets', 'hierarchy')
 
     def test_config_hierarchy_max_depth(self):
-        out_dir = build_sphinx(self.dataset, config=self.config)
+        out_dir = build_sphinx(self.dataset, config=self.config, relax=True)
 
         index = os.path.join(out_dir, 'index.conf')
         self.assertTrue(os.path.exists(index),
@@ -43,7 +43,7 @@ class TestConfluenceConfigPrevNext(unittest.TestCase):
 
     def test_config_hierarchy_parent_registration(self):
         ConfluenceState.reset()
-        build_sphinx(self.dataset, config=self.config)
+        build_sphinx(self.dataset, config=self.config, relax=True)
 
         # root toctree should not have a parent
         root_doc = ConfluenceState.parentDocname('index')
@@ -63,7 +63,7 @@ class TestConfluenceConfigPrevNext(unittest.TestCase):
         self.assertEqual(parent_doc, 'toctree-doc2')
 
     def test_storage_config_hierarchy_max_depth(self):
-        out_dir = build_sphinx(self.dataset, config=self.config)
+        out_dir = build_sphinx(self.dataset, config=self.config, relax=True)
 
         # ensure data is merged in when capping the depth
         doc2_expected_headers = [


### PR DESCRIPTION
The `confluence_max_doc_depth` has been flagged as deprecated, with the intent of users to move to using the `singleconfluence` builder instead. Adding a warning message for users who may be still using this feature.
