### PR TITLE
improve doc dirhtml builder

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -54,16 +54,16 @@ format) and optionally publish them to a Confluence instance.{%endtrans%}
 <table class="contentstable">
 <tr>
   <td>
-    <p class="biglink"><a class="biglink" href="tutorial.html">Tutorial</a><br/>
+    <p class="biglink"><a class="biglink" href="{{pathto('tutorial')}}">Tutorial</a><br/>
        <span class="linkdescr">overview of basic tasks</span></p>
-  </td><td><p class="biglink"><a class="biglink" href="search.html">Search</a><br/>
+  </td><td><p class="biglink"><a class="biglink" href="{{pathto('search')}}">Search</a><br/>
        <span class="linkdescr">search the documentation</span></p>
   </td>
 </tr><tr>
   <td>
-    <p class="biglink"><a class="biglink" href="contents.html">Contents</a><br/>
+    <p class="biglink"><a class="biglink" href="{{pathto('contents')}}">Contents</a><br/>
        <span class="linkdescr">for a complete overview</span></p>
-  </td><td><p class="biglink"><a class="biglink" href="changelog.html">Changelog</a><br/>
+  </td><td><p class="biglink"><a class="biglink" href="{{pathto('changelog')}}">Changelog</a><br/>
        <span class="linkdescr">release history</span></p>
   </td>
 </tr>

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -17,7 +17,7 @@
 </p>
 <h3>{%trans%}Download{%endtrans%}</h3>
 <p>
-    {%trans%}<a href="install.html">Install</a>
+    {%trans%}<a href="{{pathto('install')}}">Install</a>
     the PyPI package:{%endtrans%}
 </p>
 <div class="quick-grab-container">

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -1,5 +1,5 @@
 {#
-:copyright: Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 #}
 <p class="logo">

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -16,7 +16,7 @@ Documentation contents
 Indices and tables
 ==================
 
-.. only:: builder_html
+.. only:: builder_html or builder_dirhtml
 
     * :ref:`genindex`
     * :ref:`search`


### PR DESCRIPTION
Make a series of corrections to correct documentation processing when using the `dirhtml` builder. This includes:

- doc: permit dirhtml builder for indices/table references
- use pathto for various template href targets