### PR TITLE
provide some third-party extension support

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -15,7 +15,6 @@ from sphinx.builders import Builder
 from sphinx.errors import ExtensionError
 from sphinx.locale import __
 from sphinx.util import status_iterator
-from sphinx.util.math import wrap_displaymath
 from sphinx.util.osutil import ensuredir
 from sphinxcontrib.confluencebuilder.assets import ConfluenceAssetManager
 from sphinxcontrib.confluencebuilder.assets import ConfluenceSupportedImages
@@ -29,6 +28,7 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from sphinxcontrib.confluencebuilder.translator.storage import ConfluenceStorageFormatTranslator
+from sphinxcontrib.confluencebuilder.transmute import doctree_transmute
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
 from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import first
@@ -39,28 +39,6 @@ try:
     basestring
 except NameError:
     basestring = str
-
-# load graphviz extension if available to handle node pre-processing
-try:
-    from sphinx.ext.graphviz import GraphvizError
-    from sphinx.ext.graphviz import graphviz
-    from sphinx.ext.graphviz import render_dot
-except ImportError:
-    graphviz = None
-
-# load imgmath extension if available to handle math node pre-processing
-try:
-    from sphinx.ext import imgmath
-    import itertools
-except ImportError:
-    imgmath = None
-
-# load inheritance_diagram extension if available to handle node pre-processing
-if graphviz:
-    try:
-        from sphinx.ext import inheritance_diagram
-    except ImportError:
-        inheritance_diagram = None
 
 class ConfluenceBuilder(Builder):
     allow_parallel = True
@@ -301,15 +279,9 @@ class ConfluenceBuilder(Builder):
         # extract metadata information
         self._extract_metadata(docname, doctree)
 
-        # replace inheritance diagram with images
-        # (always invoke before _replace_graphviz_nodes)
-        self._replace_inheritance_diagram(doctree)
-
-        # replace graphviz nodes with images
-        self._replace_graphviz_nodes(doctree)
-
-        # replace math blocks with images
-        self._replace_math_blocks(doctree)
+        # convert any desired nodes in a doctree to node types supported by the
+        # translator implementation
+        doctree_transmute(self, doctree)
 
         # for every doctree, pick the best image candidate
         self.post_process_images(doctree)
@@ -855,155 +827,6 @@ class ConfluenceBuilder(Builder):
                     for id in section_node['ids']:
                         id = '{}#{}'.format(docname, id)
                         ConfluenceState.registerTarget(id, target)
-
-    def _replace_graphviz_nodes(self, doctree):
-        """
-        replace graphviz nodes with images
-
-        graphviz nodes are pre-processed and replaced with respective images in
-        the processed documentation set. Typically, the node support from
-        `sphinx.ext.graphviz` would be added to the builder; however, this
-        extension renders graphs during the translation phase (which is not
-        ideal for how assets are managed in this extension).
-
-        Instead, this implementation just traverses for graphviz nodes,
-        generates renderings and replaces the nodes with image nodes (which in
-        turn will be handled by the existing image-based implementation).
-
-        Args:
-            doctree: the doctree to replace blocks on
-        """
-        if graphviz is None:
-            return
-
-        # graphviz's render_dot call expects a translator to be passed in; mock
-        # a translator tied to our self-builder
-        class MockTranslator:
-            def __init__(self, builder):
-                self.builder = builder
-        mock_translator = MockTranslator(self)
-
-        for node in doctree.traverse(graphviz):
-            try:
-                _, out_filename = render_dot(mock_translator, node['code'],
-                    node['options'], self.graphviz_output_format, 'graphviz')
-                if not out_filename:
-                    node.parent.remove(node)
-                    continue
-
-                new_node = nodes.image(candidates={'?'}, uri=out_filename)
-                if 'align' in node:
-                    new_node['align'] = node['align']
-                node.replace_self(new_node)
-            except GraphvizError as exc:
-                ConfluenceLogger.warn('dot code {}: {}'.format(
-                    node['code'], exc))
-                node.parent.remove(node)
-
-    def _replace_inheritance_diagram(self, doctree):
-        """
-        replace inheritance diagrams with images
-
-        Inheritance diagrams are pre-processed and replaced with respective
-        images in the processed documentation set. Typically, the node support
-        from `sphinx.ext.inheritance_diagram` would be added to the builder;
-        however, this extension renders graphs during the translation phase
-        (which is not ideal for how assets are managed in this extension).
-
-        Instead, this implementation just traverses for inheritance diagrams,
-        generates renderings and replaces the nodes with image nodes (which in
-        turn will be handled by the existing image-based implementation).
-
-        Note that the interactive image map is not handled in this
-        implementation since Confluence does not support image maps (without
-        external extensions).
-
-        Args:
-            doctree: the doctree to replace blocks on
-        """
-        if inheritance_diagram is None:
-            return
-
-        # graphviz's render_dot call expects a translator to be passed in; mock
-        # a translator tied to our self-builder
-        class MockTranslator:
-            def __init__(self, builder):
-                self.builder = builder
-        mock_translator = MockTranslator(self)
-
-        for node in doctree.traverse(inheritance_diagram.inheritance_diagram):
-            graph = node['graph']
-
-            graph_hash = inheritance_diagram.get_graph_hash(node)
-            name = 'inheritance%s' % graph_hash
-
-            dotcode = graph.generate_dot(name, {}, env=self.env)
-
-            try:
-                _, out_filename = render_dot(mock_translator, dotcode, {},
-                    self.graphviz_output_format, 'inheritance')
-                if not out_filename:
-                    node.parent.remove(node)
-                    continue
-
-                new_node = nodes.image(candidates={'?'}, uri=out_filename)
-                if 'align' in node:
-                    new_node['align'] = node['align']
-                node.replace_self(new_node)
-            except GraphvizError as exc:
-                ConfluenceLogger.warn('dot code {}: {}'.format(dotcode, exc))
-                node.parent.remove(node)
-
-    def _replace_math_blocks(self, doctree):
-        """
-        replace math blocks with images
-
-        Math blocks are pre-processed and replaced with respective images in the
-        list of documents to process. This is to help prepare additional images
-        into the asset management for this extension. Math support will work on
-        systems which have latex/dvipng installed.
-
-        Args:
-            doctree: the doctree to replace blocks on
-        """
-        if imgmath is None:
-            return
-
-        # imgmath's render_math call expects a translator to be passed
-        # in; mock a translator tied to our self-builder
-        class MockTranslator:
-            def __init__(self, builder):
-                self.builder = builder
-        mock_translator = MockTranslator(self)
-
-        for node in itertools.chain(doctree.traverse(nodes.math),
-                doctree.traverse(nodes.math_block)):
-            try:
-                if not isinstance(node, nodes.math):
-                    if node['nowrap']:
-                        latex = node.astext()
-                    else:
-                        latex = wrap_displaymath(node.astext(), None, False)
-                else:
-                    latex = '$' + node.astext() + '$'
-
-                mf, depth = imgmath.render_math(mock_translator, latex)
-                if not mf:
-                    continue
-
-                new_node = nodes.image(
-                    candidates={'?'},
-                    uri=path.join(self.outdir, mf),
-                    **node.attributes)
-                new_node['from_math'] = True
-                if not isinstance(node, nodes.math):
-                    new_node['align'] = 'center'
-                if depth is not None:
-                    new_node['math_depth'] = depth
-                node.replace_self(new_node)
-            except imgmath.MathExtError as exc:
-                ConfluenceLogger.warn('inline latex {}: {}'.format(
-                    node.astext(), exc))
 
     def _top_ref_check(self, node):
         """

--- a/sphinxcontrib/confluencebuilder/translator/storage.py
+++ b/sphinxcontrib/confluencebuilder/translator/storage.py
@@ -1789,6 +1789,19 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     visit_jira = _visit_jira_node
     visit_jira_issue = _visit_jira_node
 
+    # ---------------------------------------------------
+    # sphinx -- extension (third party) -- sphinx-toolbox
+    # ---------------------------------------------------
+
+    def visit_ItalicAbbreviationNode(self, node):
+        self.body.append(self._start_tag(node, 'i'))
+        self.context.append(self._end_tag(node))
+        self.visit_abbreviation(node)
+
+    def depart_ItalicAbbreviationNode(self, node):
+        self.depart_abbreviation(node)
+        self.body.append(self.context.pop()) # i
+
     # -------------
     # miscellaneous
     # -------------

--- a/sphinxcontrib/confluencebuilder/transmute.py
+++ b/sphinxcontrib/confluencebuilder/transmute.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from docutils import nodes
+from os import path
+from sphinx.util.math import wrap_displaymath
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
+
+# load graphviz extension if available to handle node pre-processing
+try:
+    from sphinx.ext.graphviz import GraphvizError
+    from sphinx.ext.graphviz import graphviz
+    from sphinx.ext.graphviz import render_dot
+except ImportError:
+    graphviz = None
+
+# load imgmath extension if available to handle math node pre-processing
+try:
+    from sphinx.ext import imgmath
+    import itertools
+except ImportError:
+    imgmath = None
+
+# load inheritance_diagram extension if available to handle node pre-processing
+if graphviz:
+    try:
+        from sphinx.ext import inheritance_diagram
+    except ImportError:
+        inheritance_diagram = None
+
+
+def doctree_transmute(builder, doctree):
+    """
+    replace nodes in a doctree with support node types
+
+    This call can be used by a builder to replace various node types (typically,
+    from extensions) into alternative node types which can be processed by this
+    extension's translator(s).
+
+    Args:
+        builder: the builder
+        doctree: the doctree to replace blocks on
+    """
+
+    # replace inheritance diagram with images
+    # (always invoke before _replace_graphviz_nodes)
+    replace_inheritance_diagram(builder, doctree)
+
+    # replace graphviz nodes with images
+    replace_graphviz_nodes(builder, doctree)
+
+    # replace math blocks with images
+    replace_math_blocks(builder, doctree)
+
+
+def replace_graphviz_nodes(builder, doctree):
+    """
+    replace graphviz nodes with images
+
+    graphviz nodes are pre-processed and replaced with respective images in the
+    processed documentation set. Typically, the node support from
+    `sphinx.ext.graphviz` would be added to the builder; however, this extension
+    renders graphs during the translation phase (which is not ideal for how
+    assets are managed in this extension).
+
+    Instead, this implementation just traverses for graphviz nodes, generates
+    renderings and replaces the nodes with image nodes (which in turn will be
+    handled by the existing image-based implementation).
+
+    Args:
+        builder: the builder
+        doctree: the doctree to replace blocks on
+    """
+
+    if graphviz is None:
+        return
+
+    # graphviz's render_dot call expects a translator to be passed in; mock a
+    # translator tied to our builder
+    class MockTranslator:
+        def __init__(self, builder):
+            self.builder = builder
+    mock_translator = MockTranslator(builder)
+
+    for node in doctree.traverse(graphviz):
+        try:
+            _, out_filename = render_dot(mock_translator, node['code'],
+                node['options'], builder.graphviz_output_format, 'graphviz')
+            if not out_filename:
+                node.parent.remove(node)
+                continue
+
+            new_node = nodes.image(candidates={'?'}, uri=out_filename)
+            if 'align' in node:
+                new_node['align'] = node['align']
+            node.replace_self(new_node)
+        except GraphvizError as exc:
+            ConfluenceLogger.warn('dot code {}: {}'.format(node['code'], exc))
+            node.parent.remove(node)
+
+
+def replace_inheritance_diagram(builder, doctree):
+    """
+    replace inheritance diagrams with images
+
+    Inheritance diagrams are pre-processed and replaced with respective images
+    in the processed documentation set. Typically, the node support from
+    `sphinx.ext.inheritance_diagram` would be added to the builder; however,
+    this extension renders graphs during the translation phase (which is not
+    ideal for how assets are managed in this extension).
+
+    Instead, this implementation just traverses for inheritance diagrams,
+    generates renderings and replaces the nodes with image nodes (which in turn
+    will be handled by the existing image-based implementation).
+
+    Note that the interactive image map is not handled in this implementation
+    since Confluence does not support image maps (without external extensions).
+
+    Args:
+        builder: the builder
+        doctree: the doctree to replace blocks on
+    """
+
+    if inheritance_diagram is None:
+        return
+
+    # graphviz's render_dot call expects a translator to be passed in; mock
+    # a translator tied to our builder
+    class MockTranslator:
+        def __init__(self, builder):
+            self.builder = builder
+    mock_translator = MockTranslator(builder)
+
+    for node in doctree.traverse(inheritance_diagram.inheritance_diagram):
+        graph = node['graph']
+
+        graph_hash = inheritance_diagram.get_graph_hash(node)
+        name = 'inheritance%s' % graph_hash
+
+        dotcode = graph.generate_dot(name, {}, env=builder.env)
+
+        try:
+            _, out_filename = render_dot(mock_translator, dotcode, {},
+                builder.graphviz_output_format, 'inheritance')
+            if not out_filename:
+                node.parent.remove(node)
+                continue
+
+            new_node = nodes.image(candidates={'?'}, uri=out_filename)
+            if 'align' in node:
+                new_node['align'] = node['align']
+            node.replace_self(new_node)
+        except GraphvizError as exc:
+            ConfluenceLogger.warn('dot code {}: {}'.format(dotcode, exc))
+            node.parent.remove(node)
+
+
+def replace_math_blocks(builder, doctree):
+    """
+    replace math blocks with images
+
+    Math blocks are pre-processed and replaced with respective images in the
+    list of documents to process. This is to help prepare additional images into
+    the asset management for this extension. Math support will work on systems
+    which have latex/dvipng installed.
+
+    Args:
+        builder: the builder
+        doctree: the doctree to replace blocks on
+    """
+
+    if imgmath is None:
+        return
+
+    # imgmath's render_math call expects a translator to be passed
+    # in; mock a translator tied to our builder
+    class MockTranslator:
+        def __init__(self, builder):
+            self.builder = builder
+    mock_translator = MockTranslator(builder)
+
+    for node in itertools.chain(doctree.traverse(nodes.math),
+            doctree.traverse(nodes.math_block)):
+        try:
+            if not isinstance(node, nodes.math):
+                if node['nowrap']:
+                    latex = node.astext()
+                else:
+                    latex = wrap_displaymath(node.astext(), None, False)
+            else:
+                latex = '$' + node.astext() + '$'
+
+            mf, depth = imgmath.render_math(mock_translator, latex)
+            if not mf:
+                continue
+
+            new_node = nodes.image(
+                candidates={'?'},
+                uri=path.join(builder.outdir, mf),
+                **node.attributes)
+            new_node['from_math'] = True
+            if not isinstance(node, nodes.math):
+                new_node['align'] = 'center'
+            if depth is not None:
+                new_node['math_depth'] = depth
+            node.replace_self(new_node)
+        except imgmath.MathExtError as exc:
+            ConfluenceLogger.warn('inline latex {}: {}'.format(
+                node.astext(), exc))

--- a/sphinxcontrib/confluencebuilder/transmute.py
+++ b/sphinxcontrib/confluencebuilder/transmute.py
@@ -287,7 +287,7 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
                 refdoc=mock_docname,
                 refexplicit=True,
                 reftarget=node['refuri'],
-                )
+            )
             node.replace_self(new_node)
 
     if sphinx_toolbox_collapse:


### PR DESCRIPTION
Adding support for some third-party extensions.

Still debating if this is the right move -- in terms of maintenance/complexity to this extension. Although if it makes users of this extension experience easier, it may be worth it.

Adding support for:
- [sphinx-toolbox](https://sphinx-toolbox.readthedocs.io/en/latest/)
-  [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid)