### PR TITLE
use proper identifier for section number mapping

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -968,13 +968,8 @@ class ConfluenceBuilder(Builder):
                 if 'ids' in section_node:
                     target = ''.join(node.astext().split())
 
-                    # when confluence has a header that contains a link, the
-                    # automatically assigned identifier removes any underscores
-                    if node.next_node(addnodes.pending_xref):
-                        target = target.replace('_', '')
-
                     if self.add_secnumbers:
-                        anchorname = '#' + target
+                        anchorname = '#' + section_node['ids'][0]
                         if anchorname not in secnumbers:
                             anchorname = ''
 

--- a/tests/unit-tests/datasets/toctree-numbered/doc.rst
+++ b/tests/unit-tests/datasets/toctree-numbered/doc.rst
@@ -4,3 +4,13 @@ doc
 .. toctree::
 
     child
+
+
+section with spaces
+-------------------
+
+section_with_underscores
+------------------------
+
+section with a large name - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vitae volutpat ipsum, quis sodales eros. Aenean quis nunc quis leo aliquam gravida. Fusce accumsan nibh vitae enim ullamcorper iaculis. Duis eget augue dolor. Curabitur at enim elit. Nullam luctus mollis magna. Pellentesque pellentesque, leo quis suscipit finibus, diam justo convallis.
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/tests/unit-tests/datasets/use-cases/nested-ref-contents.rst
+++ b/tests/unit-tests/datasets/use-cases/nested-ref-contents.rst
@@ -8,3 +8,9 @@ nested ref contents
 
 :doc:`custom_name <nested-ref-external>`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:ref:`custom_name2 <ref1>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:ref:`custom_name3 <ref2>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/unit-tests/datasets/use-cases/nested-ref-external.rst
+++ b/tests/unit-tests/datasets/use-cases/nested-ref-external.rst
@@ -2,3 +2,12 @@
 
 nested ref external
 ===================
+
+.. _ref1:
+
+section
+=======
+
+.. _ref2:
+
+content

--- a/tests/unit-tests/test_singlepage_toctree.py
+++ b/tests/unit-tests/test_singlepage_toctree.py
@@ -88,7 +88,7 @@ class TestConfluenceSinglepageToctree(unittest.TestCase):
         with parse('index', out_dir) as data:
             tags = data.find_all()
             self.assertIsNotNone(tags)
-            self.assertEqual(len(tags), 3)
+            self.assertEqual(len(tags), 6)
 
             doc_header = tags.pop(0)
             self.assertEqual(doc_header.name, 'h2')
@@ -101,3 +101,15 @@ class TestConfluenceSinglepageToctree(unittest.TestCase):
             content = tags.pop(0)
             self.assertEqual(content.name, 'p')
             self.assertEqual(content.text, 'content')
+
+            doc_header = tags.pop(0)
+            self.assertEqual(doc_header.name, 'h2')
+            self.assertEqual(doc_header.text, '2. section with spaces')
+
+            doc_header = tags.pop(0)
+            self.assertEqual(doc_header.name, 'h2')
+            self.assertEqual(doc_header.text, '3. section_with_underscores')
+
+            doc_header = tags.pop(0)
+            self.assertEqual(doc_header.name, 'h2')
+            self.assertEqual(doc_header.text, '4. section with a large name - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vitae volutpat ipsum, quis sodales eros. Aenean quis nunc quis leo aliquam gravida. Fusce accumsan nibh vitae enim ullamcorper iaculis. Duis eget augue dolor. Curabitur at enim elit. Nullam luctus mollis magna. Pellentesque pellentesque, leo quis suscipit finibus, diam justo convallis.')

--- a/tests/unit-tests/test_sphinx_toctree.py
+++ b/tests/unit-tests/test_sphinx_toctree.py
@@ -135,9 +135,9 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
 
             docs = root_toc.findChildren('li', recursive=False)
             self.assertIsNotNone(docs)
-            self.assertEqual(len(docs), 1)
+            self.assertEqual(len(docs), 4)
 
-            group = docs[0]
+            group = docs.pop(0)
             self._verify_link(group, '1. doc')
 
             group_docs = group.find('ul', recursive=False)
@@ -147,6 +147,18 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             self.assertIsNotNone(sub_docs)
             self.assertEqual(len(sub_docs), 1)
             self._verify_link(sub_docs[0], '1.1. child')
+
+            group = docs.pop(0)
+            self._verify_link(group, '1. doc',
+                label='2. section with spaces')
+
+            group = docs.pop(0)
+            self._verify_link(group, '1. doc',
+                label='3. section_with_underscores')
+
+            group = docs.pop(0)
+            self._verify_link(group, '1. doc',
+                label='4. section with a large name - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vitae volutpat ipsum, quis sodales eros. Aenean quis nunc quis leo aliquam gravida. Fusce accumsan nibh vitae enim ullamcorper iaculis. Duis eget augue dolor. Curabitur at enim elit. Nullam luctus mollis magna. Pellentesque pellentesque, leo quis suscipit finibus, diam justo convallis.')
 
         with parse('doc', out_dir) as data:
             root_toc = data.find('ul', recursive=False)
@@ -208,9 +220,9 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
 
             docs = root_toc.findChildren('li', recursive=False)
             self.assertIsNotNone(docs)
-            self.assertEqual(len(docs), 1)
+            self.assertEqual(len(docs), 4)
 
-            group = docs[0]
+            group = docs.pop(0)
             self._verify_link(group, 'doc')
 
             group_docs = group.find('ul', recursive=False)
@@ -220,6 +232,15 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             self.assertIsNotNone(sub_docs)
             self.assertEqual(len(sub_docs), 1)
             self._verify_link(sub_docs[0], 'child')
+
+            group = docs.pop(0)
+            self._verify_link(group, 'doc', label='section with spaces')
+
+            group = docs.pop(0)
+            self._verify_link(group, 'doc', label='section_with_underscores')
+
+            group = docs.pop(0)
+            self._verify_link(group, 'doc', label='section with a large name - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vitae volutpat ipsum, quis sodales eros. Aenean quis nunc quis leo aliquam gravida. Fusce accumsan nibh vitae enim ullamcorper iaculis. Duis eget augue dolor. Curabitur at enim elit. Nullam luctus mollis magna. Pellentesque pellentesque, leo quis suscipit finibus, diam justo convallis.')
 
         with parse('doc', out_dir) as data:
             root_toc = data.find('ul', recursive=False)
@@ -246,9 +267,9 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
 
             docs = root_toc.findChildren('li', recursive=False)
             self.assertIsNotNone(docs)
-            self.assertEqual(len(docs), 1)
+            self.assertEqual(len(docs), 4)
 
-            group = docs[0]
+            group = docs.pop(0)
             self._verify_link(group, '1!Z /+4doc')
 
             group_docs = group.find('ul', recursive=False)
@@ -258,6 +279,18 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             self.assertIsNotNone(sub_docs)
             self.assertEqual(len(sub_docs), 1)
             self._verify_link(sub_docs[0], '1.1!Z /+4child')
+
+            group = docs.pop(0)
+            self._verify_link(group, '1!Z /+4doc',
+                label='2!Z /+4section with spaces')
+
+            group = docs.pop(0)
+            self._verify_link(group, '1!Z /+4doc',
+                label='3!Z /+4section_with_underscores')
+
+            group = docs.pop(0)
+            self._verify_link(group, '1!Z /+4doc',
+                label='4!Z /+4section with a large name - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vitae volutpat ipsum, quis sodales eros. Aenean quis nunc quis leo aliquam gravida. Fusce accumsan nibh vitae enim ullamcorper iaculis. Duis eget augue dolor. Curabitur at enim elit. Nullam luctus mollis magna. Pellentesque pellentesque, leo quis suscipit finibus, diam justo convallis.')
 
         with parse('doc', out_dir) as data:
             root_toc = data.find('ul', recursive=False)

--- a/tests/unit-tests/test_usecase_nested_ref.py
+++ b/tests/unit-tests/test_usecase_nested_ref.py
@@ -34,16 +34,18 @@ class TestConfluenceUseCaseNestedRef(unittest.TestCase):
             toc_link = root_toc.find('ac:link')
             self.assertIsNotNone(toc_link)
             self.assertTrue(toc_link.has_attr('ac:anchor'))
-            # note: anchor will be `customname` as confluence will strip
-            #       underscores in headers with links
-            self.assertEqual(toc_link['ac:anchor'], 'customname')
+            self.assertEqual(toc_link['ac:anchor'], 'custom_name')
 
             toc_link_body = toc_link.find('ac:link-body', recursive=False)
             self.assertIsNotNone(toc_link_body)
             self.assertEqual(toc_link_body.text, 'custom_name')
 
+            # header links
+            headers = data.find_all('h2')
+            self.assertEqual(len(headers), 3)
+
             # header link to external page
-            header = data.find('h2', recursive=False)
+            header = headers.pop(0)
             self.assertIsNotNone(header)
 
             header_link = header.find('ac:link', recursive=False)
@@ -53,3 +55,29 @@ class TestConfluenceUseCaseNestedRef(unittest.TestCase):
             header_link_body = header_link.find('ac:link-body', recursive=False)
             self.assertIsNotNone(header_link_body)
             self.assertEqual(header_link_body.text, 'custom_name')
+
+            # header link to external page's header
+            header = headers.pop(0)
+            self.assertIsNotNone(header)
+
+            header_link = header.find('ac:link', recursive=False)
+            self.assertIsNotNone(header_link)
+            self.assertTrue(header_link.has_attr('ac:anchor'))
+            self.assertEqual(header_link['ac:anchor'], 'section')
+
+            header_link_body = header_link.find('ac:link-body', recursive=False)
+            self.assertIsNotNone(header_link_body)
+            self.assertEqual(header_link_body.text, 'custom_name2')
+
+            # header link to external page's anchor
+            header = headers.pop(0)
+            self.assertIsNotNone(header)
+
+            header_link = header.find('ac:link', recursive=False)
+            self.assertIsNotNone(header_link)
+            self.assertTrue(header_link.has_attr('ac:anchor'))
+            self.assertEqual(header_link['ac:anchor'], 'ref2')
+
+            header_link_body = header_link.find('ac:link-body', recursive=False)
+            self.assertIsNotNone(header_link_body)
+            self.assertEqual(header_link_body.text, 'custom_name3')


### PR DESCRIPTION
Section numbers populated into the environment's `toc_secnumbers` dictionary is based off the section identifier value -- not the text content of a section (used for mapping to Confluence's "target"). When attempting to determine which section number value to apply for a target, use the proper identifier instead.