### PR TITLE
provide navdocs document list override

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -298,6 +298,9 @@ Generic configuration
         not want to use hierarchy mode should explicitly configure this to
         ``False`` in their configurations.
 
+.. |confluence_prev_next_buttons_location| replace:: ``confluence_prev_next_buttons_location``
+.. _confluence_prev_next_buttons_location:
+
 .. confval:: confluence_prev_next_buttons_location
 
     .. versionadded:: 1.2
@@ -1365,6 +1368,26 @@ Advanced processing configuration
     URI. The provided function is used to perform translations for both Sphinx's
     get_relative_uri_ method. The default translation will be the combination of
     "``docname`` + |confluence_link_suffix|_".
+
+.. confval:: confluence_navdocs_transform
+
+    .. versionadded:: 1.7
+
+    A function to override the document list used for populating navigational
+    buttons generated from a |confluence_prev_next_buttons_location|_
+    configuration. This can be helpful in advanced publishing cases where a user
+    would like ignore or re-order select pages from navigation, or even
+    reference pages outside of documentation list.
+
+    .. code-block:: python
+
+        def my_navdocs_transform(builder, docnames):
+            # override and return a new docnames list
+            return docnames
+
+       confluence_navdocs_transform = my_navdocs_transform
+
+    See also |confluence_prev_next_buttons_location|_.
 
 .. |confluence_remove_title| replace:: ``confluence_remove_title``
 .. _confluence_remove_title:

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -177,6 +177,8 @@ def setup(app):
     app.add_config_value('confluence_link_suffix', None, 'env')
     # Translation of docname to a (partial) URI.
     app.add_config_value('confluence_link_transform', None, 'env')
+    # Inject navigational hints into the documentation.
+    app.add_config_value('confluence_navdocs_transform', None, '')
     # Remove a detected title from generated documents.
     app.add_config_value('confluence_remove_title', None, 'env')
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -335,6 +335,10 @@ class ConfluenceBuilder(Builder):
                 if indexname in nav_docnames:
                     nav_docnames.remove(indexname)
 
+        navdocs_transform = self.config.confluence_navdocs_transform
+        if navdocs_transform:
+            nav_docnames = navdocs_transform(self, nav_docnames)
+
         prevdoc = nav_docnames[0] if nav_docnames else None
         for docname in nav_docnames[1:]:
             self.nav_prev[docname] = self.get_relative_uri(docname, prevdoc)

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -349,6 +349,12 @@ If planning to use a depth of zero, it is recommended to use the
 
     # ##################################################################
 
+    # confluence_navdocs_transform
+    validator.conf('confluence_navdocs_transform') \
+             .callable_()
+
+    # ##################################################################
+
     validator.conf('confluence_parent_page') \
              .string()
 


### PR DESCRIPTION
Providing an advanced navigational document list override to allow users to override the document list used when considering navigation's "Next" and "Previous" targets. This provides the ability to remove pages, reorder documents or even inject external documents into the navigation set.