### PR TITLE
cleanup command line calls

### DIFF
--- a/sphinxcontrib/confluencebuilder/__main__.py
+++ b/sphinxcontrib/confluencebuilder/__main__.py
@@ -12,6 +12,7 @@ from sphinxcontrib.confluencebuilder.cmd.report import report_main
 from sphinxcontrib.confluencebuilder.cmd.wipe import wipe_main
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 import argparse
+import os
 import sys
 
 
@@ -22,8 +23,11 @@ def main():
         description='Sphinx extension to output Atlassian Confluence content.')
 
     parser.add_argument('action', nargs='?')
+    parser.add_argument('--color', default='auto',
+        action='store_const', const='yes')
     parser.add_argument('--help', '-h', action='store_true')
-    parser.add_argument('--no-color', '-N', dest='color')
+    parser.add_argument('--no-color', '-N', dest='color',
+        action='store_const', const='no')
     parser.add_argument('--verbose', '-V', action='count', default=0)
     parser.add_argument('--version', action='version',
         version='%(prog)s ' + version)
@@ -34,14 +38,12 @@ def main():
         print(usage())
         sys.exit(0)
 
-    logger.initialize(preload=True)
-    if args.color == 'no' or (args.color == 'auto' and not color_terminal()):
+    if args.color == 'no' or (args.color == 'auto' and
+            'MSYSTEM' not in os.environ and not color_terminal()):
         nocolor()
-    # disable color (on windows) by default when using virtualenv since it
-    # appears to be causing issues
-    elif getattr(sys, 'base_prefix', sys.prefix) != sys.prefix:
-        if sys.platform == 'win32':
-            nocolor()
+
+    # pre-load logging support if sphinx is not loaded (to prevent blank lines)
+    logger.initialize(preload=True)
 
     # invoke a desired command mainline
     if args.action == 'report':
@@ -86,8 +88,9 @@ def usage():
  --danger              flag that must be set to use this action
 
 (other options)
+ --color[=WHEN]        when to colorize output: never, always or auto
  -h, --help            show this help
- --no-color            explicitly disable colorized output
+ -N, --no-color        explicitly disable colorized output
  -V, --verbose         enable verbose messages
  --version             show the version
  --work-dir            working (documentation) directory to use

--- a/sphinxcontrib/confluencebuilder/__main__.py
+++ b/sphinxcontrib/confluencebuilder/__main__.py
@@ -86,6 +86,7 @@ def usage():
 
 (wipe arguments)
  --danger              flag that must be set to use this action
+ -P, --parent          only remove pages from the configured parent page
 
 (other options)
  --color[=WHEN]        when to colorize output: never, always or auto

--- a/sphinxcontrib/confluencebuilder/cmd/build.py
+++ b/sphinxcontrib/confluencebuilder/cmd/build.py
@@ -68,6 +68,8 @@ def build_main(args_parser):
             doctrees_dir,           # output for doctree files
             builder,                # builder to execute
             confoverrides=defines,  # configuration overload
+            status=sys.stdout,      # sphinx status output
+            warning=sys.stderr,     # sphinx warning output
             freshenv=True,          # fresh environment
             verbosity=verbosity)    # verbosity
         app.build(force_all=True)

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -259,6 +259,7 @@ def report_main(args_parser):
     print('Please copy the following text for the GitHub issue:')
     print('')
     logger.note('------------[ cut here ]------------')
+    print('```')
     print('(system)')
     print(' platform:', single_line_version(platform.platform()))
     print('   python:', single_line_version(sys.version))
@@ -284,6 +285,7 @@ def report_main(args_parser):
         print('(confluence instance)')
         print(confluence_instance_info.rstrip())
 
+    print('```')
     logger.note('------------[ cut here ]------------')
 
     return rv

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -84,12 +84,15 @@ def report_main(args_parser):
         with temp_dir() as tmp_dir:
             with docutils_namespace():
                 print('fetching configuration information...')
+                builder = ConfluenceReportBuilder.name
                 app = Sphinx(
-                    work_dir,                     # document sources
-                    work_dir,                     # directory with configuration
-                    tmp_dir,                      # output for built documents
-                    tmp_dir,                      # output for doctree files
-                    ConfluenceReportBuilder.name) # builder to execute
+                    work_dir,           # document sources
+                    work_dir,           # directory with configuration
+                    tmp_dir,            # output for built documents
+                    tmp_dir,            # output for doctree files
+                    builder,            # builder to execute
+                    status=sys.stdout,  # sphinx status output
+                    warning=sys.stderr) # sphinx warning output
 
                 if app.config.confluence_publish:
                     try:

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -124,9 +124,11 @@ def report_main(args_parser):
 
     except Exception:
         sys.stdout.flush()
-        logger.error(traceback.format_exc())
+        tb_msg = traceback.format_exc()
+        logger.error(tb_msg)
         if os.path.isfile(os.path.join(work_dir, 'conf.py')):
             configuration_load_issue = 'unable to load configuration'
+            configuration_load_issue += '\n\n' + tb_msg.strip()
         else:
             configuration_load_issue = 'no documentation/missing configuration'
         rv = 1

--- a/sphinxcontrib/confluencebuilder/cmd/wipe.py
+++ b/sphinxcontrib/confluencebuilder/cmd/wipe.py
@@ -6,6 +6,7 @@
 
 from __future__ import print_function
 from sphinx.application import Sphinx
+from sphinx.locale import __
 from sphinx.util.docutils import docutils_namespace
 from sphinxcontrib.confluencebuilder.compat import input
 from sphinxcontrib.confluencebuilder.config import process_ask_configs
@@ -57,7 +58,6 @@ To use this action, the argument '--danger' must be set.
             """)
         sys.stdout.flush()
         logger.warn('!!! DANGER DANGER DANGER !!!')
-        print('')
         return 1
 
     # check configuration and prepare publisher
@@ -88,11 +88,11 @@ To use this action, the argument '--danger' must be set.
                 publisher.init(app.config)
 
     if not publisher:
-        print('(error) publishing not configured in sphinx configuration')
+        logger.error('publishing not configured in sphinx configuration')
         return 1
 
     if args.parent and not parent_name:
-        print('(error) parent option provided but no parent page is configured')
+        logger.error('parent option provided but no parent page is configured')
         return 1
 
     # reminder warning
@@ -101,7 +101,7 @@ To use this action, the argument '--danger' must be set.
     logger.warn('!!! DANGER DANGER DANGER !!!')
     print("""
 A request has been made to attempt to wipe the pages from a configured
-Confluence instance.  This action is not reversible with this tool and may
+Confluence instance. This action is not reversible with this tool and may
 require assistance from an administrator from a Confluence instance to recover
 pages. Only use this action if you know what you are doing.
         """)
@@ -163,7 +163,7 @@ pages. Only use this action if you know what you are doing.
         if not dryrun:
             logger.info('.', nonl=True)
     if not dryrun:
-        logger.info(' done\n')
+        logger.info(__('done'))
 
     return 0
 

--- a/sphinxcontrib/confluencebuilder/cmd/wipe.py
+++ b/sphinxcontrib/confluencebuilder/cmd/wipe.py
@@ -66,11 +66,13 @@ To use this action, the argument '--danger' must be set.
     with temp_dir() as tmp_dir:
         with docutils_namespace():
             app = Sphinx(
-                work_dir,     # document sources
-                work_dir,     # directory with configuration
-                tmp_dir,      # output for generated documents
-                tmp_dir,      # output for doctree files
-                'confluence') # builder to execute
+                work_dir,           # document sources
+                work_dir,           # directory with configuration
+                tmp_dir,            # output for built documents
+                tmp_dir,            # output for doctree files
+                'confluence',       # builder to execute
+                status=sys.stdout,  # sphinx status output
+                warning=sys.stderr) # sphinx warning output
 
             aggressive_search = app.config.confluence_adv_aggressive_search
             dryrun = app.config.confluence_publish_dryrun


### PR DESCRIPTION
Provide a series of changes to cleanup mainline calls:

- improve/correct color processing
- report: wrap report cut data with markdown ticks
- wipe: improve spacing/i8n/coloring output
- wipe: capture sphinx errors
- report: add traceback into report cut
- wipe: add missing parent argument