### PR TITLE
singleconfluence: support keeping toctree sections

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -17,10 +17,9 @@ Confluence generation and publishing:
     confluence_ask_password = True
     confluence_page_hierarchy = True
 
-All configurations introduced by this extension are prefixed with
-``confluence_``. This extension may take advantage of a subset of
-`Sphinx configurations`_ as well when preparing documents. View the entire list
-of configuration options below.
+All configurations introduced by this extension are listed below. This
+extension may take advantage of a subset of `Sphinx configurations`_ as well
+when preparing documents.
 
 .. only:: latex
 
@@ -331,6 +330,18 @@ Generic configuration
     .. code-block:: python
 
         confluence_use_index = True
+
+.. confval:: singleconfluence_toctree
+
+    .. versionadded:: 1.7
+
+    A boolean value to configure whether or not TOC trees will remain in place
+    when building with a ``singleconfluence`` builder. By default, this option
+    is disabled with a value of ``False``.
+
+    .. code-block:: python
+
+        singleconfluence_toctree = True
 
 Publishing configuration
 ------------------------

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -77,6 +77,8 @@ def setup(app):
     app.add_config_value('confluence_secnumber_suffix', None, False)
     # Enablement of a generated index document
     app.add_config_value('confluence_use_index', None, '')
+    # Enablement for toctrees for singleconfluence documents.
+    app.add_config_value('singleconfluence_toctree', None, 'singleconfluence')
 
     # (configuration - publishing)
     # Request for publish password to come from interactive session.

--- a/sphinxcontrib/confluencebuilder/compat.py
+++ b/sphinxcontrib/confluencebuilder/compat.py
@@ -1,12 +1,19 @@
 # -*- coding: utf-8 -*-
 """
 :copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2007-2021 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
+from __future__ import absolute_import
+from docutils import nodes
+from sphinx import addnodes
+from sphinx import version_info as sphinx_version_info
 from sphinx.locale import __
 from sphinx.util.console import bold # pylint: disable=no-name-in-module
+from sphinx.util.nodes import inline_all_toctrees as sphinx_inline_all_toctrees
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
+from typing import cast
 
 # input support with all supported python interpreters
 try:
@@ -30,3 +37,53 @@ except ImportError:
                 logger.info(__('failed'))
             else:
                 logger.info(__('done'))
+
+
+# use sphinx's inline_all_toctrees which supports the `replace` argument;
+# otherwise, use this local variant instead
+def inline_all_toctrees(builder, docnameset, docname, tree, colorfunc,
+                        traversed, replace):
+    # TODO: https://github.com/sphinx-doc/sphinx/pull/9839
+    if False and sphinx_version_info > (4, 4):
+        return sphinx_inline_all_toctrees(builder, # pylint: disable=E1123
+            docnameset, docname, tree, colorfunc, traversed, replace=replace)
+    else:
+        return _inline_all_toctrees(builder, docnameset, docname, tree,
+            colorfunc, traversed, replace)
+
+
+def _inline_all_toctrees(builder, docnameset, docname, tree, colorfunc,
+                        traversed, replace):
+    tree = cast(nodes.document, tree.deepcopy())
+    for toctreenode in list(tree.traverse(addnodes.toctree)):
+        newnodes = []
+        includefiles = map(str, toctreenode['includefiles'])
+        for includefile in includefiles:
+            if includefile not in traversed:
+                try:
+                    traversed.append(includefile)
+                    logger.info(colorfunc(includefile) + " ", nonl=True)
+                    subtree = _inline_all_toctrees(
+                        builder, docnameset, includefile,
+                        builder.env.get_doctree(includefile),
+                        colorfunc, traversed, replace)
+                    docnameset.add(includefile)
+                except Exception:
+                    logger.warn(
+                        __('toctree contains ref to nonexisting file %r'),
+                        includefile, location=docname)
+                else:
+                    sof = addnodes.start_of_file(docname=includefile)
+                    sof.children = subtree.children
+                    for sectionnode in sof.traverse(nodes.section):
+                        if 'docname' not in sectionnode:
+                            sectionnode['docname'] = includefile
+                    newnodes.append(sof)
+
+        if replace:
+            toctreenode.parent.replace(toctreenode, newnodes)
+        else:
+            for node in newnodes:
+                toctreenode.parent.append(node)
+
+    return tree

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -69,6 +69,7 @@ def apply_defaults(conf):
         'confluence_remove_title',
         'confluence_root_homepage',
         'confluence_watch',
+        'singleconfluence_toctree',
     ]
     for key in config2bool:
         if getattr(conf, key) is not None:

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -8,8 +8,8 @@
 from docutils import nodes
 from sphinx.locale import __
 from sphinx.util.console import darkgreen # pylint: disable=no-name-in-module
-from sphinx.util.nodes import inline_all_toctrees
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
+from sphinxcontrib.confluencebuilder.compat import inline_all_toctrees
 from sphinxcontrib.confluencebuilder.compat import progress_message
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 
@@ -20,10 +20,11 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         root_doc = self.config.root_doc
         tree = self.env.get_doctree(root_doc)
         tree = inline_all_toctrees(
-            self, set(), root_doc, tree, darkgreen, [root_doc])
+            self, set(), root_doc, tree, darkgreen, [root_doc],
+            replace=not self.config.singleconfluence_toctree)
         tree['docname'] = root_doc
 
-        self.env.resolve_references(tree, root_doc, self)
+        self.env.get_and_resolve_doctree(root_doc, self, doctree=tree)
         self._fix_refuris(tree)
 
         return tree


### PR DESCRIPTION
Sphinx's inlining toctree utility call will replace each toctree entry with the contents found for each document. In some cases, users may wish to keep the (resolved) toctree nodes since Confluence does not provide a customizable sidebar feature found in some HTML-based themes. With this commit, users can set `singleconfluence_toctree` to `True` to keep resolved toctree sections in a generated single documented.