### PR TITLE
translator-storage: add brackets for footnotes

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1138,7 +1138,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.context.append(self._end_tag(node))
             self._building_footnotes = True
 
-        label_text = label_node.astext()
+        label_text = '[' + label_node.astext() + ']'
 
         self.body.append(self._start_tag(node, 'tr', suffix=self.nl))
         self.context.append(self._end_tag(node))

--- a/tests/unit-tests/test_rst_citations.py
+++ b/tests/unit-tests/test_rst_citations.py
@@ -106,7 +106,7 @@ class TestConfluenceRstCitations(unittest.TestCase):
             self.assertEqual(ac_link['ac:anchor'], 'id1')
             link_body = ac_link.find('ac:plain-text-link-body')
             self.assertIsNotNone(link_body)
-            self.assertEqual(link_body.text, 'CIT01')
+            self.assertEqual(link_body.text, '[CIT01]')
 
             self.assertEqual(tds[1].text.strip(), 'citation 1')
 
@@ -127,6 +127,6 @@ class TestConfluenceRstCitations(unittest.TestCase):
             self.assertEqual(ac_link['ac:anchor'], 'id2')
             link_body = ac_link.find('ac:plain-text-link-body')
             self.assertIsNotNone(link_body)
-            self.assertEqual(link_body.text, 'CIT02')
+            self.assertEqual(link_body.text, '[CIT02]')
 
             self.assertEqual(tds[1].text.strip(), 'citation 2')

--- a/tests/unit-tests/test_rst_footnotes.py
+++ b/tests/unit-tests/test_rst_footnotes.py
@@ -129,7 +129,7 @@ class TestConfluenceRstFootnotes(unittest.TestCase):
             self.assertEqual(ac_link['ac:anchor'], 'id3')
             link_body = ac_link.find('ac:plain-text-link-body')
             self.assertIsNotNone(link_body)
-            self.assertEqual(link_body.text, '2')
+            self.assertEqual(link_body.text, '[2]')
 
             self.assertEqual(tds[1].text.strip(), 'footnote 2')
 
@@ -150,7 +150,7 @@ class TestConfluenceRstFootnotes(unittest.TestCase):
             self.assertEqual(ac_link['ac:anchor'], 'id1')
             link_body = ac_link.find('ac:plain-text-link-body')
             self.assertIsNotNone(link_body)
-            self.assertEqual(link_body.text, '1')
+            self.assertEqual(link_body.text, '[1]')
 
             self.assertEqual(tds[1].text.strip(), 'footnote num')
 
@@ -171,6 +171,6 @@ class TestConfluenceRstFootnotes(unittest.TestCase):
             self.assertEqual(ac_link['ac:anchor'], 'id2')
             link_body = ac_link.find('ac:plain-text-link-body')
             self.assertIsNotNone(link_body)
-            self.assertEqual(link_body.text, '3')
+            self.assertEqual(link_body.text, '[3]')
 
             self.assertEqual(tds[1].text.strip(), 'footnote note')


### PR DESCRIPTION
Styling footnote entries to have their identifiers wrapped with brackets.