### PR TITLE
support source link option

### DIFF
--- a/doc/_themes/sphinx13b/static/sphinx13b.css
+++ b/doc/_themes/sphinx13b/static/sphinx13b.css
@@ -407,6 +407,10 @@ div.viewcode-block:target {
     table-layout: fixed;
 }
 
+.spacedtable td {
+    padding: 1em 8px 1em 5px !important;
+}
+
 .download-pypi {
     float: right;
     line-height: 4.1em;

--- a/doc/_themes/sphinx13b/theme.conf
+++ b/doc/_themes/sphinx13b/theme.conf
@@ -1,4 +1,4 @@
 [theme]
 inherit = basic
-stylesheet = sphinx13b.css?20211106
+stylesheet = sphinx13b.css?2021116
 pygments_style = trac

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -649,6 +649,116 @@ Publishing configuration
 
     See also |confluence_purge|_.
 
+.. confval:: confluence_sourcelink
+
+    .. versionadded:: 1.7
+
+    Provides options to include a link to the documentation's sources at the top
+    of each page. This can either be a generic URL or customized to link to
+    individual documents in a repository.
+
+    An example of a simple link is as follows:
+
+    .. code-block:: python
+
+        confluence_sourcelink = {
+            'url': 'https//www.example.com/',
+        }
+
+    Templates for popular hosting services are available. Instead of defining
+    a ``url`` option, the ``type`` option can instead be set to one of the
+    following types:
+
+    - ``bitbucket``
+    - ``github``
+    - ``gitlab``
+
+    Options to set for these types are as follows:
+
+    .. rst-class:: spacedtable
+
+    +-----------------+-------------------------------------------------------+
+    | Option          | Description                                           |
+    +=================+=======================================================+
+    | | ``owner``     | The owner (group or user) of a project.               |
+    | | *(required)*  |                                                       |
+    +-----------------+-------------------------------------------------------+
+    | | ``repo``      | The name of the repository.                           |
+    | | *(required)*  |                                                       |
+    +-----------------+-------------------------------------------------------+
+    | ``container``   | The folder inside the repository which is holding the |
+    |                 | documentation. This will vary per project, for        |
+    |                 | example, this may be ``Documentation/`` or ``doc/``.  |
+    |                 | If the documentation resides in the root of the       |
+    |                 | repository, this option can be omitted or set to an   |
+    |                 | empty string.                                         |
+    +-----------------+-------------------------------------------------------+
+    | | ``version``   | The version of the sources to list. This is typically |
+    | | *(required)*  | set to either a branch (e.g. ``main``) or tag value.  |
+    +-----------------+-------------------------------------------------------+
+    | ``view``        | The view mode to configure. By default, this value is |
+    |                 | set to ``blob`` for GitHub/GitLab and ``view`` for    |
+    |                 | Bitbucket.                                            |
+    |                 |                                                       |
+    |                 | GitHub/GitLab users may wish to change this to        |
+    |                 | ``edit`` to create a link directly to the editing     |
+    |                 | view for a specific document.                         |
+    +-----------------+-------------------------------------------------------+
+    | ``host``        | The hostname value to override.                       |
+    |                 |                                                       |
+    |                 | This option is useful for instances where a custom    |
+    |                 | domain may be configured for an organization.         |
+    +-----------------+-------------------------------------------------------+
+    | ``protocol``    | The protocol value to override (defaults to           |
+    |                 | ``https``).                                           |
+    +-----------------+-------------------------------------------------------+
+
+    For example, a project hosted on GitHub can use the following:
+
+    .. code-block:: python
+
+        confluence_sourcelink = {
+            'type': 'github',
+            'owner': 'sphinx-contrib',
+            'repo': 'confluencebuilder',
+            'container': 'doc/',
+            'version': 'master',
+            'view': 'edit',
+        }
+
+    For unique environments, the source URL can be customized through the
+    ``url`` option. This option is treated as a format string which can be
+    populated based on the configuration and individual documents being
+    processed. An example is as follows:
+
+    .. code-block:: python
+
+        confluence_sourcelink = {
+            'url': 'https://git.example.com/mydocs/{page}{suffix}',
+        }
+
+    This configures a base URL, where ``page`` and ``suffix`` will be generated
+    automatically. Any option provided in the ``confluence_sourcelink``
+    dictionary will be forwarded to the format option. For example:
+
+    .. code-block:: python
+
+        confluence_sourcelink = {
+            'base': 'https://git.example.com/mydocs',
+            'url': '{base}/{version}/{page}{suffix}',
+            'version': 'main',
+        }
+
+    The ``text`` option can be used to override the name of the link observed
+    at the top of the page:
+
+    .. code-block:: python
+
+        confluence_sourcelink = {
+            ...
+            'text': 'Edit Source',
+        }
+
 .. |confluence_title_overrides| replace:: ``confluence_title_overrides``
 .. _confluence_title_overrides:
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -85,6 +85,8 @@ def setup(app):
     app.add_config_value('confluence_prev_next_buttons_location', None, 'env')
     # Suffix to put after section numbers, before section name
     app.add_config_value('confluence_secnumber_suffix', None, 'env')
+    # Enablement of a "Edit/Show Source" reference on each document
+    app.add_config_value('confluence_sourcelink', None, 'env')
     # Enablement of a generated index document
     app.add_config_value('confluence_use_index', None, '')
     # Enablement for toctrees for singleconfluence documents.

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -494,6 +494,69 @@ following:
 
     # ##################################################################
 
+    # confluence_sourcelink
+    validator.conf('confluence_sourcelink') \
+             .dict_str_str()
+
+    if config.confluence_sourcelink:
+        sourcelink = config.confluence_sourcelink
+
+        # check if a supported template type is provided
+        supported_types = [
+            'bitbucket',
+            'github',
+            'gitlab',
+        ]
+        if 'type' in sourcelink:
+            if sourcelink['type'] not in supported_types:
+                raise ConfluenceConfigurationError('''\
+unsupported type provided in confluence_sourcelink
+
+The following types are supported:
+
+ - {}
+'''.format('\n - '.join(supported_types)))
+
+            # ensure requires options are set
+            required = [
+                'owner',
+                'repo',
+                'version',
+            ]
+            if not all(k in sourcelink for k in required):
+                raise ConfluenceConfigurationError('''\
+required option missing in confluence_sourcelink
+
+The following options are required for the provided template type:
+
+ - {}
+'''.format('\n - '.join(required)))
+
+        # if not using a template type, ensure url is set
+        elif 'url' not in sourcelink or not sourcelink['url']:
+            raise ConfluenceConfigurationError('''\
+url option is not set in confluence_sourcelink
+
+If a template type is not being configured for a source link,
+the `url` field must be configured.
+''')
+
+        reserved = [
+            'page',
+            'suffix',
+        ]
+        if any(k in sourcelink for k in reserved):
+            raise ConfluenceConfigurationError('''\
+reserved option set in confluence_sourcelink
+
+The following options are reserved with confluence_sourcelink
+and cannot be set:
+
+ - {}
+'''.format('\n - '.join(reserved)))
+
+    # ##################################################################
+
     # confluence_space_key
     validator.conf('confluence_space_key') \
              .string()

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -46,6 +46,9 @@ def apply_defaults(conf):
     if conf.confluence_secnumber_suffix is None:
         conf.confluence_secnumber_suffix = '. '
 
+    if conf.confluence_sourcelink is None:
+        conf.confluence_sourcelink = {}
+
     config2bool = [
         'confluence_add_secnumbers',
         'confluence_adv_aggressive_search',

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -55,6 +55,27 @@ class confluence_page_generation_notice(nodes.TextElement):
     """
 
 
+class confluence_source_link(nodes.Element, nodes.Structural):
+    """
+    confluence source link node
+
+    Provides a source link node to hint at the creation of a reference which
+    points to a generation document's original source document (or source
+    location).
+
+    Args:
+        rawsource: raw text from which this element was constructed
+        *children: list of child nodes
+        **attributes: dictionary of attribute to apply to the element
+
+    Attributes:
+        params: dictionary of parameters to configure the node
+    """
+    def __init__(self, rawsource='', *children, **attributes):
+        nodes.Element.__init__(self, rawsource, *children, **attributes)
+        self.params = {}
+
+
 class jira(nodes.Element, nodes.Structural):
     """
     jira (query) node

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1925,6 +1925,45 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     def depart_confluence_page_generation_notice(self, node):
         self.body.append(self.context.pop()) # div
 
+    def visit_confluence_source_link(self, node):
+        uri = node.params['url']
+
+        docname = self.docname
+        suffix = self.builder.env.doc2path(docname, base=None)[len(docname):]
+        uri = uri.format(page=docname, suffix=suffix, **node.params)
+
+        source_text = node.params.get('text', L('Edit Source'))
+        uri = self.encode(uri)
+
+        div_attribs = {
+            'style': 'float: right; padding-bottom: 4px',
+        }
+
+        span_attribs = {
+            'class': 'aui-icon aui-icon-small '
+                     'aui-iconfont-edit-small aui-iconfont-edit-filled',
+        }
+
+        # if a header file is defined, ensure the source link does not overlap
+        # with any user-defined header data
+        if self.builder.config.confluence_header_file is not None:
+            self.body.append('<div style="clear: both"> </div>\n')
+
+        self.body.append(self._start_tag(node, 'div', **div_attribs))
+        self.body.append(self._start_tag(node, 'a', **{'href': uri}))
+        self.body.append(self._start_tag(node, 'span', **span_attribs))
+        self.body.append(self.encode(source_text)) # span-icon-content
+        self.body.append(self._end_tag(node, suffix='')) # span
+        self.body.append(self.encode(source_text)) # visible text
+        self.body.append(self._end_tag(node)) # a
+
+        self.body.append(self._end_tag(node)) # div
+
+        # flag that if any navnodes are created, additional spacing is needed
+        self._needs_navnode_spacing = True
+
+        raise nodes.SkipNode
+
     # ------------------------------------------
     # confluence-builder -- enhancements -- jira
     # ------------------------------------------

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -714,6 +714,77 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_space_key'] = 'DUMMY2'
         self._try_config()
 
+    def test_config_check_sourcelink(self):
+        self.config['confluence_sourcelink'] = {}
+        self._try_config()
+
+        self.config['confluence_sourcelink'] = {
+            'url': 'https://example.com',
+        }
+        self._try_config()
+
+        self.config['confluence_sourcelink'] = {
+            'dummy': 'value',
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_sourcelink'] = {
+            'url': None,
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        # reserved check
+        self.config['confluence_sourcelink'] = {
+            'url': 'https://example.com',
+            'page': 'test',
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_sourcelink'] = {
+            'url': 'https://example.com',
+            'suffix': 'test',
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        # templates
+        supported_templates = [
+            'bitbucket',
+            'github',
+            'gitlab',
+        ]
+
+        for template in supported_templates:
+            valid_template = {
+                'type': template,
+                'owner': 'test',
+                'repo': 'test',
+                'version': 'test',
+            }
+            self.config['confluence_sourcelink'] = dict(valid_template)
+            self._try_config()
+
+            sourcelink = dict(valid_template)
+            del sourcelink['owner']
+            self.config['confluence_sourcelink'] = sourcelink
+            with self.assertRaises(ConfluenceConfigurationError):
+                self._try_config()
+
+            sourcelink = dict(valid_template)
+            del sourcelink['repo']
+            self.config['confluence_sourcelink'] = sourcelink
+            with self.assertRaises(ConfluenceConfigurationError):
+                self._try_config()
+
+            sourcelink = dict(valid_template)
+            del sourcelink['version']
+            self.config['confluence_sourcelink'] = sourcelink
+            with self.assertRaises(ConfluenceConfigurationError):
+                self._try_config()
+
     def test_config_check_title_overrides(self):
         self.config['confluence_title_overrides'] = {}
         self._try_config()

--- a/tests/unit-tests/test_config_sourcelink.py
+++ b/tests/unit-tests/test_config_sourcelink.py
@@ -1,0 +1,317 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib import build_sphinx
+from tests.lib import parse
+from tests.lib import prepare_conf
+import os
+import unittest
+
+
+class TestConfluenceConfigSourceLink(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.config = prepare_conf()
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        self.dataset = os.path.join(test_dir, 'datasets', 'minimal')
+
+    def test_storage_sourcelink_custom_text(self):
+        """validate sourcelink can handle custom options (storage)"""
+        #
+        # Ensures the URL format string can be customizable by a user, if they
+        # want to provide other options to help format the source URL.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'text': 'custom text',
+            'url': 'dummy',
+        }
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            text = a_tag.find(string=True, recursive=False)
+            self.assertEqual(text, 'custom text')
+
+    def test_storage_sourcelink_custom_url(self):
+        """validate sourcelink can handle custom options (storage)"""
+        #
+        # Ensures the URL format string can be customizable by a user, if they
+        # want to provide other options to help format the source URL.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'mypath': 'test-docs',
+            'url': 'ftp://example.com/{mypath}/{version}',
+            'version': 'v8',
+        }
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], 'ftp://example.com/test-docs/v8')
+
+    def test_storage_sourcelink_docvalues(self):
+        """validate sourcelink is given page/suffix values (storage)"""
+        #
+        # Ensures the URL format string is provided individual document names
+        # and their suffixes when generating a link.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'url': '{page}{suffix}',
+        }
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], 'index.rst')
+
+    def test_storage_sourcelink_simple(self):
+        """validate sourcelink can accept a simple url value (storage)"""
+        #
+        # Ensures the URL string can be a non-special format string, applying
+        # the contents directly into the href value.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'url': 'https://git.example.net/mydocs',
+        }
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], 'https://git.example.net/mydocs')
+
+    def test_storage_sourcelink_template_bitbucket_default(self):
+        """validate sourcelink bitbucket default options (storage)"""
+        #
+        # Ensures the a Bitbucket configured source link generated an expected
+        # Bitbucket.com reference.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'container': 'subfolder/',
+            'owner': 'example-owner',
+            'repo': 'example-prj',
+            'type': 'bitbucket',
+            'version': 'v1.0',
+        }
+
+        expected = 'https://bitbucket.org/example-owner/example-prj/src/v1.0/subfolder/index.rst?mode=view'
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], expected)
+
+    def test_storage_sourcelink_template_bitbucket_edit_mode(self):
+        """validate sourcelink bitbucket edit-mode (storage)"""
+        #
+        # Ensures the a Bitbucket configured source link generated an expected
+        # Bitbucket.com reference with an edit mode.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'container': 'doc/',
+            'owner': 'example-owner',
+            'repo': 'example-prj2',
+            'type': 'bitbucket',
+            'version': 'main',
+            'view': 'edit',
+        }
+
+        expected = 'https://bitbucket.org/example-owner/example-prj2/src/main/doc/index.rst?mode=edit'
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], expected)
+
+    def test_storage_sourcelink_template_bitbucket_host_protocol(self):
+        """validate sourcelink bitbucket custom host (storage)"""
+        #
+        # Ensures the a Bitbucket configured source link generated with a custom
+        # hostname and protocol, but still with the expected Bitbucket path.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'host': 'example.com',
+            'owner': 'owner',
+            'protocol': 'http',
+            'repo': 'prj-q',
+            'type': 'bitbucket',
+            'version': 'feature-one',
+        }
+
+        expected = 'http://example.com/owner/prj-q/src/feature-one/index.rst?mode=view'
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], expected)
+
+    def test_storage_sourcelink_template_github_default(self):
+        """validate sourcelink github default options (storage)"""
+        #
+        # Ensures the a GitHub configured source link generated an expected
+        # GitHub.com reference.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'container': 'Documentation/',
+            'owner': 'example-owner',
+            'repo': 'example-prj',
+            'type': 'github',
+            'version': 'v1.0',
+        }
+
+        expected = 'https://github.com/example-owner/example-prj/blob/v1.0/Documentation/index.rst'
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], expected)
+
+    def test_storage_sourcelink_template_github_edit_mode(self):
+        """validate sourcelink github edit-mode (storage)"""
+        #
+        # Ensures the a GitHub configured source link generated an expected
+        # GitHub.com reference with an edit mode.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'container': 'doc/',
+            'owner': 'example-owner',
+            'repo': 'example-prj2',
+            'type': 'github',
+            'version': 'main',
+            'view': 'edit',
+        }
+
+        expected = 'https://github.com/example-owner/example-prj2/edit/main/doc/index.rst'
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], expected)
+
+    def test_storage_sourcelink_template_github_host_protocol(self):
+        """validate sourcelink github custom host (storage)"""
+        #
+        # Ensures the a GitHub configured source link generated with a custom
+        # hostname and protocol, but still with the expected GitHub path.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'container': 'docs/',
+            'host': 'example.com',
+            'owner': 'owner',
+            'protocol': 'http',
+            'repo': 'prj',
+            'type': 'github',
+            'version': 'bugfix/alpha',
+        }
+
+        expected = 'http://example.com/owner/prj/blob/bugfix/alpha/docs/index.rst'
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], expected)
+
+    def test_storage_sourcelink_template_gitlab_default(self):
+        """validate sourcelink gitlab default options (storage)"""
+        #
+        # Ensures the a GitLab configured source link generated an expected
+        # GitLab.com reference.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'container': 'Documentation/',
+            'owner': 'example-owner',
+            'repo': 'prj3',
+            'type': 'gitlab',
+            'version': '2-7',
+        }
+
+        expected = 'https://gitlab.com/example-owner/prj3/blob/2-7/Documentation/index.rst'
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], expected)
+
+    def test_storage_sourcelink_template_gitlab_edit_mode(self):
+        """validate sourcelink gitlab edit-mode (storage)"""
+        #
+        # Ensures the a GitLab configured source link generated an expected
+        # GitLab.com reference with an edit mode.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'owner': 'my-owner',
+            'repo': 'my-project',
+            'type': 'gitlab',
+            'version': 'master',
+            'view': 'edit',
+        }
+
+        expected = 'https://gitlab.com/my-owner/my-project/edit/master/index.rst'
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], expected)
+
+    def test_storage_sourcelink_template_gitlab_host_protocol(self):
+        """validate sourcelink gitlab custom host (storage)"""
+        #
+        # Ensures the a GitLab configured source link generated with a custom
+        # hostname and protocol, but still with the expected GitLab path.
+
+        config = dict(self.config)
+        config['confluence_sourcelink'] = {
+            'container': 'docs/',
+            'host': 'example.net',
+            'owner': 'owner4',
+            'protocol': 'http',
+            'repo': 'prj',
+            'type': 'gitlab',
+            'version': 'bugfix/beta',
+        }
+
+        expected = 'http://example.net/owner4/prj/blob/bugfix/beta/docs/index.rst'
+
+        out_dir = build_sphinx(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            a_tag = data.find('a')
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], expected)


### PR DESCRIPTION
Introduces support for a new configuration `confluence_sourcelink`, which allows links to original source (e.g. "Edit on GitHub") for each generated page.