### PR TITLE
builder: handle explicit false-asset override

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -553,6 +553,8 @@ class ConfluenceBuilder(Builder):
                     'point cannot be found ({}): {}'.format(key, docname))
                 return
 
+        attachment_id = None
+
         if conf.confluence_asset_override is None:
             # "automatic" management -- check if already published; if not, push
             attachment_id = publisher.storeAttachment(


### PR DESCRIPTION
If a configuration explicitly configures the `confluence_asset_override` option to a value of `False`, asset publishing will result in an exception; correcting.