### PR TITLE
support restriction third-party extension handling

### DIFF
--- a/sphinxcontrib/confluencebuilder/transmute.py
+++ b/sphinxcontrib/confluencebuilder/transmute.py
@@ -283,6 +283,11 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
         doctree: the doctree to replace nodes on
     """
 
+    # allow users to disabled third-party implemented extension changes
+    restricted = builder.config.confluence_adv_restricted
+    if 'ext-sphinx_toolbox' in restricted:
+        return
+
     if sphinx_toolbox_assets:
         for node in doctree.traverse(sphinx_toolbox_AssetNode):
             # mock a docname based off the configured sphinx_toolbox's asset
@@ -341,6 +346,11 @@ def replace_sphinx_gallery_nodes(builder, doctree):
         doctree: the doctree to replace blocks on
     """
 
+    # allow users to disabled third-party implemented extension changes
+    restricted = builder.config.confluence_adv_restricted
+    if 'ext-sphinx_gallery' in restricted:
+        return
+
     if not sphinx_gallery:
         return
 
@@ -362,6 +372,11 @@ def replace_sphinxcontrib_mermaid_nodes(builder, doctree):
         builder: the builder
         doctree: the doctree to replace blocks on
     """
+
+    # allow users to disabled third-party implemented extension changes
+    restricted = builder.config.confluence_adv_restricted
+    if 'ext-sphinxcontrib.mermaid' in restricted:
+        return
 
     if not sphinxcontrib_mermaid:
         return

--- a/sphinxcontrib/confluencebuilder/transmute.py
+++ b/sphinxcontrib/confluencebuilder/transmute.py
@@ -60,7 +60,7 @@ try:
 except ImportError:
     sphinx_toolbox_github_repos_and_users = False
 
-# load sphinx-gallary extension if available
+# load sphinx-gallery extension if available
 try:
     from sphinx_gallery.directives import imgsgnode as sphinx_gallery_imgsgnode
     sphinx_gallery = True
@@ -331,10 +331,10 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
 
 def replace_sphinx_gallery_nodes(builder, doctree):
     """
-    replace mermaid nodes with images
+    replace sphinx-gallery nodes with images
 
-    mermaid nodes are pre-processed and replaced with respective images in the
-    processed documentation set.
+    sphinx-gallery nodes are pre-processed and replaced with respective images
+    in the processed documentation set.
 
     Args:
         builder: the builder


### PR DESCRIPTION
This extension does attempt to provide some support for various third-party implementations, this could cause issues if a specific third-party extension wishes to provide their own support for integrating with supported Confluence builders/translators. Adding a series of restriction checks to opt-out of node processing for these extensions.