### PR TITLE
improve builder progress status

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -596,38 +596,27 @@ class ConfluenceBuilder(Builder):
                 return
 
             if self.legacy_pages:
-                n = len(self.legacy_pages)
-                self.info('removing legacy pages (total: {}) ...'.format(n),
-                    nonl=(not self._verbose))
-
-                for legacy_page_id in self.legacy_pages:
+                for legacy_page_id in status_iterator(
+                        self.legacy_pages, 'removing legacy pages... ',
+                        length=len(self.legacy_pages),
+                        verbosity=self._verbose):
                     self.publisher.removePage(legacy_page_id)
                     # remove any pending assets to remove from the page (as they
                     # are already been removed)
                     self.legacy_assets.pop(legacy_page_id, None)
 
-                    if not self._verbose:
-                        self.info('.', nonl=True)
-
-                if not self._verbose:
-                    self.info(' done\n')
-
             n = 0
             for legacy_asset_info in self.legacy_assets.values():
                 n += len(legacy_asset_info.keys())
             if n > 0:
-                self.info('removing legacy assets (total: {}) ...'.format(n),
-                    nonl=(not self._verbose))
+                for legacy_asset_info in status_iterator(
+                        self.legacy_assets.values(),
+                        'removing legacy assets... ',
+                        length=n,
+                        verbosity=self._verbose):
 
-                for legacy_asset_info in self.legacy_assets.values():
                     for id in legacy_asset_info.keys():
                         self.publisher.removeAttachment(id)
-
-                    if not self._verbose:
-                        self.info('.', nonl=True)
-
-                if not self._verbose:
-                    self.info(' done\n')
 
     def finish(self):
         # restore environment's get_doctree if it was temporarily replaced

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -576,7 +576,7 @@ class ConfluenceBuilder(Builder):
                 self.info('updating space\'s homepage... ',
                     nonl=(not self._verbose))
                 self.publisher.updateSpaceHome(self.root_doc_page_id)
-                self.info('done\n')
+                self.info('done')
 
             if self.cloud:
                 point_url = '{0}spaces/{1}/pages/{2}'
@@ -704,7 +704,7 @@ class ConfluenceBuilder(Builder):
 
             self.info('building intersphinx... ', nonl=(not self._verbose))
             build_intersphinx(self)
-            self.info('done\n')
+            self.info('done')
 
     def cleanup(self):
         if self.publish:


### PR DESCRIPTION
### builder: adjusting purge actions to use a status iterator

Adjusting both legacy page processing and legacy asset processing to use a status iterator (for percentage progress) over a simple dot-per-entity progress.

### builder: cleanup duplicate line-ending on various note calls

Some `note` calls inject an unneeded newline entry in their output, which the `note` call already handled; removing.