### PR TITLE
improve unreconciled page handling

### DIFF
--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -172,25 +172,29 @@ class ConfluenceTimeoutError(ConfluenceError):
 
 class ConfluenceUnreconciledPageError(ConfluenceError):
     def __init__(self, page_name, page_id, url, ex):
-        super(ConfluenceUnreconciledPageError, self).__init__(
-            """---\n"""
-            """Unable to update unreconciled page: %s """ % page_name +
-            """(id: %s)\n""" % str(page_id) +
-            """\n"""
-            """Unable to update the target page due to the Confluence """
-            """instance reporting an unreconciled page. A workaround for """
-            """this is to manually browse the page using a browser which """
-            """will force Confluence to reconcile the page. A link to the """
-            """page is a follows:\n"""
-            """\n"""
-            """   %spages/viewpage.action?pageId=%s""" % (url, str(page_id)) +
-            """\n\n"""
-            """If this is observed on Confluence v6.x, v7.3.3 or higher, """
-            """please report this issue to the developers of the Confluence """
-            """builder extension.\n"""
-            """\n"""
-            """See also: https://jira.atlassian.com/browse/CONFSERVER-59196\n"""
-            """\n(details: %s""" % ex +
-            """)\n"""
-            """---\n"""
-        )
+        super(ConfluenceUnreconciledPageError, self).__init__('''
+---
+Unable to update unreconciled page: {name} (id: {id})
+
+Unable to update the target page due to the Confluence instance reporting an
+unreconciled page. This is either due to a conflict with another instance
+updating the page, Confluence having trouble updating a large page request or
+possibly an old Confluence version bug [1] (pre-v7.3.3).
+
+A possible workaround for this is to manually browse the page using a browser
+which could help force Confluence to reconcile the page. A link to the page is
+a follows:
+
+   {url}pages/viewpage.action?pageId={id}
+
+If an attempt to re-publish fails after a page refresh attempt, a user could
+also try manually deleting the page and retrying again. If the page cannot be
+removed, assistance from a Confluence administrator may be needed. See also the
+sphinx-contrib/confluencebuilder#528 [2] discussion on GitHub.
+
+[1]: https://jira.atlassian.com/browse/CONFSERVER-59196
+[2]: https://github.com/sphinx-contrib/confluencebuilder/issues/528
+
+(details: {ex})
+---
+'''.format(name=page_name, id=page_id, url=url, ex=ex))

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -800,22 +800,37 @@ class ConfluencePublisher():
         try:
             self.rest_client.put('content', page_id_explicit, updatePage)
         except ConfluenceBadApiError as ex:
-            if str(ex).find('unreconciled') != -1:
-                raise ConfluenceUnreconciledPageError(
-                    page_name, page['id'], self.server_url, ex)
 
-            # Confluence Cloud may (rarely) fail to complete a
-            # content request with an OptimisticLockException/
-            # StaleObjectStateException exception. It is suspected
-            # that this is just an instance timing/processing issue.
-            # If this is observed, wait a moment and retry the
-            # content request. If it happens again, the put request
-            # will fail as it normally would.
-            if str(ex).find('OptimisticLockException') == -1:
+            # Handle select API failures by waiting a moment and retrying the
+            # content request. If it happens again, the put request will fail as
+            # it normally would.
+            retry_errors = [
+                # Confluence Cloud may (rarely) fail to complete a content
+                # request with an OptimisticLockException/
+                # StaleObjectStateException exception. It is suspected that this
+                # is just an instance timing/processing issue.
+                'OptimisticLockException',
+
+                # Confluence may report an unreconciled error -- either from a
+                # conflict with another instance updating the same page or some
+                # select backend issues processing previous updates on a page.
+                'unreconciled',
+            ]
+
+            if not any(x in str(ex) for x in retry_errors):
                 raise
+
             logger.warn('remote page updated failed; retrying...')
-            time.sleep(1)
-            self.rest_client.put('content', page_id_explicit, updatePage)
+            time.sleep(3)
+
+            try:
+                self.rest_client.put('content', page_id_explicit, updatePage)
+            except ConfluenceBadApiError as ex:
+                if 'unreconciled' in str(ex):
+                    raise ConfluenceUnreconciledPageError(
+                        page_name, page['id'], self.server_url, ex)
+
+                raise
 
     def _dryrun(self, msg, id=None, misc=''):
         """

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -796,8 +796,9 @@ class ConfluencePublisher():
         if parent_id:
             updatePage['ancestors'] = [{'id': parent_id}]
 
+        page_id_explicit = page['id'] + '?status=current'
         try:
-            self.rest_client.put('content', page['id'], updatePage)
+            self.rest_client.put('content', page_id_explicit, updatePage)
         except ConfluenceBadApiError as ex:
             if str(ex).find('unreconciled') != -1:
                 raise ConfluenceUnreconciledPageError(
@@ -814,7 +815,7 @@ class ConfluencePublisher():
                 raise
             logger.warn('remote page updated failed; retrying...')
             time.sleep(1)
-            self.rest_client.put('content', page['id'], updatePage)
+            self.rest_client.put('content', page_id_explicit, updatePage)
 
     def _dryrun(self, msg, id=None, misc=''):
         """


### PR DESCRIPTION
### publisher: force current status on page updates

When issuing a page update via a put request, explicitly set the `status` option to `current`. While `current` should be the default value for this option, there have been reports \[1\] that explicitly settings this option can help deal with unreconciled page states.

\[1\]: https://jira.atlassian.com/browse/CONFCLOUD-72349

### publisher: retry on unreconciled page failures

In addition to retrying on a lock failure, also retry on unreconciled pages as Confluence will report "Retry in a few moments".

This commit also bumps the retry count from one second to three seconds.

### update unreconciled exception message

With reports that an unreconciled API error may occur on Confluence instances greater than v7.3.2, adjusting the exception to be more generic.

---

See also: #528
