### PR TITLE
add support for sphinx-gallery

### DIFF
--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -325,6 +325,15 @@ class ConfluenceAssetManager:
             path = os.path.normpath(path)
             if os.path.isabs(path):
                 abspath = path
+
+                # some extensions will prefix the path of an asset with `/`,
+                # with the intent of that path being the root from the
+                # configured source directory instead of an absolute path on the
+                # system -- to handle this use case, if a provided absolute path
+                # cannot be found, attempt to find an asset based on a path
+                # based in the source directory
+                if not os.path.isfile(abspath) and path[0] == os.sep:
+                    abspath = os.path.join(self.env.srcdir, path[1:])
             else:
                 abspath = os.path.join(self.env.srcdir, path)
 

--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -112,7 +112,7 @@ class ConfluenceAssetManager:
             docname (optional): force the document name for this asset
 
         Returns:
-            the key and document name
+            the key, document name and path
         """
         key = None
 
@@ -153,8 +153,9 @@ class ConfluenceAssetManager:
 
         if not key:
             docname = None
+            path = None
 
-        return key, docname
+        return key, docname, path
 
     def process(self, docnames):
         """

--- a/sphinxcontrib/confluencebuilder/transmute.py
+++ b/sphinxcontrib/confluencebuilder/transmute.py
@@ -60,6 +60,13 @@ try:
 except ImportError:
     sphinx_toolbox_github_repos_and_users = False
 
+# load sphinx-gallary extension if available
+try:
+    from sphinx_gallery.directives import imgsgnode as sphinx_gallery_imgsgnode
+    sphinx_gallery = True
+except ImportError:
+    sphinx_gallery = False
+
 # load sphinxcontrib-mermaid extension if available
 try:
     from sphinxcontrib.mermaid import MermaidError
@@ -100,6 +107,8 @@ def doctree_transmute(builder, doctree):
     # --------------------------
     # sphinx external extensions
     # --------------------------
+
+    replace_sphinx_gallery_nodes(builder, doctree)
 
     replace_sphinx_toolbox_nodes(builder, doctree)
 
@@ -318,6 +327,28 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
         for node in doctree.traverse(sphinx_toolbox_GitHubObjectLinkNode):
             new_node = nodes.reference(node.name, node.name, refuri=node.url)
             node.replace_self(new_node)
+
+
+def replace_sphinx_gallery_nodes(builder, doctree):
+    """
+    replace mermaid nodes with images
+
+    mermaid nodes are pre-processed and replaced with respective images in the
+    processed documentation set.
+
+    Args:
+        builder: the builder
+        doctree: the doctree to replace blocks on
+    """
+
+    if not sphinx_gallery:
+        return
+
+    for node in doctree.traverse(sphinx_gallery_imgsgnode):
+        new_node = nodes.image(candidates={'?'}, **node.attributes)
+        if 'align' in node:
+            new_node['align'] = node['align']
+        node.replace_self(new_node)
 
 
 def replace_sphinxcontrib_mermaid_nodes(builder, doctree):


### PR DESCRIPTION
Provide support for processing sphinx-gallery nodes when using the Confluence builder.

This pull request includes a change to asset processing ("assets: flexible os.sep-prefix path finding") to support gallery-provided images starting with `/`. Also, with changes to better size detection for gallery thumbnail-like images, improvements have been made to use a better path detection whenever an image's size needs to be calculated.