### PR TITLE
test maintenance (2021-11-16)

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -173,10 +173,11 @@ def prepare_sphinx(src_dir, config=None, out_dir=None, extra_config=None,
         builder (optional): the builder to use
         relax (optional): do not generate warnings as errors
     """
-    # Enable coloring of warning and other messages.  Note that this can
+
+    # Enable coloring of warning and other messages. Note that this can
     # cause sys.stderr to be mocked which is why we pass the new value
     # explicitly on the call to Sphinx() below.
-    if not color_terminal():
+    if 'MSYSTEM' not in os.environ and not color_terminal():
         nocolor()
 
     conf = dict(config) if config else {}

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -11,6 +11,7 @@ from tests.lib import enable_sphinx_info
 from tests.lib import prepare_dirs
 from tests.lib import prepare_sphinx
 import argparse
+import io
 import os
 import sys
 
@@ -50,7 +51,7 @@ def process_raw_upload(target_sandbox):
                 'labels': [],
             }
 
-            with open(raw_file, 'r') as f:
+            with io.open(raw_file, 'r', encoding='utf-8') as f:
                 data['content'] = f.read()
 
             print('[sandbox] publishing page...')


### PR DESCRIPTION
### tests: read as utf-8 for raw requests

When reading a raw file for a sandbox "raw" request, do so using the `io` module with an explicit `utf-8` encoding. This should prevent any Unicode error messages when testing with non-ASCII characters in some environments.

### tests: skip coloring terminal for mingw environments

Explicitly disables attempts to colorize the terminal for MinGW environments, as the nature of this environment will almost always result in detection that the output streams should be be colored (even though they can support it).