### PR TITLE
translator: restore standalone fallback docname for assets

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1387,6 +1387,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 if is_svg:
                     confluence_supported_svg(self.builder, node)
 
+                if not asset_docname:
+                    asset_docname = self.docname
+
                 image_key, hosting_docname, image_path = \
                     self.assets.process_image_node(
                         node, asset_docname, standalone=True)
@@ -1567,6 +1570,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             # if this file has not already be processed (injected at a later
             # stage in the sphinx process); try processing it now
             if not file_key:
+                if not asset_docname:
+                    asset_docname = self.docname
+
                 file_key, hosting_docname, _ = \
                     self.assets.process_file_node(
                         node, asset_docname, standalone=True)


### PR DESCRIPTION
When processing the fallback condition for image/file nodes (for standalone assets), a change was added \[1\] which removed passing the active document into the asset manager (so it knows the proper document to attach an asset to). The removal of these, while valid (or irrelevant) for a `singleconfluence` builder is still needed for the standard `confluence` builder; restoring.

\[1\]: 44b6cd19b60c5cb07218ad025e1ea8340a330d4a