### PR TITLE
switch towards root_doc

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -197,7 +197,7 @@ Generic configuration
 
     A positive integer value, if provided, to indicate the maximum depth
     permitted for a nested child page before its contents is inlined with a
-    parent. The root of all pages is typically the configured master_doc_. The
+    parent. The root of all pages is typically the configured root_doc_. The
     root page is considered to be at a depth of zero. By default, the maximum
     document depth is disabled with a value of ``None``.
 
@@ -216,9 +216,9 @@ Generic configuration
 .. confval:: confluence_page_hierarchy
 
     A boolean value to whether or not nest pages in a hierarchical ordered. The
-    root of all pages is typically the configured master_doc_. If a master_doc_
+    root of all pages is typically the configured root_doc_. If a root_doc_
     instance contains a toctree_, listed documents will become child pages of
-    the master_doc_. This cycle continues for child pages with their own
+    the root_doc_. This cycle continues for child pages with their own
     toctree_ markups. By default, hierarchy mode is disabled with a value of
     ``False``.
 
@@ -226,7 +226,7 @@ Generic configuration
 
         confluence_page_hierarchy = True
 
-    Note that even if hierarchy mode is enabled, the configured master_doc_ page
+    Note that even if hierarchy mode is enabled, the configured root_doc_ page
     and other published pages that are not defined in the complete toctree_,
     these documents will still be published and uploaded to either the
     configured |confluence_parent_page|_ or in the root of the space.
@@ -374,18 +374,18 @@ Publishing configuration
     :ref:`directive <confluence_metadata>`. See also
     |confluence_append_labels|_.
 
-.. |confluence_master_homepage| replace:: ``confluence_master_homepage``
-.. _confluence_master_homepage:
+.. |confluence_root_homepage| replace:: ``confluence_root_homepage``
+.. _confluence_root_homepage:
 
-.. confval:: confluence_master_homepage
+.. confval:: confluence_root_homepage
 
     A boolean value to whether or not force the configured space's homepage to
-    be set to the page defined by the Sphinx configuration's master_doc_. By
-    default, the master_doc_ configuration is ignored with a value of ``False``.
+    be set to the page defined by the Sphinx configuration's root_doc_. By
+    default, the root_doc_ configuration is ignored with a value of ``False``.
 
     .. code-block:: python
 
-        confluence_master_homepage = False
+        confluence_root_homepage = False
 
 .. |confluence_parent_page| replace:: ``confluence_parent_page``
 .. _confluence_parent_page:
@@ -409,7 +409,7 @@ Publishing configuration
         confluence_parent_page = 'MyAwesomeDocs'
 
     If a parent page is not set, consider using the
-    |confluence_master_homepage|_ option as well. Note that the page's name can
+    |confluence_root_homepage|_ option as well. Note that the page's name can
     be case-sensitive in most (if not all) versions of Confluence.
 
     See also |confluence_publish_root|_.
@@ -522,27 +522,27 @@ Publishing configuration
     See also:
 
     - |confluence_publish_dryrun|_
-    - |confluence_purge_from_master|_
+    - |confluence_purge_from_root|_
 
-.. |confluence_purge_from_master| replace:: ``confluence_purge_from_master``
-.. _confluence_purge_from_master:
+.. |confluence_purge_from_root| replace:: ``confluence_purge_from_root``
+.. _confluence_purge_from_root:
 
-.. confval:: confluence_purge_from_master
+.. confval:: confluence_purge_from_root
 
     A boolean value to which indicates that any purging attempt should be done from
-    the root of a published master_doc_ page (instead of a configured parent page;
+    the root of a published root_doc_ page (instead of a configured parent page;
     i.e. |confluence_parent_page|_). In specific publishing scenarios, a user may
     wish to publish multiple documentation sets based off a single parent/container
     page. To prevent any purging between multiple documentation sets, this option
     can be set to ``True``. When generating legacy pages to be removed, this
     extension will only attempt to populate legacy pages based off the children of
-    the master_doc_ page. This option requires |confluence_purge|_ to be set to
+    the root_doc_ page. This option requires |confluence_purge|_ to be set to
     ``True`` before taking effect. If |confluence_publish_root|_ is set, this
     option is implicitly enabled.
 
     .. code-block:: python
 
-        confluence_purge_from_master = False
+        confluence_purge_from_root = False
 
     See also |confluence_purge|_.
 
@@ -1171,11 +1171,23 @@ Advanced processing configuration
 Deprecated options
 ------------------
 
+.. confval:: confluence_master_homepage
+
+    .. versionchanged:: 1.6
+
+    This option has been renamed to |confluence_root_homepage|_.
+
 .. confval:: confluence_publish_subset
 
     .. versionchanged:: 1.3
 
     This option has been renamed to |confluence_publish_allowlist|_.
+
+.. confval:: confluence_purge_from_master
+
+    .. versionchanged:: 1.6
+
+    This option has been renamed to |confluence_purge_from_root|_.
 
 .. references ------------------------------------------------------------------
 
@@ -1190,7 +1202,7 @@ Deprecated options
 .. _api_tokens: https://confluence.atlassian.com/cloud/api-tokens-938839638.html
 .. _get_outdated_docs: https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder.get_outdated_docs
 .. _get_relative_uri: https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder.get_relative_uri
-.. _master_doc: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-master_doc
+.. _root_doc: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-root_doc
 .. _sphinx-build: https://www.sphinx-doc.org/en/master/man/sphinx-build.html
 .. _toctree: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree
 .. _write_doc: https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder.write_doc

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -101,8 +101,8 @@ def setup(app):
     app.add_config_value('confluence_disable_notifications', None, False)
     """Define a series of labels to apply to all published pages."""
     app.add_config_value('confluence_global_labels', None, False)
-    """Enablement of configuring master as space's homepage."""
-    app.add_config_value('confluence_master_homepage', None, False)
+    """Enablement of configuring root as space's homepage."""
+    app.add_config_value('confluence_root_homepage', None, False)
     """Parent page's name to publish documents under."""
     app.add_config_value('confluence_parent_page', None, False)
     """Perform a dry run of publishing to inspect what publishing will do."""
@@ -117,8 +117,8 @@ def setup(app):
     app.add_config_value('confluence_publish_root', None, '')
     """Enablement of purging legacy child pages from a parent page."""
     app.add_config_value('confluence_purge', None, False)
-    """Enablement of purging legacy child pages from a master page."""
-    app.add_config_value('confluence_purge_from_master', None, False)
+    """Enablement of purging legacy child pages from a root page."""
+    app.add_config_value('confluence_purge_from_root', None, False)
     """docname-2-title dictionary for title overrides."""
     app.add_config_value('confluence_title_overrides', None, 'env')
     """Timeout for network-related calls (publishing)."""
@@ -195,8 +195,12 @@ def setup(app):
     app.add_config_value('confluence_adv_writer_no_section_cap', None, False)
 
     """(configuration - deprecated)"""
+    # replaced by confluence_root_homepage
+    app.add_config_value('confluence_master_homepage', None, False)
     # replaced by confluence_publish_allowlist
     app.add_config_value('confluence_publish_subset', None, False)
+    # replaced by confluence_purge_from_root
+    app.add_config_value('confluence_purge_from_master', None, False)
 
     # ##########################################################################
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -83,7 +83,7 @@ def setup(app):
     app.add_config_value('confluence_footer_file', None, False)
     """Enablement of the maximum document depth (before inlining)."""
     app.add_config_value('confluence_max_doc_depth', None, False)
-    """Enablement of publishing pages into a hierarchy from a master toctree."""
+    """Enablement of publishing pages into a hierarchy from a root toctree."""
     app.add_config_value('confluence_page_hierarchy', None, False)
     """Show previous/next buttons (bottom, top, both, None)."""
     app.add_config_value('confluence_prev_next_buttons_location', None, False)

--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -64,7 +64,7 @@ class ConfluenceAssetManager:
         self.keys = set()
         self.outdir = outdir
         self.path2asset = {}
-        self.root_doc = config.master_doc
+        self.root_doc = config.root_doc
 
     def build(self):
         """

--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2018-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2018-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -466,7 +466,7 @@ class ConfluenceBuilder(Builder):
         if conf.confluence_purge and self.legacy_pages is None:
             if conf.confluence_publish_root:
                 baseid = conf.confluence_publish_root
-            elif conf.confluence_purge_from_master and self.root_doc_page_id:
+            elif conf.confluence_purge_from_root and self.root_doc_page_id:
                 baseid = self.root_doc_page_id
             else:
                 baseid = self.parent_id
@@ -474,7 +474,7 @@ class ConfluenceBuilder(Builder):
             # if no base identifier and dry running, ignore legacy page
             # searching as there is no initial root document to reference
             # against
-            if (conf.confluence_purge_from_master and
+            if (conf.confluence_purge_from_root and
                     conf.confluence_publish_dryrun and not baseid):
                 self.legacy_pages = []
             elif self.config.confluence_adv_aggressive_search is True:
@@ -531,7 +531,7 @@ class ConfluenceBuilder(Builder):
 
     def publish_finalize(self):
         if self.root_doc_page_id:
-            if self.config.confluence_master_homepage is True:
+            if self.config.confluence_root_homepage is True:
                 self.info('updating space\'s homepage... ',
                     nonl=(not self._verbose))
                 self.publisher.updateSpaceHome(self.root_doc_page_id)

--- a/sphinxcontrib/confluencebuilder/config/__init__.py
+++ b/sphinxcontrib/confluencebuilder/config/__init__.py
@@ -26,7 +26,9 @@ def handle_config_inited(app, config):
             config[new] = config[orig]
 
     # copy over deprecated configuration names to new names (if any)
+    handle_legacy('confluence_master_homepage', 'confluence_root_homepage')
     handle_legacy('confluence_publish_allowlist', 'confluence_publish_subset')
+    handle_legacy('confluence_purge_from_master', 'confluence_purge_from_root')
 
 def process_ask_configs(config):
     """

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -290,8 +290,8 @@ dictionaries with keys 'id' and 'name' which identify the JIRA instances.
 
     # ##################################################################
 
-    # confluence_master_homepage
-    validator.conf('confluence_master_homepage') \
+    # confluence_root_homepage
+    validator.conf('confluence_root_homepage') \
              .bool()
 
     # ##################################################################
@@ -429,8 +429,8 @@ names are relative to the documentation's source directory.
 
     # ##################################################################
 
-    # confluence_purge_from_master
-    validator.conf('confluence_purge_from_master') \
+    # confluence_purge_from_root
+    validator.conf('confluence_purge_from_root') \
              .bool()
 
     # ##################################################################

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -83,3 +83,8 @@ def apply_defaults(conf):
         if getattr(conf, key) is not None:
             if not isinstance(getattr(conf, key), int) and conf[key]:
                 conf[key] = int(conf[key])
+
+    # if running an older version of Sphinx which does not define `root_doc`,
+    # copy it over now from the legacy configuration
+    if 'root_doc' not in conf:
+        conf.root_doc = conf.master_doc

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -65,7 +65,9 @@ def apply_defaults(conf):
         'confluence_publish_onlynew',
         'confluence_purge',
         'confluence_purge_from_master',
+        'confluence_purge_from_root',
         'confluence_remove_title',
+        'confluence_root_homepage',
         'confluence_watch',
     ]
     for key in config2bool:

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -17,8 +17,12 @@ DEPRECATED_CONFIGS = {
         'to be removed in a future version',
     'confluence_adv_writer_no_section_cap':
         'to be removed in a future version',
+    'confluence_master_homepage':
+        'use "confluence_root_homepage" instead',
     'confluence_publish_subset':
         'use "confluence_publish_allowlist" instead',
+    'confluence_purge_from_master':
+        'use "confluence_purge_from_root" instead',
 }
 
 def deprecated(validator):

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :copyright: Copyright 2007-2019 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -20,16 +20,14 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
     def __init__(self, app):
         super(SingleConfluenceBuilder, self).__init__(app)
 
-        self.root_doc = self.config.master_doc
-
     def assemble_doctree(self):
-        master = self.config.master_doc
-        tree = self.env.get_doctree(master)
+        root_doc = self.config.root_doc
+        tree = self.env.get_doctree(root_doc)
         tree = inline_all_toctrees(
-            self, set(), master, tree, darkgreen, [master])
-        tree['docname'] = master
+            self, set(), root_doc, tree, darkgreen, [root_doc])
+        tree['docname'] = root_doc
 
-        self.env.resolve_references(tree, master, self)
+        self.env.resolve_references(tree, root_doc, self)
         self._fix_refuris(tree)
 
         return tree
@@ -42,7 +40,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
                 alias = '{}/{}'.format(docname, id)
                 new_secnumbers[alias] = secnum
 
-        return {self.config.master_doc: new_secnumbers}
+        return {self.config.root_doc: new_secnumbers}
 
     def assemble_toc_fignumbers(self):
         new_fignumbers = {}
@@ -55,7 +53,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
                 for id, fignum in fignums.items():
                     new_fignumbers[alias][id] = fignum
 
-        return {self.config.master_doc: new_fignumbers}
+        return {self.config.root_doc: new_fignumbers}
 
     def get_outdated_docs(self):
         return 'all documents'
@@ -66,20 +64,20 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
     def get_target_uri(self, docname, typ=None):
         if docname in self.env.all_docs:
             return '{}{}#{}'.format(
-                self.config.master_doc, self.link_suffix, docname)
+                self.config.root_doc, self.link_suffix, docname)
         else:
             return self.link_transform(docname)
 
     def write(self, build_docnames, updated_docnames, method='update'):
         docnames = self.env.all_docs
-        if self.config.master_doc not in docnames:
-            ConfluenceLogger.error('singleconfluence required master_doc')
+        if self.config.root_doc not in docnames:
+            ConfluenceLogger.error('singleconfluence requires root_doc')
             return
 
         root_doctitle = self._process_root_document()
         if not root_doctitle:
             ConfluenceLogger.error(
-                'singleconfluence required title on master_doc')
+                'singleconfluence requires title on root_doc')
             return
 
         with progress_message(__('assembling single confluence document')):
@@ -96,10 +94,10 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
             # extensions, etc.) and the newer mappings for reference building.
             assembled_toc_secnumbers = self.assemble_toc_secnumbers()
             assembled_toc_fignumbers = self.assemble_toc_fignumbers()
-            self.env.toc_secnumbers.setdefault(self.root_doc, {}).update(
-                assembled_toc_secnumbers[self.root_doc])
-            self.env.toc_fignumbers.setdefault(self.root_doc, {}).update(
-                assembled_toc_fignumbers[self.root_doc])
+            self.env.toc_secnumbers.setdefault(self.config.root_doc, {}).update(
+                assembled_toc_secnumbers[self.config.root_doc])
+            self.env.toc_fignumbers.setdefault(self.config.root_doc, {}).update(
+                assembled_toc_fignumbers[self.config.root_doc])
 
             # register title targets for references before assembling doc
             # re-works them into a single document
@@ -108,12 +106,12 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
                 self._register_doctree_title_targets(docname, doctree)
 
             doctree = self.assemble_doctree()
-            self._prepare_doctree_writing(self.config.master_doc, doctree)
-            self.assets.processDocument(doctree, self.config.master_doc)
+            self._prepare_doctree_writing(self.config.root_doc, doctree)
+            self.assets.processDocument(doctree, self.config.root_doc)
 
         with progress_message(__('writing single confluence document')):
-            self.write_doc_serialized(self.config.master_doc, doctree)
-            self.write_doc(self.config.master_doc, doctree)
+            self.write_doc_serialized(self.config.root_doc, doctree)
+            self.write_doc(self.config.root_doc, doctree)
 
     def _fix_refuris(self, doctree):
         """
@@ -133,7 +131,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         Args:
             doctree: the doctree to parse
         """
-        master_docuri = self.config.master_doc + self.file_suffix
+        root_docuri = self.config.root_doc + self.file_suffix
 
         for refnode in doctree.traverse(nodes.reference):
             if 'refuri' not in refnode:
@@ -148,12 +146,12 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
             if idx2 >= 0:
                 refnode['refid'] = refuri[idx2 + 1:]
                 del refnode['refuri']
-            elif refuri.startswith(master_docuri + '#'):
+            elif refuri.startswith(root_docuri + '#'):
                 refnode['refid'] = refuri[idx + 1:]
                 del refnode['refuri']
 
     def _process_root_document(self):
-        docname = self.config.master_doc
+        docname = self.config.root_doc
 
         # Extract the title from the root document as it will be used to decide
         # which Confluence page the document will be published to.
@@ -188,7 +186,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         Returns:
             whether or not the node should be a #top reference
         """
-        return node['refid'] == self.root_doc
+        return node['refid'] == self.config.root_doc
 
     def _register_doctree_title_targets(self, docname, doctree):
         """
@@ -204,7 +202,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         """
 
         doc_used_names = {}
-        secnumbers = self.env.toc_secnumbers.get(self.config.master_doc, {})
+        secnumbers = self.env.toc_secnumbers.get(self.config.root_doc, {})
 
         docref_set = False
         doc_anchorname = '%s/' % docname

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -85,7 +85,7 @@ class ConfluenceState:
         base_tail = ''
 
         if (config.confluence_ignore_titlefix_on_index and
-                docname == config.master_doc):
+                docname == config.root_doc):
             postfix = None
             prefix = None
         else:

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -201,6 +201,13 @@ def prepare_sphinx(src_dir, config=None, out_dir=None, extra_config=None,
 
     doctrees_dir = os.path.join(out_dir, '.doctrees')
 
+    # support pre-Sphinx v4.0 installations which do not have `root_doc` by
+    # swapping to the obsolete configuration name
+    if parse_version(sphinx_version) < parse_version('4.0'):
+        if 'root_doc' in conf:
+            conf['master_doc'] = conf['root_doc']
+            del conf['root_doc']
+
     with docutils_namespace():
         app = Sphinx(
             src_dir,                # output for document sources
@@ -250,12 +257,12 @@ def prepare_sphinx_filenames(src_dir, filenames, configs=None):
     if configs:
         root_doc = 'index'
         for config in configs:
-            if config and 'master_doc' in config:
-                root_doc = config['master_doc']
+            if config and 'root_doc' in config:
+                root_doc = config['root_doc']
                 break
 
         if root_doc not in filenames:
-            configs[-1]['master_doc'] = filenames[0] # update last config
+            configs[-1]['root_doc'] = filenames[0] # update last config
 
     return files
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2018-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2018-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -68,9 +68,7 @@ class TestConfluenceValidation(unittest.TestCase):
 
         # finalize
         if cls.config['confluence_space_name'].startswith('~'):
-            cls.config['confluence_master_homepage'] = False
-        else:
-            cls.config['confluence_master_homepage'] = True
+            cls.config['confluence_root_homepage'] = False
         cls.config['confluence_publish_prefix'] = ''
         cls.config['confluence_publish_postfix'] = ''
         cls.config['confluence_purge'] = False
@@ -91,11 +89,10 @@ class TestConfluenceValidation(unittest.TestCase):
         build_sphinx(dataset, config=cls.config, out_dir=doc_dir)
 
         # finalize configuration for tests
-        cls.config['confluence_master_homepage'] = False
         cls.config['confluence_parent_page'] = cls.test_key
         cls.config['confluence_prev_next_buttons_location'] = 'both'
         cls.config['confluence_purge'] = True
-        cls.config['confluence_purge_from_master'] = True
+        cls.config['confluence_purge_from_root'] = True
 
     def test_extended_autodocs(self):
         if parse_version(sphinx_version) < parse_version('2.3.1'):

--- a/tests/unit-tests/test_config_titlefix.py
+++ b/tests/unit-tests/test_config_titlefix.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/unit-tests/test_config_titlefix.py
+++ b/tests/unit-tests/test_config_titlefix.py
@@ -14,7 +14,7 @@ class TestConfluenceConfigTitlefix(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.config = prepare_conf()
-        self.config['master_doc'] = 'titlefix'
+        self.config['root_doc'] = 'titlefix'
         test_dir = os.path.dirname(os.path.realpath(__file__))
         self.dataset = os.path.join(test_dir, 'datasets', 'common')
         self.filenames = [

--- a/tests/unit-tests/test_rst_references.py
+++ b/tests/unit-tests/test_rst_references.py
@@ -14,7 +14,7 @@ class TestConfluenceRstReferences(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.config = prepare_conf()
-        self.config['master_doc'] = 'references'
+        self.config['root_doc'] = 'references'
         test_dir = os.path.dirname(os.path.realpath(__file__))
         self.dataset = os.path.join(test_dir, 'datasets', 'common')
         self.filenames = [

--- a/tests/unit-tests/test_rst_references.py
+++ b/tests/unit-tests/test_rst_references.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/unit-tests/test_sphinx_glossary.py
+++ b/tests/unit-tests/test_sphinx_glossary.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/unit-tests/test_sphinx_glossary.py
+++ b/tests/unit-tests/test_sphinx_glossary.py
@@ -14,7 +14,7 @@ class TestConfluenceSphinxDomains(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.config = prepare_conf()
-        self.config['master_doc'] = 'glossary'
+        self.config['root_doc'] = 'glossary'
         test_dir = os.path.dirname(os.path.realpath(__file__))
         self.dataset = os.path.join(test_dir, 'datasets', 'common')
         self.filenames = [

--- a/tests/unit-tests/test_usecase_nested_ref.py
+++ b/tests/unit-tests/test_usecase_nested_ref.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/unit-tests/test_usecase_nested_ref.py
+++ b/tests/unit-tests/test_usecase_nested_ref.py
@@ -14,7 +14,7 @@ class TestConfluenceUseCaseNestedRef(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.config = prepare_conf()
-        self.config['master_doc'] = 'nested-ref-contents'
+        self.config['root_doc'] = 'nested-ref-contents'
         test_dir = os.path.dirname(os.path.realpath(__file__))
         self.dataset = os.path.join(test_dir, 'datasets', 'use-cases')
         self.filenames = [


### PR DESCRIPTION
Sphinx v4.x+ uses the `root_doc` configuration over the deprecated `master_doc` configuration. Adjusting this extension's implementation to following this renaming. Renaming configuration entries referring to a `master` document to use `root` document instead. This includes adjusting:

- `confluence_master_homepage` to `confluence_root_homepage`
- `confluence_purge_from_master` to `confluence_purge_from_root`

To ensure support with legacy revisions of Sphinx, the builder's configuration check (when initialized) will ensure `root_doc` is populated with a `master_doc` value if `root_doc` does not exist. Users using the older configuration names will be presented with a deprecated warning.