### PR TITLE
-improve single builder support

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -216,7 +216,7 @@ def confluence_builder_inited(app):
     """
 
     # ignore non-confluence builder types
-    if type(app.builder) != ConfluenceBuilder:
+    if not isinstance(app.builder, ConfluenceBuilder):
         return
 
     # register nodes required by confluence-specific directives

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -240,13 +240,19 @@ def confluence_builder_inited(app):
                 autosummary.autosummary_table,
                 confluence=(
                     autosummary.autosummary_table_visit_html,
-                    autosummary.autosummary_noop)
+                    autosummary.autosummary_noop),
+                singleconfluence=(
+                    autosummary.autosummary_table_visit_html,
+                    autosummary.autosummary_noop),
             )
             app.registry.add_translation_handlers(
                 autosummary.autosummary_toc,
                 confluence=(
                     autosummary.autosummary_toc_visit_html,
-                    autosummary.autosummary_noop)
+                    autosummary.autosummary_noop),
+                singleconfluence=(
+                    autosummary.autosummary_toc_visit_html,
+                    autosummary.autosummary_noop),
             )
             break
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -93,8 +93,10 @@ class ConfluenceBuilder(Builder):
 
         self.add_secnumbers = self.config.confluence_add_secnumbers
         self.secnumber_suffix = self.config.confluence_secnumber_suffix
-        self.use_index = config.confluence_use_index
-        self.use_search = config.confluence_include_search
+
+        if self.name != 'singleconfluence':
+            self.use_index = config.confluence_use_index
+            self.use_search = config.confluence_include_search
 
         if self.config.confluence_additional_mime_types:
             for type_ in self.config.confluence_additional_mime_types:
@@ -223,7 +225,7 @@ class ConfluenceBuilder(Builder):
         # generate domain index information
         self.domain_indices = {}
         indices_config = self.config.confluence_domain_indices
-        if indices_config:
+        if indices_config and self.name != 'singleconfluence':
             for domain_name in sorted(self.env.domains):
                 domain = self.env.domains[domain_name]
                 for indexcls in domain.indices:

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -344,8 +344,10 @@ class ConfluenceBuilder(Builder):
         # exception is assets which may be finalized during a document's post
         # transformation stage (e.g. embedded images are converted into real
         # images in Sphinx, which is then provided to a translator). Embedded
-        # images are detected during an 'doctree-resolved' hook (see __init__).
-        self.assets.process(ordered_docnames)
+        # images and other late-injected assets are processed in a translator
+        # when needed.
+        if self.name != 'singleconfluence':
+            self.assets.process(ordered_docnames)
 
     def _prepare_doctree_writing(self, docname, doctree):
         # extract metadata information

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1375,7 +1375,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         if internal_img:
             asset_docname = None
             if self.builder.name == 'singleconfluence':
-                asset_docname = self._docnames[-1]
+                asset_docname = self.docname
 
             image_key, hosting_docname, image_path = \
                 self.assets.fetch(node, docname=asset_docname)
@@ -1386,9 +1386,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 # if this is an svg image, additional processing may also needed
                 if is_svg:
                     confluence_supported_svg(self.builder, node)
-
-                if not asset_docname:
-                    asset_docname = self.docname
 
                 image_key, hosting_docname, image_path = \
                     self.assets.process_image_node(
@@ -1562,7 +1559,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         else:
             asset_docname = None
             if self.builder.name == 'singleconfluence':
-                asset_docname = self._docnames[-1]
+                asset_docname = self.docname
 
             file_key, hosting_docname, _ = \
                 self.assets.fetch(node, docname=asset_docname)
@@ -1570,9 +1567,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             # if this file has not already be processed (injected at a later
             # stage in the sphinx process); try processing it now
             if not file_key:
-                if not asset_docname:
-                    asset_docname = self.docname
-
                 file_key, hosting_docname, _ = \
                     self.assets.process_file_node(
                         node, asset_docname, standalone=True)

--- a/tests/unit-tests/test_singlepage_assets.py
+++ b/tests/unit-tests/test_singlepage_assets.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
+from tests.lib import build_sphinx
+from tests.lib import parse
+from tests.lib import prepare_conf
+import os
+import unittest
+
+class TestConfluenceSinglepageAssets(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.config = prepare_conf()
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        self.dataset = os.path.join(test_dir, 'datasets', 'shared-asset')
+
+    def test_storage_singlepage_asset_defaults(self):
+        """validate single page assets are self-contained (storage)"""
+        #
+        # Ensure when generating a single page that all assets on a page are
+        # pointing (implicitly) to itself (i.e. no `ri:page` entry).
+
+        out_dir = build_sphinx(self.dataset, config=self.config,
+            builder=SingleConfluenceBuilder.name)
+
+        with parse('index', out_dir) as data:
+            images = data.find_all('ac:image')
+            self.assertEqual(len(images), 2)
+
+            for image in images:
+                attachment = image.find('ri:attachment')
+                self.assertIsNotNone(attachment)
+                self.assertTrue(attachment.has_attr('ri:filename'))
+                self.assertEqual(attachment['ri:filename'], 'image03.png')
+
+                page_ref = attachment.find('ri:page')
+                self.assertIsNone(page_ref)
+
+    def test_storage_singlepage_asset_force_standalone(self):
+        """validate single page assets are self-contained alt (storage)"""
+        #
+        # Ensure when generating a single page that all assets on a page are
+        # pointing (implicitly) to itself (i.e. no `ri:page` entry) -- ensure
+        # the `confluence_asset_force_standalone` option is not causing issues.
+
+        config = dict(self.config)
+        config['confluence_asset_force_standalone'] = True
+        out_dir = build_sphinx(self.dataset, config=config,
+            builder=SingleConfluenceBuilder.name)
+
+        with parse('index', out_dir) as data:
+            images = data.find_all('ac:image')
+            self.assertEqual(len(images), 2)
+
+            for image in images:
+                attachment = image.find('ri:attachment')
+                self.assertIsNotNone(attachment)
+                self.assertTrue(attachment.has_attr('ri:filename'))
+                self.assertEqual(attachment['ri:filename'], 'image03.png')
+
+                page_ref = attachment.find('ri:page')
+                self.assertIsNone(page_ref)


### PR DESCRIPTION
Perform a series of corrections/improvements for users of the `singleconfluence` builder.

- do not enable special page generation for singleconfluence builder
- restore singlebuilder initialization
- autoload autosummary for singleconfluence builder
- skip pre-processing assets for singleconfluence builder
- translator: ensure proper asset document name