### PR TITLE
build checks for documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: docs
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+      - '.github/workflows/docs.yml'
+      - 'docs/**'
+      - 'CHANGES.rst'
+  pull_request:
+    branches:
+    - master
+    paths:
+      - '.github/workflows/docs.yml'
+      - 'docs/**'
+      - 'CHANGES.rst'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: docs-pip
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install \
+            latexmk \
+            texlive-latex-extra \
+            texlive-latex-recommended \
+            -y
+        python -m pip install --upgrade sphinx
+
+    - name: HTML
+      run: make html
+      working-directory: doc
+
+    - name: PDF
+      run: make latexpdf
+      working-directory: doc
+
+    - name: Archive generated PDF
+      uses: actions/upload-artifact@v2
+      with:
+        name: sphinxcontrib-confluencebuilder.pdf
+        path: doc/_build/latex/sphinxconfluencebuilder.pdf
+        retention-days: 10

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,7 +11,7 @@ endif
 
 .PHONY: all
 all:
-	@pushd $(BASE_DIR) >/dev/null && \
+	@cd $(BASE_DIR) >/dev/null && \
 		python -m sphinx -M $(BUILDER) $(DOC_DIR) $(DOC_DIR)_build/ -E -a -W
 
 $(eval $(BUILDER):all)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+# Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 
 DOC_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 BASE_DIR := $(abspath $(DOC_DIR)/..)
@@ -12,6 +12,6 @@ endif
 .PHONY: all
 all:
 	@pushd $(BASE_DIR) >/dev/null && \
-		python -m sphinx -M $(BUILDER) $(DOC_DIR) $(DOC_DIR)_build/ -E -a
+		python -m sphinx -M $(BUILDER) $(DOC_DIR) $(DOC_DIR)_build/ -E -a -W
 
 $(eval $(BUILDER):all)

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,6 +1,6 @@
 @echo OFF
 setlocal
-REM Copyright 2020 Sphinx Confluence Builder Contributors (AUTHORS)
+REM Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
 
 REM find python
 where /q python
@@ -21,5 +21,8 @@ if "%builder%" == "" (
 
 REM invoke build
 pushd %root_dir%
-python -m sphinx -M %builder% %~dp0 %~dp0_build -E -a
+set errorlevel=
+python -m sphinx -M %builder% %~dp0 %~dp0_build -E -a -W
 popd
+
+exit /b %errorlevel%


### PR DESCRIPTION
### doc: treat warnings as errors

When using build helper scripts for documentation, treat any warnings as errors. This should help produce a cleaner documentation state when updating and ensure issues are not missed.

### .github: add documentation check

Adding a GitHub action to validate the successful build of desired documentation outputs.