### PR TITLE
config: correct deprecation legacy mappings and warning messages

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/__init__.py
+++ b/sphinxcontrib/confluencebuilder/config/__init__.py
@@ -26,9 +26,9 @@ def handle_config_inited(app, config):
             config[new] = config[orig]
 
     # copy over deprecated configuration names to new names (if any)
-    handle_legacy('confluence_master_homepage', 'confluence_root_homepage')
     handle_legacy('confluence_publish_allowlist', 'confluence_publish_subset')
-    handle_legacy('confluence_purge_from_master', 'confluence_purge_from_root')
+    handle_legacy('confluence_purge_from_root', 'confluence_purge_from_master')
+    handle_legacy('confluence_root_homepage', 'confluence_master_homepage')
 
 def process_ask_configs(config):
     """

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -46,11 +46,11 @@ def deprecated(validator):
 
     # promote singleconfluence over confluence_max_doc_depth=0
     if config.confluence_max_doc_depth == 0:
-        ConfluenceLogger.warn('%s with a value of zero is deprecated; '
-            "use the 'singleconfluence' builder instead" % key)
+        ConfluenceLogger.warn('confluence_max_doc_depth with a value of zero '
+            "is deprecated; use the 'singleconfluence' builder instead")
     elif config.confluence_max_doc_depth:
-        ConfluenceLogger.warn('%s is deprecated and will be removed; '
-            "consider using the 'singleconfluence' builder instead" % key)
+        ConfluenceLogger.warn('confluence_max_doc_depth is deprecated and will '
+            "be removed; consider using the 'singleconfluence' builder instead")
 
 def warnings(validator):
     """

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -153,7 +153,7 @@ class TestConfluenceValidation(unittest.TestCase):
         dataset = os.path.join(self.datasets, 'hierarchy')
         doc_dir = prepare_dirs('validation-set-hierarchy')
 
-        build_sphinx(dataset, config=config, out_dir=doc_dir)
+        build_sphinx(dataset, config=config, out_dir=doc_dir, relax=True)
 
     def test_nonjsonresponse(self):
         config = dict(self.config)


### PR DESCRIPTION
A recent set of new legacy mappings \[1\] were incorrectly defined (mapping new to old); correcting. Also, deprecation checks were added for `confluence_max_doc_depth`; however, the warning message did not properly reference the configuration key value (it instead used the last cycled key from the cycled deprecated configuration keys. Adjusting these warnings messages to use the proper key value.

\[1\]: 273769c1c8d37d48fe2a27bf326e1d33377022ba