### PR TITLE
cmd-report: include singleconfluece prefix options

### DIFF
--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -110,7 +110,11 @@ def report_main(args_parser):
                     else:
                         value = raw
 
-                    if not args.full_config and not k.startswith('confluence_'):
+                    prefixes = (
+                        'confluence_',
+                        'singleconfluence_',
+                    )
+                    if not args.full_config and not k.startswith(prefixes):
                         continue
 
                     # always extract some known builder configurations


### PR DESCRIPTION
Not all configuration options provided by this extension are prefixed with `confluence_`; adjusting to also include the recently added support for singleconfluence builder options.