### PR TITLE
publisher: always force v1 editor

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -576,17 +576,6 @@ class ConfluencePublisher:
             if not page:
                 new_page = self._build_page(page_name, data)
 
-                # only the legacy editor is supported at this time; forced v1
-                # since Confluence Cloud appears to have an inconsistent default
-                # editor
-                new_page['metadata'] = {
-                    'properties': {
-                        'editor': {
-                            'value': 'v1',
-                        }
-                    }
-                }
-
                 if self.can_labels:
                     self._populate_labels(new_page, data['labels'])
 
@@ -805,6 +794,16 @@ class ConfluencePublisher:
                 'storage': {
                     'representation': 'storage',
                     'value': data['content'],
+                }
+            },
+            # only the legacy editor is supported at this time; forced v1
+            # since Confluence Cloud appears to have an inconsistent default
+            # editor
+            'metadata': {
+                'properties': {
+                    'editor': {
+                        'value': 'v1',
+                    }
                 }
             },
             'space': {


### PR DESCRIPTION
The existing storage format translator only supports capabilities from the v1 editor. While new pages are always created with the v1 flag, if an existing page was converted or previous made with a new editor, updates with this extension will publish and render poorly using the newer editor. Adjusting every update page event to always use v1.