### PR TITLE
tests-validation: adding markdown check with validation

### DIFF
--- a/requirements_validation.txt
+++ b/requirements_validation.txt
@@ -1,1 +1,2 @@
 breathe; python_version >= '3.5'
+myst_parser

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -210,6 +210,28 @@ class TestConfluenceValidation(unittest.TestCase):
 
         build_sphinx(dataset, config=config, out_dir=doc_dir, relax=True)
 
+    def test_markdown(self):
+        config = self.config.clone()
+        config['confluence_sourcelink']['container'] += 'markdown/'
+        config['extensions'].append('myst_parser')
+
+        dataset = os.path.join(self.datasets, 'markdown')
+        doc_dir = prepare_dirs('validation-set-markdown')
+
+        # inject a navdoc from the last "standard (no macro)" page, to the
+        # hierarchy example start page
+        def navdocs_transform(builder, docnames):
+            builder.state.register_title(
+                '_validation_prev', 'Hierarchy example (d)', None)
+            docnames.insert(0, '_validation_prev')
+            builder.state.register_title(
+                '_validation_next', 'Extensions', None)
+            docnames.append('_validation_next')
+            return docnames
+        config['confluence_navdocs_transform'] = navdocs_transform
+
+        build_sphinx(dataset, config=config, out_dir=doc_dir)
+
     def test_standard_default(self):
         config = dict(self.config)
         dataset = os.path.join(self.datasets, 'standard')

--- a/tests/validation-sets/markdown/code.md
+++ b/tests/validation-sets/markdown/code.md
@@ -1,0 +1,7 @@
+# Markdown Code
+
+Code block example:
+
+```python
+print('this is python')
+```

--- a/tests/validation-sets/markdown/index.md
+++ b/tests/validation-sets/markdown/index.md
@@ -1,0 +1,17 @@
+# Markdown
+
+Demonstration that Markdown documents can be generated and published to
+Confluence using [MyST-Parser][MyST-Parser]
+
+```{note}
+This is not an extensive demonstration of Markdown capabilities; only a simple
+sanity check that Markdown content can be created and linked across multiple
+pages.
+```
+
+```{toctree}
+code
+table
+```
+
+[MyST-Parser]: https://myst-parser.readthedocs.io/

--- a/tests/validation-sets/markdown/table.md
+++ b/tests/validation-sets/markdown/table.md
@@ -1,0 +1,7 @@
+# Markdown Table
+
+Table example:
+
+| Header row, column 1   | Header 2   | Header 3 | Header 4 |
+| :--------------------- | :--------: | -------: | -------- |
+| body row 1, column 1   | 2          | 3        | 4        |


### PR DESCRIPTION
Adding a validation set specific to the verification of Markdown support (using the MyST-Parser extension).