### PR TITLE
rest: cleanup session on destruction

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -52,6 +52,9 @@ class Rest:
         self.session = self._setup_session(config)
         self.verbosity = config.sphinx_verbosity
 
+    def __del__(self):
+        self.session.close()
+
     def _setup_session(self, config):
         session = requests.Session()
         session.headers.update({


### PR DESCRIPTION
Explicitly cleans up the ``Rest`` class's session on deletion. This prevents warnings such as "ResourceWarning: unclosed SSLSocket" when the session is cleaned up automatically.