### PR TITLE
tox: add support for python 3.11.x series

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,12 +39,12 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 pip_pre = true
 
-[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-}interactive]
+[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-,py311-}interactive]
 commands =
     {envpython} -m sphinxcontrib.confluencebuilder {posargs}
 passenv = *
 
-[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-}prerelease]
+[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-,py311-}prerelease]
 pip_pre = true
 
 [testenv:flake8]
@@ -68,14 +68,14 @@ commands =
     tests \
     setup.py
 
-[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-}sandbox]
+[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-,py311-}sandbox]
 deps =
     -r{toxinidir}/sandbox/requirements.txt
 commands =
     {envpython} -m tests.test_sandbox {posargs}
 passenv = *
 
-[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-}validation]
+[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-,py311-}validation]
 deps = 
     {[testenv]deps}
     -r{toxinidir}/requirements_validation.txt


### PR DESCRIPTION
Python 3.11 has an alpha revision available. Adding an environment to help test this specific interpreter.