### PR TITLE
page generation notice adjustments

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/templates/domainindex.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/domainindex.html
@@ -11,7 +11,7 @@ Template for a storage-format domainindex document.
         {{ L('This page has been automatically generated.') }}
     </div>
 
-    <hr style="clear: both; padding-top: 10px; margin-bottom: 30px" />
+    <hr style="clear: both; padding-top: 10px" />
 {%- else -%}
     <hr />
 {%- endif %}

--- a/sphinxcontrib/confluencebuilder/storage/templates/genindex.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/genindex.html
@@ -37,7 +37,7 @@ Template for a storage-format genindex document.
         {{ L('This page has been automatically generated.') }}
     </div>
 
-    <hr style="clear: both; padding-top: 10px; margin-bottom: 30px" />
+    <hr style="clear: both; padding-top: 10px" />
 {%- else -%}
     <hr />
 {%- endif %}

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1949,9 +1949,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         raise nodes.SkipNode
 
-    def depart_confluence_page_generation_notice(self, node):
-        self.body.append(self.context.pop()) # div
-
     def visit_confluence_source_link(self, node):
         uri = node.params['url']
 


### PR DESCRIPTION
Including some corrections from the initial page-generation-notice support:

- translator: dropping unused depart for page-generation-notice node
- translator-storage: remove undesired spacing on index pages