### PR TITLE
config: remove permits-empty logic for string checks

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -485,7 +485,7 @@ names are relative to the documentation's source directory.
 
     # confluence_secnumber_suffix
     validator.conf('confluence_secnumber_suffix') \
-             .string(permit_empty=True)
+             .string()
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -300,7 +300,7 @@ class ConfigurationValidation:
 
         return self
 
-    def string(self, permit_empty=False):
+    def string(self):
         """
         checks if a configuration is a string
 
@@ -312,14 +312,11 @@ class ConfigurationValidation:
         In the event that the configuration is not set (e.g. a value of `None`),
         this method will have no effect.
 
-        Args:
-            permit_empty (optional): whether or not all an empty string of this
-                                      value is considered to be a set value
-
         Returns:
             the validator instance
         """
-        value = self._value(permit_empty=True)
+
+        value = self._value()
 
         if value is not None and not isinstance(value, basestring):
             raise ConfluenceConfigurationError(
@@ -390,17 +387,13 @@ class ConfigurationValidation:
 
         return self
 
-    def _value(self, permit_empty=False):
+    def _value(self):
         """
         return a value for a configuration
 
         Return the value (if any) of the provided key found in the registered
         builder's configuration. If any configuration translator is set for a
         key, the translation will be performed and returned with this call.
-
-        Args:
-            permit_empty (optional): whether or not an empty string of this
-                                      value is considered to be a set value
 
         Returns:
             the value for a key
@@ -410,12 +403,10 @@ class ConfigurationValidation:
         if value is not None and self._translate:
             value = self._translate(value)
 
-        # If an empty string, treat (in most cases) that this value is actually
-        # a `None` value. This permits callers from passing "empty"/unset
-        # configuration entries via the command line to "clear" a configuration
-        # value. Note that this does not apply to all configuration entries (for
-        # example, see `confluence_secnumber_suffix`).
-        if not permit_empty and isinstance(value, basestring) and not value:
+        # If an empty string, treat that this value is actually a `None` value.
+        # This permits callers from passing "empty"/unset configuration entries
+        # via the command line to "clear" a configuration value.
+        if isinstance(value, basestring) and not value:
             value = None
 
         return value

--- a/tests/unit-tests/test_sphinx_toctree.py
+++ b/tests/unit-tests/test_sphinx_toctree.py
@@ -254,7 +254,62 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             doc = docs[0]
             self._verify_link(doc, 'child')
 
-    def test_storage_sphinx_toctree_numbered_secnumbers_suffix(self):
+    def test_storage_sphinx_toctree_numbered_secnumbers_suffix_empty(self):
+        """validate toctree secnumber supports empty str (storage)"""
+        #
+        # Ensure that the toctree secnumber suffix value can be set to an
+        # empty string.
+
+        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-numbered')
+
+        config = dict(self.config)
+        config['confluence_secnumber_suffix'] = ''
+
+        out_dir = build_sphinx(dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            root_toc = data.find('ul', recursive=False)
+            self.assertIsNotNone(root_toc)
+
+            docs = root_toc.findChildren('li', recursive=False)
+            self.assertIsNotNone(docs)
+            self.assertEqual(len(docs), 4)
+
+            group = docs.pop(0)
+            self._verify_link(group, '1doc')
+
+            group_docs = group.find('ul', recursive=False)
+            self.assertIsNotNone(group_docs)
+
+            sub_docs = group_docs.findChildren('li', recursive=False)
+            self.assertIsNotNone(sub_docs)
+            self.assertEqual(len(sub_docs), 1)
+            self._verify_link(sub_docs[0], '1.1child')
+
+            group = docs.pop(0)
+            self._verify_link(group, '1doc',
+                label='2section with spaces')
+
+            group = docs.pop(0)
+            self._verify_link(group, '1doc',
+                label='3section_with_underscores')
+
+            group = docs.pop(0)
+            self._verify_link(group, '1doc',
+                label='4section with a large name - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vitae volutpat ipsum, quis sodales eros. Aenean quis nunc quis leo aliquam gravida. Fusce accumsan nibh vitae enim ullamcorper iaculis. Duis eget augue dolor. Curabitur at enim elit. Nullam luctus mollis magna. Pellentesque pellentesque, leo quis suscipit finibus, diam justo convallis.')
+
+        with parse('doc', out_dir) as data:
+            root_toc = data.find('ul', recursive=False)
+            self.assertIsNotNone(root_toc)
+
+            docs = root_toc.findChildren('li', recursive=False)
+            self.assertIsNotNone(docs)
+            self.assertEqual(len(docs), 1)
+
+            doc = docs[0]
+            self._verify_link(doc, '1.1child')
+
+    def test_storage_sphinx_toctree_numbered_secnumbers_suffix_set(self):
         dataset = os.path.join(self.test_dir, 'datasets', 'toctree-numbered')
 
         config = dict(self.config)


### PR DESCRIPTION
The configuration checks related to "empty permitted" string have not been applicable for sometime. Originally, strict checking was added to help prevent strings from being set and empty; however, this causes complications for users trying to override/clean options from a command line (passing in empty defines which result in an empty string).

Removing this implementation.

Also, adding a unit test to validate a user defining an empty `confluence_secnumber_suffix` option.