### PR TITLE
maintenance (2021-11-06)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ A demonstration of this extension can be seen by inspecting the published
 validation/testing documents found here:
 
  | Atlassian Confluence Builder for Sphinx - Online Demo on Confluence Cloud
- | https://sphinxcontrib-confluencebuilder.atlassian.net/wiki/spaces/STABLE
+ | https://sphinxcontrib-confluencebuilder.atlassian.net/
 
 ----
 

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -63,7 +63,12 @@ format) and optionally publish them to a Confluence instance.{%endtrans%}
   <td>
     <p class="biglink"><a class="biglink" href="{{pathto('contents')}}">Contents</a><br/>
        <span class="linkdescr">for a complete overview</span></p>
-  </td><td><p class="biglink"><a class="biglink" href="{{pathto('changelog')}}">Changelog</a><br/>
+  </td><td><p class="biglink"><a class="biglink" href="{{pathto('configuration')}}">Configuration</a><br/>
+       <span class="linkdescr">extension options</span></p>
+  </td>
+</tr>
+</tr><tr>
+  <td colspan="2"><p class="biglink"><a class="biglink" href="{{pathto('changelog')}}">Changelog</a><br/>
        <span class="linkdescr">release history</span></p>
   </td>
 </tr>

--- a/doc/_themes/sphinx13b/static/sphinx13b.css
+++ b/doc/_themes/sphinx13b/static/sphinx13b.css
@@ -409,7 +409,7 @@ div.viewcode-block:target {
 
 .download-pypi {
     float: right;
-    line-height: 4em;
+    line-height: 4.1em;
 }
 
 .quick-grab-container {

--- a/doc/_themes/sphinx13b/theme.conf
+++ b/doc/_themes/sphinx13b/theme.conf
@@ -1,4 +1,4 @@
 [theme]
 inherit = basic
-stylesheet = sphinx13b.css
+stylesheet = sphinx13b.css?20211106
 pygments_style = trac

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -6,7 +6,9 @@ Confluence generation and publishing:
 
 .. code-block:: python
 
-    extensions = ['sphinxcontrib.confluencebuilder']
+    extensions = [
+        'sphinxcontrib.confluencebuilder',
+    ]
     confluence_publish = True
     confluence_space_key = 'TEST'
     confluence_parent_page = 'Documentation'

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -90,7 +90,7 @@ Essential configuration
 
     .. code-block:: python
 
-        confluence_space_key = '~123456789' 
+        confluence_space_key = '~123456789'
 
 .. |confluence_server_user| replace:: ``confluence_server_user``
 .. _confluence_server_user:

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -1,5 +1,5 @@
-Compatibilities
-===============
+Features
+========
 
 The following outlines the reStructuredText_/Sphinx_ markup, configuration
 entries and more supported by this extension. The intent of this extension is to

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,10 @@
 # build a universal wheel (Python 2 and 3 supported)
 universal=1
 
+[sdist]
+owner = root
+group = root
+
 [coverage:run]
 parallel = 1
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ setup(
     install_requires=requires,
     namespace_packages=['sphinxcontrib'],
     test_suite='tests',
-    tests_require=['sphinx'],
     cmdclass={
         'clean': ExtendedClean,
     },

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ class ExtendedClean(clean):
                 dir_util.remove_tree(extra, dry_run=self.dry_run)
 
 requires = [
+    'docutils<0.18;python_version<"3.0"',  # legacy docutils for older sphinx
     'requests>=2.14.0',
     'sphinx>=1.8',
 ]

--- a/sphinxcontrib/confluencebuilder/transmute.py
+++ b/sphinxcontrib/confluencebuilder/transmute.py
@@ -42,33 +42,33 @@ if graphviz:
 try:
     from sphinx_toolbox.assets import AssetNode as sphinx_toolbox_AssetNode
     sphinx_toolbox_assets = True
-except:
+except:  # noqa: E722
     sphinx_toolbox_assets = False
 
 try:
     from sphinx_toolbox.collapse import CollapseNode as sphinx_toolbox_CollapseNode
     sphinx_toolbox_collapse = True
-except:
+except:  # noqa: E722
     sphinx_toolbox_collapse = False
 
 try:
     from sphinx_toolbox.github.issues import IssueNode as sphinx_toolbox_IssueNode
     from sphinx_toolbox.github.issues import IssueNodeWithName as sphinx_toolbox_IssueNodeWithName
     sphinx_toolbox_github_issues = True
-except:
+except:  # noqa: E722
     sphinx_toolbox_github_issues = False
 
 try:
     from sphinx_toolbox.github.repos_and_users import GitHubObjectLinkNode as sphinx_toolbox_GitHubObjectLinkNode
     sphinx_toolbox_github_repos_and_users = True
-except:
+except:  # noqa: E722
     sphinx_toolbox_github_repos_and_users = False
 
 # load sphinx-gallery extension if available
 try:
     from sphinx_gallery.directives import imgsgnode as sphinx_gallery_imgsgnode
     sphinx_gallery = True
-except:
+except:  # noqa: E722
     sphinx_gallery = False
 
 # load sphinxcontrib-mermaid extension if available
@@ -77,7 +77,7 @@ try:
     from sphinxcontrib.mermaid import mermaid
     from sphinxcontrib.mermaid import render_mm as mermaid_render
     sphinxcontrib_mermaid = True
-except:
+except:  # noqa: E722
     sphinxcontrib_mermaid = False
 
 # re-enable pylint warnings from above

--- a/sphinxcontrib/confluencebuilder/transmute.py
+++ b/sphinxcontrib/confluencebuilder/transmute.py
@@ -34,37 +34,41 @@ if graphviz:
     except ImportError:
         inheritance_diagram = None
 
+# ##############################################################################
+# disable import/except warnings for third-party modules
+# pylint: disable=E
+
 # load sphinx_toolbox extension if available to handle node pre-processing
 try:
     from sphinx_toolbox.assets import AssetNode as sphinx_toolbox_AssetNode
     sphinx_toolbox_assets = True
-except ImportError:
+except:
     sphinx_toolbox_assets = False
 
 try:
     from sphinx_toolbox.collapse import CollapseNode as sphinx_toolbox_CollapseNode
     sphinx_toolbox_collapse = True
-except ImportError:
+except:
     sphinx_toolbox_collapse = False
 
 try:
     from sphinx_toolbox.github.issues import IssueNode as sphinx_toolbox_IssueNode
     from sphinx_toolbox.github.issues import IssueNodeWithName as sphinx_toolbox_IssueNodeWithName
     sphinx_toolbox_github_issues = True
-except ImportError:
+except:
     sphinx_toolbox_github_issues = False
 
 try:
     from sphinx_toolbox.github.repos_and_users import GitHubObjectLinkNode as sphinx_toolbox_GitHubObjectLinkNode
     sphinx_toolbox_github_repos_and_users = True
-except ImportError:
+except:
     sphinx_toolbox_github_repos_and_users = False
 
 # load sphinx-gallery extension if available
 try:
     from sphinx_gallery.directives import imgsgnode as sphinx_gallery_imgsgnode
     sphinx_gallery = True
-except ImportError:
+except:
     sphinx_gallery = False
 
 # load sphinxcontrib-mermaid extension if available
@@ -73,8 +77,12 @@ try:
     from sphinxcontrib.mermaid import mermaid
     from sphinxcontrib.mermaid import render_mm as mermaid_render
     sphinxcontrib_mermaid = True
-except ImportError:
+except:
     sphinxcontrib_mermaid = False
+
+# re-enable pylint warnings from above
+# pylint: enable=E
+# ##############################################################################
 
 
 def doctree_transmute(builder, doctree):

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -47,6 +47,9 @@ def main():
             pass
 
         enable_sphinx_info(verbosity=verbosity)
+    else:
+        # disable short descriptions to minimize output (one test per line)
+        unittest.TestCase.shortDescription = lambda x: None
 
     # discover unit tests
     test_base = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Perform a series of improvements to this extension:

### setup.py: configure py27 environments to force older docutils

Enforce that when install on a Python 2.7 interpreter that docutils is explicitly configured to an older version. This is to help enforce a docutils version which Sphinx 1.8.x series supports (which is the only supported version with Python 2.7)

### setup.cfg: default tar'ing to use root users

When packaging sources (sdist), use a root owner/group to ensure consistent source package building no matter what user triggers a build.

### setup.py: drop tests_require entry

Dropping the usage of the `tests_require` option. Aside from the option being deprecated and ignoring that the package listed in this field is already installed via `install_requires`, any test dependencies in this project are managed through a tox requirement file.

### tests: ignore docstring printing for unit test builds

Disables short descriptions for unit tests (populated via any configured docstring on the test) from being added to the standard unit test building. This minimizes the test outputs by using on a single line per test.

### increase fallback protection on third-party libraries

Perform a full exception catching when loading third-party modules to prevent any risks associated from importing these optional packages into this extension (e.g. third-party extensions failing to load on older interpreters).


### doc: improve alignment of pypi icon

Tweak the line-height for the PyPI download icon to better align itself alongside the "Download"  title.

### doc: trigger cache update on theme updates

The documentation's stylesheet has been updated. Appending a datetime to the stylesheet reference to help promote a cache refresh.

### doc: add configuration link on landing page

Provides a link to the configuration section on the documentation's landing page, as it is most likely a popular page which users may wish to jump to.

### doc: rename compatibilities page to features

Renaming the `Compatibilities` document title to `Features`.

### doc: restructure extensions example

Adjusting the configuration section's quick-example to promote a more extendable `extensions` definition.