### PR TITLE
introduce confluence newline directive

### DIFF
--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -71,6 +71,17 @@ Common
     See also ``confluence_global_labels``
     (:ref:`ref<confluence_global_labels>`).
 
+.. rst:directive:: confluence_newline
+
+    .. versionadded:: 1.7
+
+    The ``confluence_newline`` directive supports the injection of a newline
+    in a document where seperation may be desired between inlined elements.
+
+    .. code-block:: rst
+
+        .. confluence_newline::
+
 Jira
 ----
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -10,6 +10,7 @@ from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.config import handle_config_inited
 from sphinxcontrib.confluencebuilder.directives import ConfluenceExpandDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceMetadataDirective
+from sphinxcontrib.confluencebuilder.directives import ConfluenceNewline
 from sphinxcontrib.confluencebuilder.directives import JiraDirective
 from sphinxcontrib.confluencebuilder.directives import JiraIssueDirective
 from sphinxcontrib.confluencebuilder.locale import MESSAGE_CATALOG_NAME
@@ -245,6 +246,7 @@ def confluence_builder_inited(app):
     # register directives
     app.add_directive('confluence_expand', ConfluenceExpandDirective)
     app.add_directive('confluence_metadata', ConfluenceMetadataDirective)
+    app.add_directive('confluence_newline', ConfluenceNewline)
     app.add_directive('jira', JiraDirective)
     app.add_directive('jira_issue', JiraIssueDirective)
 

--- a/sphinxcontrib/confluencebuilder/directives.py
+++ b/sphinxcontrib/confluencebuilder/directives.py
@@ -8,6 +8,7 @@ from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 from sphinxcontrib.confluencebuilder.nodes import confluence_expand
 from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
+from sphinxcontrib.confluencebuilder.nodes import confluence_newline
 from sphinxcontrib.confluencebuilder.nodes import jira
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
 from uuid import UUID
@@ -68,6 +69,15 @@ class ConfluenceMetadataDirective(Directive):
 
         for k, v in self.options.items():
             params[kebab_case_to_camel_case(k)] = v
+
+        return [node]
+
+
+class ConfluenceNewline(Directive):
+    has_content = False
+
+    def run(self):
+        node = confluence_newline()
 
         return [node]
 

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -45,6 +45,16 @@ class confluence_metadata(nodes.Element):
     """
 
 
+class confluence_newline(nodes.Element):
+    """
+    confluence newline node
+
+    A Confluence builder defined newline node which provides a convience hint
+    that a newline should be injected into a document (for users not wanted to
+    define a custom raw type).
+    """
+
+
 class confluence_page_generation_notice(nodes.TextElement):
     """
     confluence page generation notice node

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1937,6 +1937,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             **{'style':
                 'clear: both; padding-top: 10px; margin-bottom: 30px'}))
 
+    def visit_confluence_newline(self, node):
+        self.body.append(self._start_tag(
+            node, 'br', suffix=self.nl, empty=True))
+
+        raise nodes.SkipNode
+
     def visit_confluence_page_generation_notice(self, node):
         attribs = {
             'style': 'color: #707070; font-size: 12px;'


### PR DESCRIPTION
Adding a convenience directive to help users inject a newline into a Confluence page. This is to provide an alternative to generating a raw node entry to manually injecting a `br` tag.