### PR TITLE
tox: reorder linter environments to be run first

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
+    flake8
+    pylint
     py{27,36,37,38,39,310}-sphinx{18}
     py{36,37,38,39}-sphinx{35,40,41,42,43}
     py{310}-sphinx{42,43}
-    flake8
-    pylint
 
 [testenv]
 deps =


### PR DESCRIPTION
Adjusting the tox environment list to perform linter checks first. This is to help development environments output linter errors sooner than later, where styling/etc. errors can be corrected while other functional tests are being performed.