### PR TITLE
doc: correct sidebar install path building

### DIFF
--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -17,8 +17,8 @@
 </p>
 <h3>{%trans%}Download{%endtrans%}</h3>
 <p>
-    {%trans%}<a href="{{pathto('install')}}">Install</a>
-    the PyPI package:{%endtrans%}
+    <a href="{{ pathto('install') }}">{%trans%}Install{%endtrans%}</a>
+    {%trans%}the PyPI package:{%endtrans%}
 </p>
 <div class="quick-grab-container">
     <input


### PR DESCRIPTION
Build the sidebar's link to the install document outside of the translation tags or the build process will fail. This corrects the following error:

    Theme error:
    An error happened in rendering the page index.
    Reason: TemplateSyntaxError("expected token 'end of print statement', got '('")