### PR TITLE
improve testing state (explicit docutils; validation check correction)

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,7 +6,7 @@
 
 from pkg_resources import parse_version
 from sphinx.__init__ import __version__ as sphinx_version
-from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadApiError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadServerUrlError
 from tests.lib import build_sphinx
 from tests.lib import enable_sphinx_info
 from tests.lib import prepare_conf
@@ -161,7 +161,7 @@ class TestConfluenceValidation(unittest.TestCase):
         dataset = os.path.join(self.datasets, 'base')
         doc_dir = prepare_dirs('validation-set-nonjsonresponse')
 
-        with self.assertRaises(ConfluenceBadApiError):
+        with self.assertRaises(ConfluenceBadServerUrlError):
             build_sphinx(dataset, config=config, out_dir=doc_dir)
 
     def test_standard_default(self):

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,11 @@ envlist =
 [testenv]
 deps =
     -r{toxinidir}/requirements_dev.txt
+    sphinx18: docutils<0.18
     sphinx18: sphinx>=1.8,<2.0
+    sphinx34: docutils<0.18
     sphinx34: sphinx>=3.4,<3.5
+    sphinx35: docutils<0.18
     sphinx35: sphinx>=3.5,<3.6
     sphinx40: sphinx>=4.0,<4.1
     sphinx41: sphinx>=4.1,<4.2


### PR DESCRIPTION
### tox: explicitly pin docutils<0.18 for older sphinx versions

Older versions of Sphinx do not support the recent docutils v0.18 release. Explicitly configuring the test environment to enforce this for the older versions being tested.

Note that in Sphinx v4+, the supported docutils version is listed in its setup definition (i.e. does not need to be managed here).

### tests: handle new bad-space exception

Error handling was adjusted for a "bad space" detection which now raises a `ConfluenceBadServerUrlError` exception [1]. Adjusting the validation test to account for this.

[1]: d23dc9a1fdbb5845f9e08c32efe9c080ceefcaf5