### PR TITLE
correct xml-declaration injection for svgs

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -461,8 +461,8 @@ class ConfluencePublisher():
             raw_data = data
             XML_DEC = b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
             if mimetype == 'image/svg+xml':
-                if raw_data.lstrip().startswith(b'<?xml'):
-                    raw_data = XML_DEC + raw_data
+                if not raw_data.lstrip().startswith(b'<?xml'):
+                    raw_data = XML_DEC + b'\n' + raw_data
 
             data = {
                 'comment': '{}:{}'.format(HASH_KEY, hash),


### PR DESCRIPTION
A previous commit \[1\] added support to inject XML declarations for SVGs which may be missing them. When the change was prepared, a switch in the development version from a `<svg` check to an `<?xml` check did not properly update the condition -- which now leads to injecting XML declaration on SVGs which already have them; correcting this.

\[1\]: dcc7f027f00e0909851586c9c473e6c30fd7f114