### PR TITLE
maintenance (2021-11-21)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,6 +16,9 @@ on:
       test_desc:
         description: 'Test Description'
         default: 'test state'
+      test_version:
+        description: 'Test Version'
+        default: 'master'
 
 jobs:
   build:
@@ -52,4 +55,5 @@ jobs:
         CONFLUENCE_SPACE: ${{ github.event.inputs.space }}
         CONFLUENCE_TEST_DESC: ${{ github.event.inputs.test_desc }}
         CONFLUENCE_TEST_KEY: ${{ github.event.inputs.test_key }}
+        CONFLUENCE_TEST_VERSION: ${{ github.event.inputs.test_version }}
       run: tox -e validation

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ development
 * improve support for attached svg images with length/scaling modifiers
 * improve support for non-pixel length units for images
 * improve support for svg images without an xml declaration
+* improve support when publishing page updates converted to a new editor
 * improve support when using the sphinx-gallery extension
 * improve support when using the sphinx_toolbox extension
 * improve support when using the sphinxcontrib-mermaid extension
@@ -25,6 +26,7 @@ development
 * introduce the page generation notice option (notice for top of documents)
 * introduce the source link option (e.g. "Edit Source" link)
 * prevent issues with extension directives causing errors with other builders
+* provide a configuration hook to override requests session information
 * remove borders on footnote tables
 * support domain indices generation/processing
 * support for leaving resolved toctrees for singleconfluence

--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -103,11 +103,13 @@ reference, ensure the following post-release tasks are performed:
       config_overrides['confluence_space_name'] = 'V010X00'
       config_test_key = 'v1.x'
       config_test_desc = 'v1.x release'
+      config_version = '<tag>'
 
       # stable space
       config_overrides['confluence_space_name'] = 'STABLE'
       config_test_key = 'Stable'
       config_test_desc = 'stable release (v1.x)'
+      config_version = '<tag>'
 
 .. _Atlassian Support End of Life Policy: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
 .. _CONTRIBUTING.rst: https://github.com/sphinx-contrib/confluencebuilder/blob/master/CONTRIBUTING.rst

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Requirements
 
 If publishing:
 
-* Confluence_ Cloud or Data Center / Server 7.1+
+* Confluence_ Cloud or Data Center / Server 7.2+
 
 Installing
 ==========

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Requirements
 
 * Python_ 2.7 or 3.6+
 * Requests_ 2.14.0+
-* Sphinx_ 1.8 or 3.4+
+* Sphinx_ 1.8 or 3.5+
 
 If publishing:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,7 @@ author = 'Sphinx Confluence Builder Contributors'
 version = sphinxcontrib.confluencebuilder.__version__
 release = sphinxcontrib.confluencebuilder.__version__
 
-supported_confluence_ver = '7.1+'
+supported_confluence_ver = '7.2+'
 supported_python_ver = '2.7 or 3.6+'
 supported_sphinx_ver = '1.8 or 3.4+'
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ release = sphinxcontrib.confluencebuilder.__version__
 
 supported_confluence_ver = '7.2+'
 supported_python_ver = '2.7 or 3.6+'
-supported_sphinx_ver = '1.8 or 3.4+'
+supported_sphinx_ver = '1.8 or 3.5+'
 
 root_doc = 'contents'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,9 +55,11 @@ output_file = sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebui
 [init_catalog]
 domain = sphinxcontrib.confluencebuilder
 input_file = sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
+omit_header = True
 output_dir = sphinxcontrib/confluencebuilder/locale/
 
 [update_catalog]
 domain = sphinxcontrib.confluencebuilder
 input_file = sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
+omit_header = True
 output_dir = sphinxcontrib/confluencebuilder/locale/

--- a/sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
+++ b/sphinxcontrib/confluencebuilder/locale/sphinxcontrib.confluencebuilder.pot
@@ -9,7 +9,11 @@ msgstr ""
 #: sphinxcontrib/confluencebuilder/storage/templates/domainindex.html:11
 #: sphinxcontrib/confluencebuilder/storage/templates/genindex.html:37
 #: sphinxcontrib/confluencebuilder/storage/templates/search.html:10
-#: sphinxcontrib/confluencebuilder/storage/translator.py:1917
+#: sphinxcontrib/confluencebuilder/storage/translator.py:1953
 msgid "This page has been automatically generated."
+msgstr ""
+
+#: sphinxcontrib/confluencebuilder/storage/translator.py:1968
+msgid "Edit Source"
 msgstr ""
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -120,6 +120,7 @@ class TestConfluenceValidation(unittest.TestCase):
         cls.config['confluence_parent_page'] = cls.test_key
         cls.config['confluence_purge'] = True
         cls.config['confluence_purge_from_root'] = True
+        cls.config['confluence_root_homepage'] = False
 
     def test_extended_autodocs(self):
         if parse_version(sphinx_version) < parse_version('2.3.1'):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -264,6 +264,9 @@ class TestConfluenceValidation(unittest.TestCase):
         # inject a navdoc to the "standard (no macro)" page
         def navdocs_transform(builder, docnames):
             builder.state.register_title(
+                '_validation_prev', self.test_key, None)
+            docnames.insert(0, '_validation_prev')
+            builder.state.register_title(
                 '_validation_next', 'Standard (nomacro)', None)
             docnames.append('_validation_next')
             return docnames

--- a/tests/validation-sets/base/index.rst
+++ b/tests/validation-sets/base/index.rst
@@ -1,7 +1,7 @@
 |test_key|
 ==========
 
-Validation set result for sphinxcontrib-confluencebuilder |test_desc|:
+Validation set result for `sphinxcontrib-confluencebuilder`_ |test_desc|:
 
 ----
 
@@ -10,3 +10,8 @@ Validation set result for sphinxcontrib-confluencebuilder |test_desc|:
     <ac:structured-macro ac:name="children">
         <ac:parameter ac:name="all">true</ac:parameter>
     </ac:structured-macro>
+
+
+.. references ------------------------------------------------------------------
+
+.. _sphinxcontrib-confluencebuilder: https://sphinxcontrib-confluencebuilder.readthedocs.io/


### PR DESCRIPTION
A series of maintenance changes to the repository:

- validation: add link to homepage in base validation document
- validation: only permit root homepage on base document
- validation: correct navlink on the standard document set
- README.rst: sync eol confluence versions
- doc: sync eol confluence versions
- README.rst: adjust supported sphinx versions
- doc: adjust supported sphinx versions
- .github: add test version in validation workflow
- i8n: omit headers on all catalog calls
- i8n: updating message list
- MAINTAINERS.rst: mention config version overrides
- CHANGES.rst: adding features/changes