### PR TITLE
publisher: better reflect new attachments in dry-runs

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -501,7 +501,7 @@ class ConfluenceBuilder(Builder):
         title = ConfluenceState.title(docname)
         page_id = ConfluenceState.uploadId(docname)
 
-        if not page_id:
+        if not page_id and not conf.confluence_publish_dryrun:
             # A page identifier may not be tracked in cases where only a subset
             # of documents are published and the target page an asset will be
             # published to was not part of the request. In this case, ask the

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -402,7 +402,10 @@ class ConfluencePublisher():
         HASH_KEY = 'SCB_KEY'
         uploaded_attachment_id = None
 
-        _, attachment = self.getAttachment(page_id, name)
+        if self.dryrun:
+            attachment = None
+        else:
+            _, attachment = self.getAttachment(page_id, name)
 
         # check if attachment (of same hash) is already published to this page
         comment = None


### PR DESCRIPTION
If a user performs a dry-run test which includes new attachments for pages that do not exist, the run will report several warning messages for these attachments:

    WARNING: cannot publish asset since publishing point cannot be found (<file>): <document>

Since this is a dry-run, there is not a need to validate a publishing point for an attachment. In the event that a publishing point is not detected, handle it in a way that represents a new attachment.