### PR TITLE
add ancestor check

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -514,6 +514,11 @@ class ConfluenceBuilder(Builder):
         if self.config.root_doc == docname:
             self.root_doc_page_id = uploaded_id
 
+            # populate ancestors to be used to pre-check ancestors assignments
+            # on new pages
+            root_ancestors = self.publisher.get_ancestors(uploaded_id)
+            self.publisher.restrict_ancestors(root_ancestors)
+
         # if purging is enabled and we have yet to populate a list of legacy
         # pages to cache, populate pages in our target scope now
         if conf.confluence_purge and self.legacy_pages is None:

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -147,11 +147,40 @@ class ConfluencePublishCheckError(ConfluenceError):
     pass
 
 
+class ConfluencePublishAncestorError(ConfluencePublishCheckError):
+    def __init__(self, page_name):
+        super(ConfluencePublishAncestorError, self).__init__('''
+---
+Ancestor publish check failed for: {name}
+
+A request has been made to publish a page as a nested child of itself.
+This is most likely a result of an existing documentation set on a
+Confluence instance where a publish attempt is trying to push new pages
+into a parent page which has an ancestor with a matching name:
+
+    {name} (original)
+        |
+         --> Configured Parent/Root
+                     |
+                      --> {name} (new update)
+
+This extension will not reorder a configured base page from its
+location. A user can either rename the page in their documentation to
+prevent the page title conflict (either in the document itself or using
+the `confluence_title_overrides` option), or rename/reorder the existing
+page on the Confluence instance.
+
+If the above does not appear to be related to the current use case,
+please inform the maintainers of this extension.
+---
+'''.format(name=page_name))
+
+
 class ConfluencePublishSelfAncestorError(ConfluencePublishCheckError):
     def __init__(self, page_name):
         super(ConfluencePublishSelfAncestorError, self).__init__('''
 ---
-Ancestor publish check failed for: {name}
+Ancestor (self) publish check failed for: {name}
 
 A request has been made to publish a page as a child of itself. This is
 most likely due to a configuration of `confluence_parent_page` with the


### PR DESCRIPTION
Adding a pre-check to generate a detailed exception when a page is being updated as a child of itself. When a root page is first upload, ancestors of the page will be fetched and marked as "reserved". If a future page update request attempts to move a root page's ancestor under the root page's tree, the `ConfluencePublishAncestorError` exception will be raised.

See also: #348, #559 and #517