### PR TITLE
publisher: reflect server url error on 404-failed connect attempt

### DIFF
--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -24,7 +24,7 @@ class ConfluenceAuthenticationFailedUrlError(ConfluenceError):
         )
 
 class ConfluenceBadApiError(ConfluenceError):
-    def __init__(self, details):
+    def __init__(self, code, details):
         SphinxError.__init__(self,
             """---\n"""
             """An unsupported Confluence API call has been made.\n"""
@@ -32,6 +32,7 @@ class ConfluenceBadApiError(ConfluenceError):
             """%s""" % details +
             """\n---\n"""
         )
+        self.status_code = code
 
 class ConfluenceBadSpaceError(ConfluenceError):
     def __init__(self, space_key, uname, pw_set, extras):

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -116,7 +116,8 @@ class Rest:
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
         if not rsp.ok:
-            raise ConfluenceBadApiError(self._format_error(rsp, key))
+            errdata = self._format_error(rsp, key)
+            raise ConfluenceBadApiError(rsp.status_code, errdata)
         if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError
 
@@ -150,7 +151,7 @@ class Rest:
             if self.verbosity > 0:
                 errdata += "\n"
                 errdata += json.dumps(data, indent=2)
-            raise ConfluenceBadApiError(errdata)
+            raise ConfluenceBadApiError(rsp.status_code, errdata)
         if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError
 
@@ -184,7 +185,7 @@ class Rest:
             if self.verbosity > 0:
                 errdata += "\n"
                 errdata += json.dumps(data, indent=2)
-            raise ConfluenceBadApiError(errdata)
+            raise ConfluenceBadApiError(rsp.status_code, errdata)
         if not rsp.text:
             raise ConfluenceSeraphAuthenticationFailedUrlError
 
@@ -214,7 +215,8 @@ class Rest:
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
         if not rsp.ok:
-            raise ConfluenceBadApiError(self._format_error(rsp, key))
+            errdata = self._format_error(rsp, key)
+            raise ConfluenceBadApiError(rsp.status_code, errdata)
 
     def close(self):
         self.session.close()


### PR DESCRIPTION
If the first connection event fails to do a 404 error, rework the generated (exception) error to present that the configured server URL is incorrect. This could help users who may not understand the 404 error code and not assume it is some other issues (e.g. credentials).