### PR TITLE
improve publisher

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -50,6 +50,7 @@ class Rest:
     def __init__(self, config):
         self.url = config.confluence_server_url
         self.session = self._setup_session(config)
+        self.timeout = config.confluence_timeout
         self.verbosity = config.sphinx_verbosity
 
     def __del__(self):
@@ -61,7 +62,7 @@ class Rest:
             'User-Agent': 'Sphinx Confluence Builder',
             'X-Atlassian-Token': NOCHECK,
         })
-        session.timeout = config.confluence_timeout
+
         if config.confluence_proxy is not None:
             session.proxies = {
                 'http': config.confluence_proxy,
@@ -106,8 +107,10 @@ class Rest:
 
     def get(self, key, params):
         rest_url = self.url + API_REST_BIND_PATH + '/' + key
+
         try:
-            rsp = self.session.get(rest_url, params=params)
+            rsp = self.session.get(
+                rest_url, params=params, timeout=self.timeout)
         except requests.exceptions.Timeout:
             raise ConfluenceTimeoutError(self.url)
         except requests.exceptions.SSLError as ex:
@@ -138,7 +141,8 @@ class Rest:
     def post(self, key, data, files=None):
         rest_url = self.url + API_REST_BIND_PATH + '/' + key
         try:
-            rsp = self.session.post(rest_url, json=data, files=files)
+            rsp = self.session.post(
+                rest_url, json=data, files=files, timeout=self.timeout)
         except requests.exceptions.Timeout:
             raise ConfluenceTimeoutError(self.url)
         except requests.exceptions.SSLError as ex:
@@ -172,7 +176,7 @@ class Rest:
     def put(self, key, value, data):
         rest_url = self.url + API_REST_BIND_PATH + '/' + key + '/' + str(value)
         try:
-            rsp = self.session.put(rest_url, json=data)
+            rsp = self.session.put(rest_url, json=data, timeout=self.timeout)
         except requests.exceptions.Timeout:
             raise ConfluenceTimeoutError(self.url)
         except requests.exceptions.SSLError as ex:
@@ -206,7 +210,7 @@ class Rest:
     def delete(self, key, value):
         rest_url = self.url + API_REST_BIND_PATH + '/' + key + '/' + str(value)
         try:
-            rsp = self.session.delete(rest_url)
+            rsp = self.session.delete(rest_url, timeout=self.timeout)
         except requests.exceptions.Timeout:
             raise ConfluenceTimeoutError(self.url)
         except requests.exceptions.SSLError as ex:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -42,7 +42,7 @@ class TestConfluenceValidation(unittest.TestCase):
         cls.config['confluence_server_url'] = DEFAULT_TEST_URL
         cls.config['confluence_server_user'] = DEFAULT_TEST_USER
         cls.config['confluence_space_key'] = space_key
-        cls.config['confluence_timeout'] = 1
+        cls.config['confluence_timeout'] = 10
         cls.config['imgmath_font_size'] = 14
         cls.config['imgmath_image_format'] = 'svg'
         cls.config['imgmath_use_preview'] = True

--- a/tests/unit-tests/test_publisher.py
+++ b/tests/unit-tests/test_publisher.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceAuthenticationFailedUrlError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadServerUrlError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluencePermissionError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceProxyPermissionError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceTimeoutError
+from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
+from tests.lib import mock_confluence_instance
+from tests.lib import prepare_conf
+import os
+import time
+import unittest
+
+
+class TestConfluencePublisher(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.config = prepare_conf()
+        self.config.confluence_timeout = 1
+
+    def test_publisher_bad_response_code(self):
+        """validate publisher can handle bad response code"""
+        #
+        # Verify that the initial connection event for a publisher can safely
+        # handle a 500 server error on a connection.
+
+        with mock_confluence_instance(self.config) as daemon:
+            daemon.register_get_rsp(500, None)
+
+            publisher = ConfluencePublisher()
+            publisher.init(self.config)
+
+            with self.assertRaises(ConfluenceBadServerUrlError):
+                publisher.connect()
+
+    def test_publisher_handle_authentication_error(self):
+        """validate publisher reports an authentication error"""
+        #
+        # Verify that the publisher will report a tailored error message when a
+        # Confluence instance reports an authentication issue.
+
+        with mock_confluence_instance(self.config) as daemon:
+            daemon.register_get_rsp(401, None)
+
+            publisher = ConfluencePublisher()
+            publisher.init(self.config)
+
+            with self.assertRaises(ConfluenceAuthenticationFailedUrlError):
+                publisher.connect()
+
+    def test_publisher_handle_permission_error(self):
+        """validate publisher reports a permission error"""
+        #
+        # Verify that the publisher will report a tailored error message when a
+        # Confluence instance reports a Confluence-specific permission issue.
+
+        with mock_confluence_instance(self.config) as daemon:
+            daemon.register_get_rsp(403, None)
+
+            publisher = ConfluencePublisher()
+            publisher.init(self.config)
+
+            with self.assertRaises(ConfluencePermissionError):
+                publisher.connect()
+
+    def test_publisher_handle_proxy_permission_error(self):
+        """validate publisher reports a proxy-permission error"""
+        #
+        # Verify that the publisher will report a tailored error message when a
+        # configured proxy reports a permission issue.
+
+        with mock_confluence_instance(self.config) as daemon:
+            daemon.register_get_rsp(407, None)
+
+            publisher = ConfluencePublisher()
+            publisher.init(self.config)
+
+            with self.assertRaises(ConfluenceProxyPermissionError):
+                publisher.connect()
+
+    def test_publisher_invalid_json(self):
+        """validate publisher can handle non-json data"""
+        #
+        # Verify that the initial connection event for a publisher can safely
+        # handle non-JSON data returned from a configured instance (either a
+        # non-Confluence instance or a proxy response).
+
+        with mock_confluence_instance(self.config) as daemon:
+            daemon.register_get_rsp(200, 'Welcome to my website.')
+
+            publisher = ConfluencePublisher()
+            publisher.init(self.config)
+
+            with self.assertRaises(ConfluenceBadServerUrlError):
+                publisher.connect()
+
+    def test_publisher_proxy(self):
+        """validate publisher can find a valid space"""
+        #
+        # Verify that a publisher can query a Confluence instance and cache the
+        # display name for a space.
+
+        std_space_name = 'My Default Space'
+        std_rsp = {
+            'size': 1,
+            'results': [{
+                'name': std_space_name,
+            }],
+        }
+
+        proxy_space_name = 'My Proxy Space'
+        proxy_rsp = {
+            'size': 1,
+            'results': [{
+                'name': proxy_space_name,
+            }],
+        }
+
+        try:
+            with mock_confluence_instance(self.config) as default_daemon,\
+                    mock_confluence_instance() as proxy_daemon:
+
+                proxy_host, proxy_port = proxy_daemon.server_address
+                proxy_url = 'http://{}:{}/'.format(proxy_host, proxy_port)
+
+                # check default space is accessible
+                default_daemon.register_get_rsp(200, std_rsp)
+                proxy_daemon.register_get_rsp(200, proxy_rsp)
+
+                publisher = ConfluencePublisher()
+                publisher.init(self.config)
+                publisher.connect()
+
+                self.assertEqual(publisher.space_display_name, std_space_name)
+
+                # check confluence proxy option will go through proxy instance
+                config = self.config.clone()
+                config.confluence_proxy = proxy_url
+
+                default_daemon.register_get_rsp(200, std_rsp)
+                proxy_daemon.register_get_rsp(200, proxy_rsp)
+
+                publisher = ConfluencePublisher()
+                publisher.init(config)
+                publisher.connect()
+
+                self.assertEqual(publisher.space_display_name, proxy_space_name)
+
+                # check system proxy option will go through proxy instance
+                os.environ['http_proxy'] = proxy_url
+
+                default_daemon.register_get_rsp(200, std_rsp)
+                proxy_daemon.register_get_rsp(200, proxy_rsp)
+
+                publisher = ConfluencePublisher()
+                publisher.init(self.config)
+                publisher.connect()
+
+                self.assertEqual(publisher.space_display_name, proxy_space_name)
+        finally:
+            if 'http_proxy' in os.environ:
+                del os.environ['http_proxy']
+
+    def test_publisher_unsupported_json(self):
+        """validate publisher can handle unexpected json data"""
+        #
+        # Verify that the initial connection event for a publisher provides a
+        # bit more strict error checking on the provided JSON data returned.
+        # This is to help deal with a configuration which points to a
+        # non-Confluence instance, but the server provides JSON data in its
+        # response.
+
+        with mock_confluence_instance(self.config) as daemon:
+            publisher = ConfluencePublisher()
+            publisher.init(self.config)
+
+            # random json data
+            rsp = {
+                'some-data': 'hello',
+            }
+            daemon.register_get_rsp(200, rsp)
+            with self.assertRaises(ConfluenceBadServerUrlError):
+                publisher.connect()
+
+            # data with a size field, but unrelated data
+            rsp = {
+                'size': 3,
+                'data': [
+                    'item-1',
+                    'item-2',
+                    'item-3',
+                ],
+            }
+            daemon.register_get_rsp(200, rsp)
+            with self.assertRaises(ConfluenceBadServerUrlError):
+                publisher.connect()
+
+            # result data not matching expected
+            rsp = {
+                'size': 1,
+                'results': [{
+                    'misc-option': 123,
+                }],
+            }
+            daemon.register_get_rsp(200, rsp)
+            with self.assertRaises(ConfluenceBadServerUrlError):
+                publisher.connect()
+
+    def test_publisher_valid_space(self):
+        """validate publisher can find a valid space"""
+        #
+        # Verify that a publisher can query a Confluence instance and cache the
+        # display name for a space.
+
+        space_name = 'My Space'
+
+        val = {
+            'size': 1,
+            'results': [{
+                'name': space_name,
+            }],
+        }
+
+        with mock_confluence_instance(self.config) as daemon:
+            daemon.register_get_rsp(200, val)
+
+            publisher = ConfluencePublisher()
+            publisher.init(self.config)
+            publisher.connect()
+
+            self.assertEqual(publisher.space_display_name, space_name)
+
+    def test_publisher_verify_timeout(self):
+        """validate publisher timeout"""
+        #
+        # Verify that a non-served request from a publisher event will timeout.
+
+        with mock_confluence_instance(self.config, ignore_requests=True):
+            publisher = ConfluencePublisher()
+            publisher.init(self.config)
+
+            start = time.time()
+
+            with self.assertRaises(ConfluenceTimeoutError):
+                publisher.connect()
+
+            end = time.time()
+            diff = int(end - start)
+
+            self.assertLessEqual(diff, self.config.confluence_timeout + 1)


### PR DESCRIPTION
### improve first connect handling

Adjusting the checks to verify expected JSON data on a first connection. This can better help debug/inform new connections which may be misconfigured, presenting more useful error messages instead of possible stacktraces.

### correct regression in timeout option

The timeout option was moved into the Requests session instance, when session support was added into this extension; however, Requests does not support a timeout option being used in the session. Adjusting the timeout options to be applied to the various request calls.

### adding publisher tests

Introducing a series of publisher-related tests -- to help verify space fetching, verify timeout options and expected error handling.