### PR TITLE
include hash-key prefix in chunking

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -446,11 +446,12 @@ class ConfluencePublisher():
         try:
             # split hash comment into chunks to minize rendering issues with a
             # single one-world-long-hash value
+            hash = '{}:{}'.format(HASH_KEY, hash)
             chunked_hash = '\n'.join(
                 [hash[i:i + 16] for i in range(0, len(hash), 16)])
 
             data = {
-                'comment': '{}:{}'.format(HASH_KEY, chunked_hash),
+                'comment': chunked_hash,
                 'file': (name, data, mimetype),
             }
 


### PR DESCRIPTION
When breaking a hash-key for an attachment into chunks \[1\], do so including the prefix. This should provide a better visual experience in the attachment page.

\[1\]: 4d8cfa16591f1aefde9f80f8f5a8c9405f75df0a