### PR TITLE
tox.ini: add develop environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,12 @@ commands =
     {envpython} -m coverage html
     {envpython} -m coverage report
 
+[testenv:develop]
+deps =
+    git+https://github.com/sphinx-doc/sphinx.git@master
+    -r{toxinidir}/requirements_dev.txt
+pip_pre = true
+
 [testenv:{,py27-,py36-,py37-,py38-,py39-,py310-}interactive]
 commands =
     {envpython} -m sphinxcontrib.confluencebuilder {posargs}


### PR DESCRIPTION
Adding a new environment called `develop` to help sanity check tests against the main development branch of Sphinx.