### PR TITLE
apply lengths for svgs with only a viewbox

### DIFF
--- a/sphinxcontrib/confluencebuilder/svg.py
+++ b/sphinxcontrib/confluencebuilder/svg.py
@@ -93,11 +93,13 @@ def confluence_supported_svg(builder, node):
         svg_width = svg_root.attrib['width']
 
     # try to fallback on the viewbox attribute
+    viewbox = False
     if svg_height is None or svg_width is None:
         if 'viewBox' in svg_root.attrib:
             try:
                 _, _, svg_width, svg_height = \
                     svg_root.attrib['viewBox'].split(' ')
+                viewbox = True
             except ValueError:
                 pass
 
@@ -113,6 +115,13 @@ def confluence_supported_svg(builder, node):
     height, hu = extract_length(node.get('height'))
     scale = node.get('scale')
     width, wu = extract_length(node.get('width'))
+
+    # confluence can have difficulty rendering svgs with only a viewbox entry;
+    # if a viewbox is used, use it for the height/width if these options have
+    # not been explicitly configured on the directive
+    if viewbox and not height and not width:
+        height = svg_height
+        width = svg_width
 
     # if only one size is set, fetch (and scale) the other
     if width and not height:

--- a/tests/unit-tests/datasets/svg/index.rst
+++ b/tests/unit-tests/datasets/svg/index.rst
@@ -5,14 +5,17 @@ svgs
 
 .. image:: svg.svg
 
-.. image:: svg-viewbox.svg
-
 .. image:: svg-none.svg
 
 
 .. doctype should be injected into this document
 
 .. image:: svg-doctype.svg
+
+
+.. viewbox sizes should be added into height/width
+
+.. image:: svg-viewbox.svg
 
 
 .. applying length/scale options into the svgs

--- a/tests/unit-tests/test_svg.py
+++ b/tests/unit-tests/test_svg.py
@@ -49,14 +49,6 @@ class TestSvg(unittest.TestCase):
 
             attachment = image.find('ri:attachment')
             self.assertTrue(attachment.has_attr('ri:filename'))
-            self.assertEqual(attachment['ri:filename'], 'svg-viewbox.svg')
-            self.assertFalse(attachment.has_attr('ac:height'))
-            self.assertFalse(attachment.has_attr('ac:width'))
-
-            image = images.pop(0)
-
-            attachment = image.find('ri:attachment')
-            self.assertTrue(attachment.has_attr('ri:filename'))
             self.assertEqual(attachment['ri:filename'], 'svg-none.svg')
             self.assertFalse(attachment.has_attr('ac:height'))
             self.assertFalse(attachment.has_attr('ac:width'))
@@ -77,6 +69,23 @@ class TestSvg(unittest.TestCase):
             with open(fname, 'rb') as f:
                 svg_data = f.read()
                 self.assertTrue(svg_data.lstrip().startswith(b'<?xml'))
+
+            # ##########################################################
+            # viewbox sizes into height/width attributes
+            # ##########################################################
+
+            image = images.pop(0)
+
+            attachment = image.find('ri:attachment')
+            self.assertTrue(attachment.has_attr('ri:filename'))
+            self.assertNotEqual(attachment['ri:filename'], 'svg-viewbox.svg')
+            self.assertFalse(attachment.has_attr('ac:height'))
+            self.assertFalse(attachment.has_attr('ac:width'))
+
+            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            svg_width, svg_height = self._extract_svg_size(fname)
+            self.assertEqual(svg_height, 100)
+            self.assertEqual(svg_width, 25)
 
             # ##########################################################
             # applying length/scale options into the svgs


### PR DESCRIPTION
SVGs which only have a `viewbox` attribute may not properly render on Confluence (e.g. an SVG may visually load for a moment and the hide itself). By specifying an explicit width/height value inside SVGs provides a more consistent user experience -- adjusting SVG processing so that when a viewbox-only SVG is detected, use these values as the target width/height options to apply (which should set the attributes on the final SVG image).