### PR TITLE
add a publishing pre-check for self-referenced ancestor request

### DIFF
--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -125,6 +125,30 @@ class ConfluenceProxyPermissionError(ConfluenceError):
         )
 
 
+class ConfluencePublishCheckError(ConfluenceError):
+    pass
+
+
+class ConfluencePublishSelfAncestorError(ConfluencePublishCheckError):
+    def __init__(self, page_name):
+        super(ConfluencePublishSelfAncestorError, self).__init__('''
+---
+Ancestor publish check failed for: {name}
+
+A request has been made to publish a page as a child of itself. This is most
+likely due to a configuration of `confluence_parent_page` with the same value of
+the title page for the documentation's `root_doc`. If this is the case and the
+configuration uses `confluence_page_hierarchy`, there may be no need to set the
+`confluence_parent_page` option for this documentation's configuration. However,
+if `confluence_page_hierarchy` is not set, users will most likely want to use
+the `confluence_publish_root` option instead.
+
+If the above does not appear to be related to the current use case, please
+inform the maintainers of this extension.
+---
+'''.format(name=page_name))
+
+
 class ConfluenceSeraphAuthenticationFailedUrlError(ConfluenceError):
     def __init__(self):
         super(ConfluenceSeraphAuthenticationFailedUrlError, self).__init__(

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -14,6 +14,7 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadSpaceError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceMissingPageIdError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluencePermissionError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluencePublishSelfAncestorError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceUnreconciledPageError
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.rest import Rest
@@ -795,6 +796,9 @@ class ConfluencePublisher():
 
         if parent_id:
             updatePage['ancestors'] = [{'id': parent_id}]
+
+            if page['id'] == parent_id:
+                raise ConfluencePublishSelfAncestorError(page_name)
 
         page_id_explicit = page['id'] + '?status=current'
         try:


### PR DESCRIPTION
Adding a check to help detect if a request has been made to publish a page as a child of itself. This issue should only ever happen if a configuration sets `confluence_parent_page` with the same value of the title page for the documentation's `root_doc`. On Confluence Cloud, a publish attempt for this case provides a descriptive message "Cannot add an existing ancestor as a child!"; although on Confluence self-hosted solutions, it can report a non-descriptive 500 error.

Adding this message should provide a more helpful description of the issue, and also avoid invoking an invalid request to a Confluence instance.

See also: #517