### PR TITLE
rest: provide request session override

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1193,6 +1193,21 @@ Advanced publishing configuration
 
         confluence_publish_onlynew = True
 
+.. confval:: confluence_request_session_override
+
+    .. versionadded:: 1.7
+
+    A hook to manipulate a Requests_ session prepared by this extension. Allows
+    users who wish to perform advanced configuration of a session for features
+    which may not be supported by this extension.
+
+    .. code-block:: python
+
+        def my_request_session_override(session):
+            session.trust_env = False
+
+        confluence_request_session_override = my_request_session_override
+
 .. confval:: confluence_server_auth
 
     An authentication handler which can be directly provided to a REST API

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -159,6 +159,8 @@ def setup(app):
     app.add_config_value('confluence_publish_denylist', None, '')
     # Header(s) to use for Confluence REST interaction.
     app.add_config_value('confluence_publish_headers', None, '')
+    # Manipulate a requests instance.
+    app.add_config_value('confluence_request_session_override', None, '')
     # Authentication passthrough for Confluence REST interaction.
     app.add_config_value('confluence_server_auth', None, '')
     # Cookie(s) to use for Confluence REST interaction.

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -483,6 +483,12 @@ names are relative to the documentation's source directory.
 
     # ##################################################################
 
+    # confluence_request_session_override
+    validator.conf('confluence_request_session_override') \
+             .callable_()
+
+    # ##################################################################
+
     # confluence_secnumber_suffix
     validator.conf('confluence_secnumber_suffix') \
              .string()

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -103,6 +103,13 @@ class Rest:
         if config.confluence_server_cookies:
             session.cookies.update(config.confluence_server_cookies)
 
+        # provides users a direct hook into manipulating a built requests
+        # session, to allow full control over requests capabilities which may
+        # not be managed by this extension
+        session_override = config.confluence_request_session_override
+        if session_override:
+            session_override(session)
+
         return session
 
     def get(self, key, params):


### PR DESCRIPTION
Provides a configuration `confluence_request_session_override` which enables a user to override specific options on a Requests session object. This is to provide flexibility in managing various Requests options which may not be supported through other Confluence builder configuration options.