### PR TITLE
translator: relax unsupported node error

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -133,7 +133,8 @@ class ConfluenceBaseTranslator(BaseTranslator):
             handler[node_name](self, node)
             raise nodes.SkipNode
 
-        raise NotImplementedError('unknown node: ' + node_name)
+        self.warn('unknown node: ' + node_name)
+        raise nodes.SkipNode
 
     # ---------
     # structure


### PR DESCRIPTION
Instead of throwing a `NotImplementedError` exception for an unknown node, log the unhandled node type as a warning. This should provide some additional flexibility when using a Sphinx-based Confluence builder for users attempting to use third-party extensions.