### PR TITLE
support page generation notice

### DIFF
--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -14,6 +14,44 @@ Confluence Cloud with an organization account and a user account (tilde-leading)
 as well as all Confluence supported server revisions (consult
 `Atlassian Support End of Life Policy`_ for the most recent list).
 
+Internationalization
+--------------------
+
+When new translations are added into the implementation/templates, ensure these
+messages are included in the portable object template (``.pot``):
+
+.. code-block:: shell-session
+
+    $ python setup.py extract_messages
+    running extract_messages
+    ...
+    writing PO template file to sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
+
+If adding support for a new locale, invoke the following:
+
+.. code-block:: shell-session
+
+    $ python setup.py init_catalog --locale <locale>
+    running init_catalog
+    ...
+
+Ensure each supported locale has the most recent portable object (``.po``)
+state:
+
+.. code-block:: shell-session
+
+    $ python setup.py update_catalog
+    running update_catalog
+    ...
+
+Compile machine objects  (``.mo``) using the following:
+
+.. code-block:: shell-session
+
+    $ python setup.py compile_catalog
+    running compile_catalog
+    ...
+
 Release steps
 -------------
 
@@ -22,6 +60,7 @@ following steps are performed:
 
 - Ensure newly added/changed configuration options are properly reflecting a
   ``versionadded`` or equivalent hint.
+- Ensure message catalogs are up-to-date (see "Internationalization"; above).
 - Update ``CHANGES.rst``, replacing the development title with release version
   and date.
 - Ensure version values in the implementation are incremented and tagged

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include README.rst
 include LICENSE
 include CHANGES.rst
 
+recursive-include sphinxcontrib/confluencebuilder/locale *.pot *.po *.mo
 recursive-include sphinxcontrib/confluencebuilder/storage/templates *

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,10 @@
+# Babel configuration file
+
+# python sources
+[python: **.py]
+encoding = utf-8
+
+# jinja2 template files
+[jinja2: **/templates/**.html]
+encoding = utf-8
+ignore_tags = style

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -262,6 +262,18 @@ Generic configuration
 
         confluence_max_doc_depth = 2
 
+.. confval:: confluence_page_generation_notice
+
+    .. versionadded:: 1.7
+
+    A boolean value to whether or not to generate a message at the top of each
+    document that the page has been automatically generated. By default, this
+    notice is disabled with a value of ``False``.
+
+    .. code-block:: python
+
+        confluence_page_generation_notice = True
+
 .. confval:: confluence_page_hierarchy
 
     A boolean value to whether or not nest pages in a hierarchical ordered. The

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,3 +37,27 @@ disable =
     C,
     R,
     W,
+
+########################################################################
+# Translation support (Babel)
+
+[compile_catalog]
+domain = sphinxcontrib.confluencebuilder
+directory = sphinxcontrib/confluencebuilder/locale/
+
+[extract_messages]
+keywords = L C
+mapping_file = babel.cfg
+no_default_keywords = True
+omit_header = True
+output_file = sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
+
+[init_catalog]
+domain = sphinxcontrib.confluencebuilder
+input_file = sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
+output_dir = sphinxcontrib/confluencebuilder/locale/
+
+[update_catalog]
+domain = sphinxcontrib.confluencebuilder
+input_file = sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
+output_dir = sphinxcontrib/confluencebuilder/locale/

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,11 @@ from setuptools import find_packages
 from setuptools import setup
 import os
 
+try:
+    from babel.messages import frontend as babel
+except ImportError:
+    babel = None
+
 with open('README.rst', 'r') as readme_rst:
     long_desc = readme_rst.read()
 
@@ -34,6 +39,18 @@ requires = [
     'requests>=2.14.0',
     'sphinx>=1.8',
 ]
+
+cmdclass={
+    'clean': ExtendedClean,
+}
+
+if babel:
+    cmdclass.update({
+        'compile_catalog': babel.compile_catalog,
+        'extract_messages': babel.extract_messages,
+        'init_catalog': babel.init_catalog,
+        'update_catalog': babel.update_catalog,
+    })
 
 setup(
     name='sphinxcontrib-confluencebuilder',
@@ -73,9 +90,7 @@ setup(
     install_requires=requires,
     namespace_packages=['sphinxcontrib'],
     test_suite='tests',
-    cmdclass={
-        'clean': ExtendedClean,
-    },
+    cmdclass=cmdclass,
     entry_points={
         'console_scripts': [
             'sphinx-build-confluence = sphinxcontrib.confluencebuilder.__main__:main',

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -4,6 +4,7 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
+from os import path
 from sphinx.util import docutils
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.config import handle_config_inited
@@ -11,6 +12,7 @@ from sphinxcontrib.confluencebuilder.directives import ConfluenceExpandDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceMetadataDirective
 from sphinxcontrib.confluencebuilder.directives import JiraDirective
 from sphinxcontrib.confluencebuilder.directives import JiraIssueDirective
+from sphinxcontrib.confluencebuilder.locale import MESSAGE_CATALOG_NAME
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.nodes import jira
@@ -40,6 +42,11 @@ def setup(app):
     app.add_builder(ConfluenceBuilder)
     app.add_builder(ConfluenceReportBuilder)
     app.add_builder(SingleConfluenceBuilder)
+
+    # register this extension's locale
+    package_dir = path.abspath(path.dirname(__file__))
+    locale_dir = path.join(package_dir, 'locale')
+    app.add_message_catalog(MESSAGE_CATALOG_NAME, locale_dir)
 
     # ##########################################################################
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -77,6 +77,8 @@ def setup(app):
     app.add_config_value('confluence_include_search', None, '')
     # Enablement of the maximum document depth (before inlining).
     app.add_config_value('confluence_max_doc_depth', None, 'env')
+    # Enablement of a "page generated" notice.
+    app.add_config_value('confluence_page_generation_notice', None, 'env')
     # Enablement of publishing pages into a hierarchy from a root toctree.
     app.add_config_value('confluence_page_hierarchy', None, False)
     # Show previous/next buttons (bottom, top, both, None).

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -15,7 +15,7 @@ from os import path
 from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.errors import ExtensionError
-from sphinx.locale import __
+from sphinx.locale import _ as SL
 from sphinx.util import status_iterator
 from sphinx.util.osutil import ensuredir
 from sphinxcontrib.confluencebuilder.assets import ConfluenceAssetManager
@@ -313,10 +313,10 @@ class ConfluenceBuilder(Builder):
         # register titles for special documents (if needed); if a title is not
         # already set from a placeholder document, configure a default title
         if self.use_index and not self.state.title('genindex'):
-            self.state.registerTitle('genindex', __('Index'), self.config)
+            self.state.registerTitle('genindex', SL('Index'), self.config)
 
         if self.use_search and not self.state.title('search'):
-            self.state.registerTitle('search', __('Search'), self.config)
+            self.state.registerTitle('search', SL('Search'), self.config)
 
         if self.domain_indices:
             for indexname, indexdata in self.domain_indices.items():
@@ -741,7 +741,7 @@ class ConfluenceBuilder(Builder):
         navnode = ConfluenceNavigationNode()
 
         if docname in self.nav_prev:
-            prev_label = '← ' + __('Previous')
+            prev_label = '← ' + SL('Previous')
             reference = nodes.reference(prev_label, prev_label, internal=True,
                 refuri=self.nav_prev[docname])
             reference._navnode = True
@@ -750,7 +750,7 @@ class ConfluenceBuilder(Builder):
             navnode.append(reference)
 
         if docname in self.nav_next:
-            next_label = __('Next') + ' →'
+            next_label = SL('Next') + ' →'
             reference = nodes.reference(next_label, next_label, internal=True,
                 refuri=self.nav_next[docname])
             reference._navnode = True

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -28,6 +28,7 @@ from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 from sphinxcontrib.confluencebuilder.nodes import confluence_footer
 from sphinxcontrib.confluencebuilder.nodes import confluence_header
 from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
+from sphinxcontrib.confluencebuilder.nodes import confluence_page_generation_notice
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from sphinxcontrib.confluencebuilder.storage.index import generate_storage_format_domainindex
@@ -918,6 +919,12 @@ class ConfluenceBuilder(Builder):
         footer_node = confluence_footer()
 
         prev_next_loc = self.config.confluence_prev_next_buttons_location
+
+        # add page generation notice
+        if self.config.confluence_page_generation_notice:
+            pgn_node = confluence_page_generation_notice()
+            header_node.append(pgn_node)
+            add_header_node = True
 
         # add header next/previous
         if prev_next_loc in ('top', 'both'):

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -116,6 +116,9 @@ class ConfluenceBuilder(Builder):
         self.config.sphinx_verbosity = self._verbose
         self.publisher.init(self.config)
 
+        self.create_template_bridge()
+        self.templates.init(self)
+
         old_url = self.config.confluence_server_url
         new_url = ConfluenceUtil.normalizeBaseUrl(old_url)
         if old_url != new_url:

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -330,6 +330,12 @@ If planning to use a depth of zero, it is recommended to use the
 
     # ##################################################################
 
+    # confluence_page_generation_notice
+    validator.conf('confluence_page_generation_notice') \
+             .bool()
+
+    # ##################################################################
+
     # confluence_prev_next_buttons_location
     try:
         validator.conf('confluence_prev_next_buttons_location') \

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -61,6 +61,7 @@ def apply_defaults(conf):
         'confluence_disable_ssl_validation',
         'confluence_ignore_titlefix_on_index',
         'confluence_master_homepage',
+        'confluence_page_generation_notice',
         'confluence_page_hierarchy',
         'confluence_publish_dryrun',
         'confluence_publish_onlynew',

--- a/sphinxcontrib/confluencebuilder/locale/__init__.py
+++ b/sphinxcontrib/confluencebuilder/locale/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinx.locale import get_translation
+
+# name of this extension's gettext catalog
+MESSAGE_CATALOG_NAME = 'sphinxcontrib.confluencebuilder'
+
+# translator for messages in documentation
+L = get_translation(MESSAGE_CATALOG_NAME)
+
+# translator for console messages
+C = get_translation(MESSAGE_CATALOG_NAME, 'console')

--- a/sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
+++ b/sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
@@ -1,0 +1,15 @@
+#: sphinxcontrib/confluencebuilder/singlebuilder.py:80
+msgid "assembling single confluence document"
+msgstr ""
+
+#: sphinxcontrib/confluencebuilder/singlebuilder.py:109
+msgid "writing single confluence document"
+msgstr ""
+
+#: sphinxcontrib/confluencebuilder/storage/templates/domainindex.html:11
+#: sphinxcontrib/confluencebuilder/storage/templates/genindex.html:37
+#: sphinxcontrib/confluencebuilder/storage/templates/search.html:10
+#: sphinxcontrib/confluencebuilder/storage/translator.py:1917
+msgid "This page has been automatically generated."
+msgstr ""
+

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -45,6 +45,16 @@ class confluence_metadata(nodes.Element):
     """
 
 
+class confluence_page_generation_notice(nodes.TextElement):
+    """
+    confluence page generation notice node
+
+    A Confluence builder defined page generation notice node, used to create a
+    helpful message for users to indicate that the document's content has been
+    generated.
+    """
+
+
 class jira(nodes.Element, nodes.Structural):
     """
     jira (query) node

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -7,32 +7,32 @@
 from docutils import nodes
 
 
-class ConfluenceNavigationNode(nodes.General, nodes.Element):
-
-    """
-    confluence navigational node
-
-    A Confluence builder defined navigational node provides information on how
-    to manipulate documents to add navigational enhancements (e.g. next,
-    previous, etc.) at the top or bottom of pages (based on user configuration).
-
-    Attributes:
-        bottom: show navigation information at the bottom of a document
-        top: show navigation information at the top of a document
-    """
-    def __init__(self):
-        nodes.Element.__init__(self)
-
-        self.bottom = False
-        self.top = False
-
-
 class confluence_expand(nodes.Element):
     """
     confluence expand node
 
     A Confluence builder defined expand node serves as a hint to wrap content
     using Confluence's expand macro.
+    """
+
+
+class confluence_footer(nodes.General, nodes.Element):
+    """
+    confluence footer node
+
+    A Confluence builder defined footer node provides additional generates
+    nodes such as navigational nodes (e.g. next, previous, etc.) for the bottom
+    of a document.
+    """
+
+
+class confluence_header(nodes.General, nodes.Element):
+    """
+    confluence header node
+
+    A Confluence builder defined header node provides additional generates
+    nodes such as navigational nodes (e.g. next, previous, etc.) for the top of
+    a document.
     """
 
 

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -6,11 +6,11 @@
 """
 
 from docutils import nodes
-from sphinx.locale import __
 from sphinx.util.console import darkgreen # pylint: disable=no-name-in-module
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.compat import inline_all_toctrees
 from sphinxcontrib.confluencebuilder.compat import progress_message
+from sphinxcontrib.confluencebuilder.locale import C
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 
 
@@ -77,7 +77,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
             logger.error('singleconfluence requires title on root_doc')
             return
 
-        with progress_message(__('assembling single confluence document')):
+        with progress_message(C('assembling single confluence document')):
             # assemble toc section/figure numbers
             #
             # Both the environment's `toc_secnumbers` and `toc_fignumbers`
@@ -106,7 +106,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
             self._prepare_doctree_writing(self.config.root_doc, doctree)
             self.assets.processDocument(doctree, self.config.root_doc)
 
-        with progress_message(__('writing single confluence document')):
+        with progress_message(C('writing single confluence document')):
             self.write_doc_serialized(self.config.root_doc, doctree)
             self.write_doc(self.config.root_doc, doctree)
 

--- a/sphinxcontrib/confluencebuilder/storage/index.py
+++ b/sphinxcontrib/confluencebuilder/storage/index.py
@@ -5,6 +5,7 @@
 """
 
 from sphinx.environment.adapters.indexentries import IndexEntries
+from sphinxcontrib.confluencebuilder.locale import L as sccb_translation
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from sphinxcontrib.confluencebuilder.storage import intern_uri_anchor_value
 import os
@@ -50,6 +51,7 @@ def generate_storage_format_domainindex(builder, docname, f):
 
     # process the template with the generated index
     ctx = {
+        'L': sccb_translation,
         'index': content,
     }
     output = builder.templates.render_string(template_data.decode('utf-8'), ctx)
@@ -91,6 +93,7 @@ def generate_storage_format_genindex(builder, docname, f):
 
     # process the template with the generated index
     ctx = {
+        'L': sccb_translation,
         'index': genindex,
     }
     output = builder.templates.render_string(template_data.decode('utf-8'), ctx)

--- a/sphinxcontrib/confluencebuilder/storage/index.py
+++ b/sphinxcontrib/confluencebuilder/storage/index.py
@@ -4,7 +4,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from jinja2 import Template
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from sphinxcontrib.confluencebuilder.storage import intern_uri_anchor_value
@@ -50,8 +49,10 @@ def generate_storage_format_domainindex(builder, docname, f):
     template_data = pkgutil.get_data(__name__, domainindex_template)
 
     # process the template with the generated index
-    t = Template(template_data.decode('utf-8'))
-    output = t.render(index=content)
+    ctx = {
+        'index': content,
+    }
+    output = builder.templates.render_string(template_data.decode('utf-8'), ctx)
     f.write(output)
 
 
@@ -89,8 +90,10 @@ def generate_storage_format_genindex(builder, docname, f):
     template_data = pkgutil.get_data(__name__, genindex_template)
 
     # process the template with the generated index
-    t = Template(template_data.decode('utf-8'))
-    output = t.render(index=genindex)
+    ctx = {
+        'index': genindex,
+    }
+    output = builder.templates.render_string(template_data.decode('utf-8'), ctx)
     f.write(output)
 
 

--- a/sphinxcontrib/confluencebuilder/storage/index.py
+++ b/sphinxcontrib/confluencebuilder/storage/index.py
@@ -53,6 +53,7 @@ def generate_storage_format_domainindex(builder, docname, f):
     ctx = {
         'L': sccb_translation,
         'index': content,
+        'pagegen_notice': builder.config.confluence_page_generation_notice,
     }
     output = builder.templates.render_string(template_data.decode('utf-8'), ctx)
     f.write(output)
@@ -95,6 +96,7 @@ def generate_storage_format_genindex(builder, docname, f):
     ctx = {
         'L': sccb_translation,
         'index': genindex,
+        'pagegen_notice': builder.config.confluence_page_generation_notice,
     }
     output = builder.templates.render_string(template_data.decode('utf-8'), ctx)
     f.write(output)

--- a/sphinxcontrib/confluencebuilder/storage/index.py
+++ b/sphinxcontrib/confluencebuilder/storage/index.py
@@ -7,9 +7,9 @@
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from sphinxcontrib.confluencebuilder.storage import intern_uri_anchor_value
+import os
 import pkgutil
 import posixpath
-import os
 
 
 def generate_storage_format_domainindex(builder, docname, f):

--- a/sphinxcontrib/confluencebuilder/storage/search.py
+++ b/sphinxcontrib/confluencebuilder/storage/search.py
@@ -4,7 +4,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from jinja2 import Template
 import pkgutil
 import os
 
@@ -30,6 +29,8 @@ def generate_storage_format_search(builder, docname, f):
     template_data = pkgutil.get_data(__name__, search_template)
 
     # process the template with the generated index
-    t = Template(template_data.decode('utf-8'))
-    output = t.render(space=space_name)
+    ctx = {
+        'space': space_name,
+    }
+    output = builder.templates.render_string(template_data.decode('utf-8'), ctx)
     f.write(output)

--- a/sphinxcontrib/confluencebuilder/storage/search.py
+++ b/sphinxcontrib/confluencebuilder/storage/search.py
@@ -32,6 +32,7 @@ def generate_storage_format_search(builder, docname, f):
     # process the template with the generated index
     ctx = {
         'L': sccb_translation,
+        'pagegen_notice': builder.config.confluence_page_generation_notice,
         'space': space_name,
     }
     output = builder.templates.render_string(template_data.decode('utf-8'), ctx)

--- a/sphinxcontrib/confluencebuilder/storage/search.py
+++ b/sphinxcontrib/confluencebuilder/storage/search.py
@@ -4,8 +4,8 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-import pkgutil
 import os
+import pkgutil
 
 
 def generate_storage_format_search(builder, docname, f):

--- a/sphinxcontrib/confluencebuilder/storage/search.py
+++ b/sphinxcontrib/confluencebuilder/storage/search.py
@@ -4,6 +4,7 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
+from sphinxcontrib.confluencebuilder.locale import L as sccb_translation
 import os
 import pkgutil
 
@@ -30,6 +31,7 @@ def generate_storage_format_search(builder, docname, f):
 
     # process the template with the generated index
     ctx = {
+        'L': sccb_translation,
         'space': space_name,
     }
     output = builder.templates.render_string(template_data.decode('utf-8'), ctx)

--- a/sphinxcontrib/confluencebuilder/storage/templates/domainindex.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/domainindex.html
@@ -6,7 +6,16 @@ Template for a storage-format domainindex document.
 :license: BSD-2-Clause (LICENSE)
 #}
 
-<hr />
+{%- if pagegen_notice -%}
+    <div style="color: #707070; font-size: 12px;">
+        {{ L('This page has been automatically generated.') }}
+    </div>
+
+    <hr style="clear: both; padding-top: 10px; margin-bottom: 30px" />
+{%- else -%}
+    <hr />
+{%- endif %}
+
 <div style="text-align: center">
     {% for (key, _) in index -%}
     <ac:link ac:anchor="{{ key|upper }}">

--- a/sphinxcontrib/confluencebuilder/storage/templates/genindex.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/genindex.html
@@ -32,7 +32,16 @@ Template for a storage-format genindex document.
     {%- endif %}
 {% endmacro %}
 
-<hr />
+{%- if pagegen_notice -%}
+    <div style="color: #707070; font-size: 12px;">
+        {{ L('This page has been automatically generated.') }}
+    </div>
+
+    <hr style="clear: both; padding-top: 10px; margin-bottom: 30px" />
+{%- else -%}
+    <hr />
+{%- endif %}
+
 <div style="text-align: center">
     {% for key, _ in index -%}
     <ac:link ac:anchor="{{ key }}">

--- a/sphinxcontrib/confluencebuilder/storage/templates/search.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/search.html
@@ -5,6 +5,14 @@ Template for a storage-format search document.
 :license: BSD-2-Clause (LICENSE)
 #}
 
+{%- if pagegen_notice -%}
+    <div style="color: #707070; font-size: 12px;">
+        {{ L('This page has been automatically generated.') }}
+    </div>
+
+    <hr style="clear: both; padding-top: 10px; margin-bottom: 30px" />
+{%- endif %}
+
 <ac:structured-macro ac:name="livesearch">
     <ac:parameter ac:name="additional">page excerpt</ac:parameter>
     <ac:parameter ac:name="size">large</ac:parameter>

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1868,21 +1868,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     # sphinx -- extension -- confluence builder
     # -----------------------------------------
 
-    def visit_ConfluenceNavigationNode(self, node):
-        if node.bottom:
-            self.body.append(self._start_tag(
-                node, 'hr', suffix=self.nl, empty=True,
-                **{'style': 'padding-bottom: 10px; margin-top: 30px'}))
-
-    def depart_ConfluenceNavigationNode(self, node):
-        if node.top:
-            self.body.append(self._start_tag(
-                node, 'hr', suffix=self.nl, empty=True,
-                **{'style':
-                    'clear: both; padding-top: 10px; margin-bottom: 30px'}))
-        else:
-            self.body.append('<div style="clear: both"> </div>\n')
-
     def visit_confluence_expand(self, node):
         if not self.can_expand:
             raise nodes.SkipNode
@@ -1897,6 +1882,23 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
     def depart_confluence_expand(self, node):
         self.body.append(self.context.pop()) # macro
+
+    def visit_confluence_footer(self, node):
+        self.body.append(self._start_tag(
+            node, 'hr', suffix=self.nl, empty=True,
+            **{'style': 'padding-bottom: 10px; margin-top: 30px'}))
+
+    def depart_confluence_footer(self, node):
+        self.body.append('<div style="clear: both"> </div>\n')
+
+    def visit_confluence_header(self, node):
+        pass
+
+    def depart_confluence_header(self, node):
+        self.body.append(self._start_tag(
+            node, 'hr', suffix=self.nl, empty=True,
+            **{'style':
+                'clear: both; padding-top: 10px; margin-bottom: 30px'}))
 
     # ------------------------------------------
     # confluence-builder -- enhancements -- jira

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 from docutils import nodes
 from os import path
 from sphinx import addnodes
-from sphinx.locale import _
+from sphinx.locale import _ as SL
 from sphinx.locale import admonitionlabels
 from sphinx.util.images import get_image_size
 from sphinx.util.images import guess_mimetype
@@ -771,7 +771,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._build_ac_param(node, '', node['ids'][0]))
             self.body.append(self._end_ac_macro(node))
 
-        self._visit_admonition(node, 'info', title=_('Todo'))
+        self._visit_admonition(node, 'info', title=SL('Todo'))
 
     def _visit_warning(self, node):
         self._visit_admonition(node, 'warning')


### PR DESCRIPTION
The following pull request brings support for a new option `confluence_page_generation_notice` which allows a user to add a "this page has been generated" message at the top of each document.

In order to make this feature work, adjustments/improvements have been made to this extension to improve additional languages and future support for manipulating document's header/footer content.

### navigational node refactoring to header/footer nodes

Adjusting the original navigation node implementation to use a more generic Confluence header/footer nodes. This allows this extension to easily inject more than just next/previous page content at the start of pages, specifically in this case, adding a page generation notice. This is also being done for future considerations towards adding a "show/edit source" links (see #339).

### improved internationalization support

The majority of messages used in this extension already have translation support through the Sphinx's define locale catalogs. The exceptions were two console messages in the `singleconfluence` builder. This new pull request introduces a new message "This page has been automatically generated" which non-English users may wish to override. To better handling dealing with this, this extension now properly registered extension specific messages in its own catalog, and provides flexibility for future translations to be added. Unfortunately, at this time, no translations are available (as this contribution was performed from an English-only user).