### PR TITLE
.github: only perform build validation for required paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,4 +85,4 @@ jobs:
     - name: tox
       env:
         TOXENV: ${{ matrix.toxenv }}
-      run: tox 
+      run: tox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,25 @@ on:
   push:
     branches:
     - master
+    paths:
+      - '.github/workflows/build.yml'
+      - 'sphinxcontrib/**'
+      - 'tests/**'
+      - 'requirements_dev.txt'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
   pull_request:
     branches:
     - master
+    paths:
+      - '.github/workflows/build.yml'
+      - 'sphinxcontrib/**'
+      - 'tests/**'
+      - 'requirements_dev.txt'
+      - 'setup.cfg'
+      - 'setup.py'
+      - 'tox.ini'
 
 jobs:
   build:


### PR DESCRIPTION
Only trigger build validation when dealing with the implementation or related files (e.g. excluding documentation, README.rst, etc.).