### PR TITLE
avoid configuring rest session proxies if no proxy is set

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2020 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 


### PR DESCRIPTION
Adjusting all REST session building to only configure the proxy value if a configuration assigns an explicit proxy value. This prevents get/etc. errors on older versions of requests which assume a set `http`/`https` proxy value is a valid string (where calls fail to handle a `None` value).