### PR TITLE
support strikethrough through strike role

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1291,6 +1291,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         elif classes in [['accelerator']]:
             self.body.append(self._start_tag(node, 'u'))
             has_added = True
+        elif classes in [['strike']]:
+            self.body.append(self._start_tag(node, 's'))
+            has_added = True
         elif isinstance(node.parent, addnodes.desc_parameter):
             # check if an identifier in signature
             if classes in [['n']]:


### PR DESCRIPTION
It is "common" (with HTML builder environments) for inline text assigned with a `strike` role to be an indication that the text should have a strikethrough style applied. Since Confluence provides support through strikethrough content, using this role hint to create `s` tags for any marked text.