### PR TITLE
Improve image length option management and svg support

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -268,10 +268,3 @@ def confluence_builder_inited(app):
         if transform.__name__ == 'MathNodeMigrator':
             app.registry.get_post_transforms().remove(transform)
             break
-
-    # Images defined by data uri schemas can be resolved into generated images
-    # after a document's post-transformation stage. After a document's doctree
-    # has been resolved, re-check for any images that have been translated.
-    def resolve_assets_hook(app, doctree, docname):
-        app.builder.assets.processDocument(doctree, docname, True)
-    app.connect('doctree-resolved', resolve_assets_hook)

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -444,26 +444,6 @@ class ConfluencePublisher():
 
         # publish attachment
         try:
-            # ensure svg attachment as xml declaration
-            #
-            # This is a special case of manipulating attachment data in the
-            # publishing stage of this extension. SVG files must have an XML
-            # declaration in them, or Confluence will not accept them. This
-            # extension will not modify references image files on the disk (not
-            # to edit a documentation's original content) or try to maintain a
-            # duplicate cache of image files that need to correct these SVG
-            # files. Instead, when ready to publish SVG content data to a
-            # Confluence instance, we will sanity check that the declaration
-            # exists on the first line. If not, it will be injected at the start
-            # before publishing. Still does bypass some hash-tracking concepts,
-            # but managing hash entries based off the original source content is
-            # fine and should not have any significant side effects.
-            raw_data = data
-            XML_DEC = b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
-            if mimetype == 'image/svg+xml':
-                if not raw_data.lstrip().startswith(b'<?xml'):
-                    raw_data = XML_DEC + b'\n' + raw_data
-
             # split hash comment into chunks to minize rendering issues with a
             # single one-world-long-hash value
             chunked_hash = '\n'.join(
@@ -471,7 +451,7 @@ class ConfluencePublisher():
 
             data = {
                 'comment': '{}:{}'.format(HASH_KEY, chunked_hash),
-                'file': (name, raw_data, mimetype),
+                'file': (name, data, mimetype),
             }
 
             if not self.notify:

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -19,6 +19,12 @@ INVALID_CHARS = ['\\', '/', '"', ':', '?', '*', '|', '<', '>']
 # confluence default first-child masked margin offset (in pixels)
 FCMMO = 10
 
+# confluence font size observed from its default theme
+FONT_SIZE = 14
+
+# confluence font x-height size observed from its default theme
+FONT_X_HEIGHT = 7
+
 # sphinx literal to confluence language map
 #
 # Provides a map of Sphinx literal language values to respective and supported*

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -23,8 +23,9 @@ from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_HIGHLIGHT_STYLE
 from sphinxcontrib.confluencebuilder.storage import encode_storage_format
 from sphinxcontrib.confluencebuilder.storage import intern_uri_anchor_value
 from sphinxcontrib.confluencebuilder.translator import ConfluenceBaseTranslator
+from sphinxcontrib.confluencebuilder.util import convert_px_length
+from sphinxcontrib.confluencebuilder.util import extract_length
 from sphinxcontrib.confluencebuilder.util import first
-import math
 import posixpath
 import sys
 
@@ -1382,28 +1383,50 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             alt = self.encode(alt)
             attribs['ac:alt'] = alt
 
-        if 'scale' in node and 'width' not in node:
+        # extract height, width and scale values on this image
+        height, hu = extract_length(node.get('height'))
+        scale = node.get('scale')
+        width, wu = extract_length(node.get('width'))
+
+        # if a scale value is provided and a height/width is not set, attempt to
+        # determine the size of the image so that we can apply a scale value on
+        # the detected size values
+        if scale and not height and not width:
             if internal_img:
                 size = get_image_size(image_path)
                 if size is None:
                     self.warn('could not obtain image size; :scale: option is '
                         'ignored for ' + image_path)
                 else:
-                    scale = node['scale'] / 100.0
-                    node['width'] = str(int(math.ceil(size[0] * scale))) + 'px'
+                    width = size[0]
+                    wu = 'px'
             else:
                 self.warn('cannot not obtain image size for external image; '
                     ':scale: option is ignored for ' + uri)
 
-        if 'height' in node:
-            self.warn('height value for image is unsupported in confluence')
+        # apply scale factor to height/width fields
+        if scale:
+            if height:
+                height = int(round(float(height) * scale / 100))
+            if width:
+                width = int(round(float(width) * scale / 100))
 
-        if 'width' in node:
-            width = node['width']
+        # confluence only supports pixel sizes -- adjust any other unit type
+        # (if possible) to a pixel length
+        if height:
+            height = convert_px_length(height, hu)
+            if height is None:
+                self.warn('unsupported unit type for confluence: ' + hu)
+        if width:
+            width = convert_px_length(width, wu)
+            if width is None:
+                self.warn('unsupported unit type for confluence: ' + wu)
+
+        # apply width/height fields on the image macro
+        if height:
+            attribs['ac:height'] = height
+        if width:
             attribs['ac:width'] = width
-
-            if not width.endswith('px'):
-                self.warn('unsupported unit type for confluence: ' + width)
 
         # [sphinx-gallary] create "thumbnail" images for sphinx-gallary
         #
@@ -1413,13 +1436,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         # images to a smaller size with a Confluence editor). Although, if the
         # detected image size is smaller than our target, ignore any forced size
         # changes.
-        elif 'sphx-glr-multi-img' in node.get('class', []):
-            size = None
-            if image_path:
+        if height is None and width is None and internal_img:
+            if 'sphx-glr-multi-img' in node.get('class', []):
                 size = get_image_size(image_path)
 
-            if not size or size[1] > 250:
-                attribs['ac:height'] = '250'
+                if not size or size[1] > 250:
+                    attribs['ac:height'] = '250'
 
         if not internal_img:
             # an external or embedded image

--- a/sphinxcontrib/confluencebuilder/svg.py
+++ b/sphinxcontrib/confluencebuilder/svg.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from hashlib import sha256
+from sphinx.util.images import guess_mimetype
+from sphinx.util.osutil import ensuredir
+from sphinxcontrib.confluencebuilder.util import convert_px_length
+from sphinxcontrib.confluencebuilder.util import extract_length
+from sphinxcontrib.confluencebuilder.util import find_env_abspath
+import os
+import xml.etree.ElementTree as xml_et
+
+
+# xml declaration string
+XML_DEC = b'<?xml version="1.0" encoding="UTF-8" standalone="no"?>'
+
+
+def svg_initialize():
+    """
+    initialize support for processing svgs
+
+    The following call will initialize this extension to help support processing
+    SVG files which need manipulation.
+    """
+
+    # prevent ns0 namespace introduction if ever generating svg files
+    xml_et.register_namespace('', 'http://www.w3.org/2000/svg')
+
+
+def confluence_supported_svg(builder, node):
+    """
+    process an image node and ensure confluence-supported svg  (if applicable)
+
+    SVGs have some limitations when being presented on a Confluence instance.
+    The following have been observed issues:
+
+    1) If an SVG file does not have an XML declaration, Confluence will fail to
+       render an image.
+    2) If an `ac:image` macro is applied custom width/height values on an SVG,
+       Confluence Confluence will fail to render the image.
+
+    This call will process a provided image node and ensure an SVG is in a ready
+    state for publishing. If a node is not an SVG, this method will do nothing.
+
+    To support custom width/height fields for an SVG image, the image file
+    itself will be modified to an expected lengths. Any hints in the
+    documentation using width/height or scale, the desired width and height
+    fields of an image will calculated and replaced/injected into the SVG image.
+
+    Any SVG files which do not have an XML declaration will have on injected.
+
+    Args:
+        builder: the builder
+        node: the image node to check
+    """
+
+    uri = node['uri']
+
+    # ignore external/embedded images
+    if uri.find('://') != -1 or uri.startswith('data:'):
+        return
+
+    # invalid uri/path
+    uri_abspath = find_env_abspath(builder.env, builder.outdir, uri)
+    if not uri_abspath:
+        return
+
+    # ignore non-svgs
+    mimetype = guess_mimetype(uri_abspath)
+    if mimetype != 'image/svg+xml':
+        return
+
+    try:
+        with open(uri_abspath, 'rb') as f:
+            svg_data = f.read()
+    except (IOError, OSError) as err:
+        builder.warn('error reading svg: %s' % err)
+        return
+
+    modified = False
+    svg_root = xml_et.fromstring(svg_data)
+
+    # determine (if possible) the svgs desired width/height
+    svg_height = None
+    if 'height' in svg_root.attrib:
+        svg_height = svg_root.attrib['height']
+
+    svg_width = None
+    if 'width' in svg_root.attrib:
+        svg_width = svg_root.attrib['width']
+
+    # try to fallback on the viewbox attribute
+    if svg_height is None or svg_width is None:
+        if 'viewBox' in svg_root.attrib:
+            try:
+                _, _, svg_width, svg_height = \
+                    svg_root.attrib['viewBox'].split(' ')
+            except ValueError:
+                pass
+
+    # if tracking an svg width/height, ensure the sizes are in pixels
+    if svg_height:
+        svg_height, svg_height_units = extract_length(svg_height)
+        svg_height = convert_px_length(svg_height, svg_height_units)
+    if svg_width:
+        svg_width, svg_width_units = extract_length(svg_width)
+        svg_width = convert_px_length(svg_width, svg_width_units)
+
+    # extract length/scale properties from the node
+    height, hu = extract_length(node.get('height'))
+    scale = node.get('scale')
+    width, wu = extract_length(node.get('width'))
+
+    # if only one size is set, fetch (and scale) the other
+    if width and not height:
+        if svg_height and svg_width:
+            height = float(width) / svg_width * svg_height
+        else:
+            height = width
+        hu = wu
+
+    if height and not width:
+        if svg_height and svg_width:
+            width = float(height) / svg_height * svg_width
+        else:
+            width = height
+        wu = hu
+
+    # if a scale value is provided and a height/width is not set, attempt to
+    # determine the size of the image so that we can apply a scale value on
+    # the detected size values
+    if scale:
+        if not height and svg_height:
+            height = svg_height
+            hu = 'px'
+
+        if not width and svg_width:
+            width = svg_width
+            wu = 'px'
+
+    # apply scale factor to height/width fields
+    if scale:
+        if height:
+            height = int(round(float(height) * scale / 100))
+        if width:
+            width = int(round(float(width) * scale / 100))
+
+    # confluence only supports pixel sizes -- adjust any other unit type
+    # (if possible) to a pixel length
+    if height:
+        height = convert_px_length(height, hu)
+        if height is None:
+            builder.warn('unsupported unit type for confluence: ' + hu)
+    if width:
+        width = convert_px_length(width, wu)
+        if width is None:
+            builder.warn('unsupported unit type for confluence: ' + wu)
+
+    # if we have a height/width to apply, adjust the svg
+    if height and width:
+        svg_root.attrib['height'] = str(height)
+        svg_root.attrib['width'] = str(width)
+        svg_data = xml_et.tostring(svg_root)
+        modified = True
+
+    # ensure xml declaration exists
+    if not svg_data.lstrip().startswith(b'<?xml'):
+        svg_data = XML_DEC + b'\n' + svg_data
+        modified = True
+
+    # ignore svg file if not modifications are needed
+    if not modified:
+        return
+
+    fname = sha256(svg_data).hexdigest() + '.svg'
+    outfn = os.path.join(builder.outdir, builder.imagedir, 'svgs', fname)
+
+    # write the new svg file (if needed)
+    if not os.path.isfile(outfn):
+        ensuredir(os.path.dirname(outfn))
+        try:
+            with open(outfn, 'wb') as f:
+                f.write(svg_data)
+        except (IOError, OSError) as err:
+            builder.warn('error writing svg: %s' % err)
+            return
+
+    # replace the required node attributes
+    node['uri'] = outfn
+
+    if 'height' in node:
+        del node['height']
+    if 'scale' in node:
+        del node['scale']
+    if 'width' in node:
+        del node['width']

--- a/sphinxcontrib/confluencebuilder/transmute.py
+++ b/sphinxcontrib/confluencebuilder/transmute.py
@@ -10,6 +10,8 @@ from sphinx import addnodes
 from sphinx.util.math import wrap_displaymath
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 from sphinxcontrib.confluencebuilder.nodes import confluence_expand
+from sphinxcontrib.confluencebuilder.svg import confluence_supported_svg
+from sphinxcontrib.confluencebuilder.svg import svg_initialize
 from sphinxcontrib.confluencebuilder.util import first
 
 # load graphviz extension if available to handle node pre-processing
@@ -121,6 +123,32 @@ def doctree_transmute(builder, doctree):
     replace_sphinx_toolbox_nodes(builder, doctree)
 
     replace_sphinxcontrib_mermaid_nodes(builder, doctree)
+
+    # -------------------
+    # post-transmute work
+    # -------------------
+
+    # re-work svg entries to support confluence
+    prepare_svgs(builder, doctree)
+
+
+def prepare_svgs(builder, doctree):
+    """
+    process any svgs found in a doctree to work on confluence
+
+    The following will process a doctree for any SVG images to ensure they are
+    compatible with published on a Confluence instance. See
+    `confluence_supported_svg` for more details.
+
+    Args:
+        builder: the builder
+        doctree: the doctree to check for svgs
+    """
+
+    svg_initialize()
+
+    for node in doctree.traverse(nodes.image):
+        confluence_supported_svg(builder, node)
 
 
 def replace_graphviz_nodes(builder, doctree):

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -7,9 +7,12 @@
 from contextlib import contextmanager
 from sphinxcontrib.confluencebuilder import compat
 from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
+from sphinxcontrib.confluencebuilder.std.confluence import FONT_SIZE
+from sphinxcontrib.confluencebuilder.std.confluence import FONT_X_HEIGHT
 from hashlib import sha256
 import getpass
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -67,6 +70,84 @@ class ConfluenceUtil:
             elif not url.endswith('/'):
                 url += '/'
         return url
+
+def convert_px_length(value, unit):
+    """
+    convert a length value to an integer pixel-equivalent value
+
+    This call accepts a length value and associated units and will return a
+    pixel-length representation of the provided length value. If no units are
+    provided in this call, it will be assumed that the units are already
+    represented by a pixel unit.
+
+    Args:
+        value: the value to convert
+        unit: the units of the value
+
+    Returns:
+        the length in pixels
+    """
+
+    if value is None:
+        return None
+
+    fvalue = float(value)
+
+    if unit is None:
+        return int(round(fvalue))
+
+    if unit == 'px':
+        pass
+    elif unit == 'em':
+        fvalue *= FONT_SIZE
+    elif unit == 'ex':
+        fvalue *= FONT_X_HEIGHT
+    elif unit == 'mm':
+        fvalue *= 3.7795
+    elif unit == 'cm':
+        fvalue *= 37.7952
+    elif unit == 'in':
+        fvalue *= 96
+    elif unit == 'pt':
+        fvalue *= 1.3333
+    elif unit == 'pc':
+        fvalue *= 16
+    else:
+        return None
+
+    return int(round(fvalue))
+
+def extract_length(value):
+    """
+    extract length data from a provided value
+
+    Returns a tuple of a detected length value and a length unit. If no unit
+    type can be extracted, it will be assumed that the provided value has no
+    unit.
+
+    Args:
+        value: the value to parse
+
+    Returns:
+        the length and unit type
+    """
+
+    if not value:
+        return None, None
+
+    matched = re.match(r'^\s*(\d*\.?\d*)\s*(\S*)?\s*$', value)
+    if not matched:
+        return None, None
+
+    amount, unit = matched.groups()
+
+    if not amount:
+        amount = None
+        unit = None
+    elif not unit:
+        unit = None
+
+    return amount, unit
 
 def extract_strings_from_file(filename):
     """

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -175,6 +175,54 @@ def extract_strings_from_file(filename):
 
     return filelist
 
+def find_env_abspath(env, outdir, path):
+    """
+    find an existing absolute path for a provided path in a sphinx environment
+
+    This call will accept a path string and attempt to return an absolute path
+    to the file (if it exists). If no path can be found, this call will return
+    `None`.
+
+    Args:
+        env: the build environment
+        outdir: the build's output directory
+        path: the path to use
+
+    Returns:
+        the absolute path
+    """
+
+    abspath = None
+    if path:
+        path = os.path.normpath(path)
+        if os.path.isabs(path):
+            abspath = path
+
+            # some generated nodes will prefix the path of an asset with `/`,
+            # with the intent of that path being the root from the
+            # configured source directory instead of an absolute path on the
+            # system -- check the environment's source directory first before
+            # checking the full system's path
+            if path[0] == os.sep:
+                new_path = os.path.join(env.srcdir, path[1:])
+
+                if os.path.isfile(new_path):
+                    abspath = new_path
+        else:
+            abspath = os.path.join(env.srcdir, path)
+
+            # extensions may dump a generated asset in the output directory; if
+            # the absolute mapping to the source directory does not find the
+            # asset, attempt to bind the path based on the output directory
+            if not os.path.isfile(abspath):
+                abspath = os.path.join(outdir, path)
+
+    # if no asset can be found, ensure a `None` path is returned
+    if not os.path.isfile(abspath):
+        abspath = None
+
+    return abspath
+
 def first(it):
     """
     returns the first element in an iterable

--- a/tests/unit-tests/datasets/common/image.rst
+++ b/tests/unit-tests/datasets/common/image.rst
@@ -15,8 +15,23 @@ image
     :width: 200px
     :alt: alt text
 
-.. internal image with scaling
+.. internal image with alignment
 
 .. image:: ../../assets/image01.png
     :align: right
-    :scale: 20%
+
+.. internal image with no length units (assumed pixel size)
+
+.. image:: ../../assets/image01.png
+    :width: 123
+
+.. internal image with scaling
+
+.. image:: ../../assets/image01.png
+    :scale: 50%
+    :width: 100px
+
+.. internal image with non-pixel units
+
+.. image:: ../../assets/image01.png
+    :width: 2in

--- a/tests/unit-tests/datasets/svg/index.rst
+++ b/tests/unit-tests/datasets/svg/index.rst
@@ -1,0 +1,41 @@
+svgs
+====
+
+.. normal image processing
+
+.. image:: svg.svg
+
+.. image:: svg-viewbox.svg
+
+.. image:: svg-none.svg
+
+
+.. doctype should be injected into this document
+
+.. image:: svg-doctype.svg
+
+
+.. applying length/scale options into the svgs
+
+.. image:: svg.svg
+    :width: 75px
+
+.. image:: svg.svg
+    :height: 2in
+
+.. image:: svg.svg
+    :height: 50px
+    :width: 100pc
+
+.. image:: svg.svg
+    :scale: 200%
+    :width: 100px
+
+
+.. applying length/scale options based on viewbox
+
+.. image:: svg-viewbox.svg
+    :width: 50px
+
+.. image:: svg-viewbox.svg
+    :height: 200px

--- a/tests/unit-tests/datasets/svg/svg-doctype.svg
+++ b/tests/unit-tests/datasets/svg/svg-doctype.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="10"></circle>
+</svg>

--- a/tests/unit-tests/datasets/svg/svg-doctype.svg
+++ b/tests/unit-tests/datasets/svg/svg-doctype.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <circle cx="12" cy="12" r="10"></circle>
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+    <circle cx="24" cy="24" r="10"></circle>
 </svg>

--- a/tests/unit-tests/datasets/svg/svg-none.svg
+++ b/tests/unit-tests/datasets/svg/svg-none.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <circle cx="12" cy="12" r="10"></circle>
+</svg>

--- a/tests/unit-tests/datasets/svg/svg-viewbox.svg
+++ b/tests/unit-tests/datasets/svg/svg-viewbox.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 100">
+    <circle cx="12" cy="12" r="10"></circle>
+</svg>

--- a/tests/unit-tests/datasets/svg/svg.svg
+++ b/tests/unit-tests/datasets/svg/svg.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="10"></circle>
+</svg>

--- a/tests/unit-tests/test_rst_image.py
+++ b/tests/unit-tests/test_rst_image.py
@@ -26,7 +26,7 @@ class TestConfluenceRstImage(unittest.TestCase):
 
         with parse('image', out_dir) as data:
             images = data.find_all('ac:image', recursive=False)
-            self.assertEqual(len(images), 3)
+            self.assertEqual(len(images), 6)
 
             # ##########################################################
             # basic image
@@ -47,7 +47,7 @@ class TestConfluenceRstImage(unittest.TestCase):
             self.assertTrue(image.has_attr('ac:alt'))
             self.assertEqual(image['ac:alt'], 'alt text')
             self.assertTrue(image.has_attr('ac:width'))
-            self.assertEqual(image['ac:width'], '200px')
+            self.assertEqual(image['ac:width'], '200')
             self.assertFalse(image.has_attr('ac:align'))
 
             attachment = image.find('ri:attachment')
@@ -55,14 +55,48 @@ class TestConfluenceRstImage(unittest.TestCase):
             self.assertEqual(attachment['ri:filename'], 'image01.png')
 
             # ##########################################################
-            # image with alignment and scaling
+            # image with alignment
+            # ##########################################################
+            image = images.pop(0)
+
+            self.assertTrue(image.has_attr('ac:align'))
+            self.assertEqual(image['ac:align'], 'right')
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertEqual(attachment['ri:filename'], 'image01.png')
+
+            # ##########################################################
+            # image with no length units
             # ##########################################################
             image = images.pop(0)
 
             self.assertTrue(image.has_attr('ac:width'))
-            self.assertIsNotNone(image['ac:width'])
-            self.assertTrue(image.has_attr('ac:align'))
-            self.assertEqual(image['ac:align'], 'right')
+            self.assertEqual(image['ac:width'], '123')
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertEqual(attachment['ri:filename'], 'image01.png')
+
+            # ##########################################################
+            # image with scaling
+            # ##########################################################
+            image = images.pop(0)
+
+            self.assertTrue(image.has_attr('ac:width'))
+            self.assertEqual(image['ac:width'], '50')
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertEqual(attachment['ri:filename'], 'image01.png')
+
+            # ##########################################################
+            # image with non-pixel units
+            # ##########################################################
+            image = images.pop(0)
+
+            self.assertTrue(image.has_attr('ac:width'))
+            self.assertEqual(image['ac:width'], '192')
 
             attachment = image.find('ri:attachment')
             self.assertTrue(attachment.has_attr('ri:filename'))

--- a/tests/unit-tests/test_svg.py
+++ b/tests/unit-tests/test_svg.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib import build_sphinx
+from tests.lib import parse
+from tests.lib import prepare_conf
+import os
+import unittest
+import xml.etree.ElementTree as xml_et
+
+
+class TestSvg(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.config = prepare_conf()
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        self.dataset = os.path.join(test_dir, 'datasets', 'svg')
+
+    def _extract_svg_size(self, fname):
+        with open(fname, 'rb') as f:
+            svg_data = f.read()
+
+        svg_root = xml_et.fromstring(svg_data)
+        return int(svg_root.attrib['width']), int(svg_root.attrib['height'])
+
+    def test_storage_svgs(self):
+        out_dir = build_sphinx(self.dataset, config=self.config)
+
+        with parse('index', out_dir) as data:
+            images = data.find_all('ac:image', recursive=False)
+            self.assertEqual(len(images), 10)
+
+            # ##########################################################
+            # normal image processing
+            # ##########################################################
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertEqual(attachment['ri:filename'], 'svg.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertEqual(attachment['ri:filename'], 'svg-viewbox.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertEqual(attachment['ri:filename'], 'svg-none.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            # ##########################################################
+            # doctype should be injected into this document
+            # ##########################################################
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertNotEqual(attachment['ri:filename'], 'svg-doctype.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            with open(fname, 'rb') as f:
+                svg_data = f.read()
+                self.assertTrue(svg_data.lstrip().startswith(b'<?xml'))
+
+            # ##########################################################
+            # applying length/scale options into the svgs
+            # ##########################################################
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertNotEqual(attachment['ri:filename'], 'svg.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            svg_width, svg_height = self._extract_svg_size(fname)
+            self.assertEqual(svg_height, 75)
+            self.assertEqual(svg_width, 75)
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertNotEqual(attachment['ri:filename'], 'svg.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            svg_width, svg_height = self._extract_svg_size(fname)
+            self.assertEqual(svg_height, 192)
+            self.assertEqual(svg_width, 192)
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertNotEqual(attachment['ri:filename'], 'svg.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            svg_width, svg_height = self._extract_svg_size(fname)
+            self.assertEqual(svg_height, 50)
+            self.assertEqual(svg_width, 1600)
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertNotEqual(attachment['ri:filename'], 'svg.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            svg_width, svg_height = self._extract_svg_size(fname)
+            self.assertEqual(svg_height, 200)
+            self.assertEqual(svg_width, 200)
+
+            # ##########################################################
+            # applying length/scale options based on viewbox
+            # ##########################################################
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertNotEqual(attachment['ri:filename'], 'svg.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            svg_width, svg_height = self._extract_svg_size(fname)
+            self.assertEqual(svg_height, 200)
+            self.assertEqual(svg_width, 50)
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertNotEqual(attachment['ri:filename'], 'svg.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            svg_width, svg_height = self._extract_svg_size(fname)
+            self.assertEqual(svg_height, 200)
+            self.assertEqual(svg_width, 50)

--- a/tests/unit-tests/test_util_convert_px_length.py
+++ b/tests/unit-tests/test_util_convert_px_length.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.util import convert_px_length
+import unittest
+
+class TestConfluenceUtilConvertPxLength(unittest.TestCase):
+    def test_util_convertpxlen_invalid(self):
+        self.assertIsNone(convert_px_length(None, None))
+
+    def test_util_convertpxlen_unitless(self):
+        self.assertEqual(convert_px_length(123, None), 123)
+        self.assertEqual(convert_px_length(456.2, None), 456)
+        self.assertEqual(convert_px_length('789.7', None), 790)
+
+    def test_util_convertpxlen_units(self):
+        self.assertEqual(convert_px_length(321, 'px'), 321)
+        self.assertEqual(convert_px_length('654', 'px'), 654)
+        self.assertEqual(convert_px_length('987.6', 'px'), 988)
+        self.assertEqual(convert_px_length('987.3', 'px'), 987)
+        self.assertEqual(convert_px_length(1, 'in'), 96)
+        self.assertEqual(convert_px_length(1, 'pc'), 16)
+        self.assertGreater(convert_px_length(100, 'em'), 100)
+        self.assertGreater(convert_px_length(100, 'ex'), 100)
+        self.assertGreater(convert_px_length(100, 'mm'), 100)
+        self.assertGreater(convert_px_length(100, 'cm'), 100)
+        self.assertGreater(convert_px_length(100, 'pt'), 100)

--- a/tests/unit-tests/test_util_extract_length.py
+++ b/tests/unit-tests/test_util_extract_length.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.util import extract_length
+import unittest
+
+class TestConfluenceUtilExtractLength(unittest.TestCase):
+    def test_util_extractlen_invalid(self):
+        self.assertEqual(extract_length(None), (None, None))
+        self.assertEqual(extract_length(' '), (None, None))
+        self.assertEqual(extract_length('px'), (None, None))
+
+    def test_util_extractlen_unitless(self):
+        self.assertEqual(extract_length('123'), ('123', None))
+        self.assertEqual(extract_length(' 123'), ('123', None))
+        self.assertEqual(extract_length('123 '), ('123', None))
+
+    def test_util_extractlen_units(self):
+        self.assertEqual(extract_length('321px'), ('321', 'px'))
+        self.assertEqual(extract_length('2em'), ('2', 'em'))
+        self.assertEqual(extract_length('52 pt'), ('52', 'pt'))
+        self.assertEqual(extract_length(' 3 ex '), ('3', 'ex'))


### PR DESCRIPTION
### translator-storage: improve image unit/scaling handling

Improves the handling of various image-set unit sizes and usage of the scaling option. Confluence supports only a pixel-define height/width values for images -- and this extension's original implementation will just forward whatever width/height value was set to Confluence while also generating a warning for non-pixel-detected size values.

This results in:

1) Users needing to update various images/figures to use pixels, even when not desired (when mixing with other builder types).
2) Cause images uploaded to Confluence to show a "broken" icon, since Confluence could not handle unique height/width values.

Also, the scale value was only ever applied when a width entry was not set -- where it should have been applied no matter the situation (i.e. scaling the provided height/width values, as documented in the docutils documentation [1]).

reStructuredText outlines the following length units supported [2]: em, ex, mm, cm, in, px, pt and pc. This adjustment provides support for all these variants by converting the values set with these units to their pixel equivalent values. Note for `em` entry, a pixel value is configured based off the observed default font size found on Confluence (set in `CONFLUENCE_DEFAULT_FONT_SIZE`); and `ex` determined by the observed X-height value for a default font used on Confluence (set in `CONFLUENCE_DEFAULT_X_HEIGHT`).

In addition, this commit also corrects the application of the scale option to apply to any configured height/width -- either explicitly set or implicitly determined.

Note that Confluence does not support the percentage (%) unit type.

\[1\]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html
\[2\]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#length-units

### skip processing for assets on a doctree-resolve

The following removes the hook to re-check for assets after a doctree has been resolved. While it is still possible for new assets that need to be processed after a doctree has been resolved, there can still be events later on in the process where additional node changes can still result in assets needing to be processed for again. Support for this is handled in the translator class when a given asset-based node (i.e. images or downloads) will trigger a node processing for asset on-demand.

Since there is no major difference to looking for standalone assets on a doctree resolve event or when the translator needs to process a node, dropping the event hook for simplicity in the implementation.

### improve handling of length/scale options on svgs

If a documentation set defines length or scale options for an SVG that is attached to a page, the options will most likely cause the rendering of the image to fail on Confluence ("bad image"). Confluence appears to use the height/width options from the SVG image itself -- instead of accepting hints via the `ac:width` or `ac:height` options.

To improve handling of SVG images, any self-hosted SVGs needing to apply a custom width/height value will be modified and uploaded instead.

Since SVGs will have more than one way \[1\] they made need to be modified, SVGs will now be pre-processed and modified/dumped into a temporary directory in the output directory before being published.

\[1\]: c100dc89614c071a78c45a3b173bb80f09df2c3f

### tests: improve/extend length and scale options for image types

With improved handling various length and scale options added to the extension, add additional sanity checks for when processing images; and add more tests to validate length/unit parsing and processing.

### tests: add svg-specific processing tests

Adding a series of tests to validate the handling of XML declaration injections and SVG width/height modifications.