### PR TITLE
publisher: fixed page title caching for explicit page id fetches

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+Development
+===========
+
+* fixed regression where publish-root/dryrun modes would fail with an exception
+
 1.7.0 (2021-11-21)
 ==================
 

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -380,7 +380,7 @@ class ConfluencePublisher:
 
         if page:
             assert int(page_id) == int(page['id'])
-            self._name_cache[page_id] = ['title']
+            self._name_cache[page_id] = page['title']
 
         return page_id, page
 

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -17,13 +17,13 @@ import time
 import unittest
 
 
-class TestConfluencePublisher(unittest.TestCase):
+class TestConfluencePublisherConnect(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = prepare_conf()
         cls.config.confluence_timeout = 1
 
-    def test_publisher_bad_response_code(self):
+    def test_publisher_connect_bad_response_code(self):
         """validate publisher can handle bad response code"""
         #
         # Verify that the initial connection event for a publisher can safely
@@ -38,7 +38,7 @@ class TestConfluencePublisher(unittest.TestCase):
             with self.assertRaises(ConfluenceBadServerUrlError):
                 publisher.connect()
 
-    def test_publisher_handle_authentication_error(self):
+    def test_publisher_connect_handle_authentication_error(self):
         """validate publisher reports an authentication error"""
         #
         # Verify that the publisher will report a tailored error message when a
@@ -53,7 +53,7 @@ class TestConfluencePublisher(unittest.TestCase):
             with self.assertRaises(ConfluenceAuthenticationFailedUrlError):
                 publisher.connect()
 
-    def test_publisher_handle_permission_error(self):
+    def test_publisher_connect_handle_permission_error(self):
         """validate publisher reports a permission error"""
         #
         # Verify that the publisher will report a tailored error message when a
@@ -68,7 +68,7 @@ class TestConfluencePublisher(unittest.TestCase):
             with self.assertRaises(ConfluencePermissionError):
                 publisher.connect()
 
-    def test_publisher_handle_proxy_permission_error(self):
+    def test_publisher_connect_handle_proxy_permission_error(self):
         """validate publisher reports a proxy-permission error"""
         #
         # Verify that the publisher will report a tailored error message when a
@@ -83,7 +83,7 @@ class TestConfluencePublisher(unittest.TestCase):
             with self.assertRaises(ConfluenceProxyPermissionError):
                 publisher.connect()
 
-    def test_publisher_invalid_json(self):
+    def test_publisher_connect_invalid_json(self):
         """validate publisher can handle non-json data"""
         #
         # Verify that the initial connection event for a publisher can safely
@@ -99,7 +99,7 @@ class TestConfluencePublisher(unittest.TestCase):
             with self.assertRaises(ConfluenceBadServerUrlError):
                 publisher.connect()
 
-    def test_publisher_proxy(self):
+    def test_publisher_connect_proxy(self):
         """validate publisher can find a valid space"""
         #
         # Verify that a publisher can query a Confluence instance and cache the
@@ -166,7 +166,7 @@ class TestConfluencePublisher(unittest.TestCase):
             if 'http_proxy' in os.environ:
                 del os.environ['http_proxy']
 
-    def test_publisher_unsupported_json(self):
+    def test_publisher_connect_unsupported_json(self):
         """validate publisher can handle unexpected json data"""
         #
         # Verify that the initial connection event for a publisher provides a
@@ -211,7 +211,7 @@ class TestConfluencePublisher(unittest.TestCase):
             with self.assertRaises(ConfluenceBadServerUrlError):
                 publisher.connect()
 
-    def test_publisher_valid_space(self):
+    def test_publisher_connect_valid_space(self):
         """validate publisher can find a valid space"""
         #
         # Verify that a publisher can query a Confluence instance and cache the
@@ -235,7 +235,7 @@ class TestConfluencePublisher(unittest.TestCase):
 
             self.assertEqual(publisher.space_display_name, space_name)
 
-    def test_publisher_verify_timeout(self):
+    def test_publisher_connect_verify_timeout(self):
         """validate publisher timeout"""
         #
         # Verify that a non-served request from a publisher event will timeout.

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
+from tests.lib import mock_confluence_instance
+from tests.lib import prepare_conf
+import unittest
+
+
+class TestConfluencePublisherPage(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config = prepare_conf()
+        cls.config.confluence_timeout = 1
+
+        cls.std_space_connect_rsp = {
+            'size': 1,
+            'results': [{
+                'name': 'Mock Space',
+            }],
+        }
+
+    def test_publisher_page_store_page_id_allow_watch(self):
+        """validate publisher will store a page by id (watch)"""
+        #
+        # Verify that a publisher can update an existing page by an
+        # identifier value. Instance will be configured to watch content,
+        # so any page updates should not trigger an watch event.
+
+        config = self.config.clone()
+        config.confluence_watch = True
+
+        with mock_confluence_instance(config) as daemon:
+            daemon.register_get_rsp(200, self.std_space_connect_rsp)
+
+            publisher = ConfluencePublisher()
+            publisher.init(config)
+            publisher.connect()
+
+            # consume connect request
+            self.assertIsNotNone(daemon.pop_get_request())
+
+            # prepare response for a page id fetch
+            expected_page_id = 7456
+            mocked_version = 28
+
+            page_fetch_rsp = {
+                'id': str(expected_page_id),
+                'title': 'mock page',
+                'type': 'page',
+                'version': {
+                    'number': str(mocked_version),
+                },
+            }
+            daemon.register_get_rsp(200, page_fetch_rsp)
+
+            # prepare response for update event
+            daemon.register_put_rsp(200, dict(page_fetch_rsp))
+
+            # perform page update request
+            data = {
+                'content': 'dummy page data',
+                'labels': [],
+            }
+            page_id = publisher.store_page_by_id(
+                'dummy-name', expected_page_id, data)
+
+            # check expected page id returned
+            self.assertEqual(page_id, expected_page_id)
+
+            # check that the provided page id is set in the request
+            fetch_req = daemon.pop_get_request()
+            self.assertIsNotNone(fetch_req)
+            req_path, _ = fetch_req
+
+            expected_request = '/rest/api/content/{}?'.format(expected_page_id)
+            self.assertTrue(req_path.startswith(expected_request))
+
+            # check that an update request is processed
+            update_req = daemon.pop_put_request()
+            self.assertIsNotNone(update_req)
+
+            # verify that no other request was made
+            self.assertFalse(daemon.check_unhandled_requests())
+
+    def test_publisher_page_store_page_id_default(self):
+        """validate publisher will store a page by id (default)"""
+        #
+        # Verify that a publisher can update an existing page by an
+        # identifier value. By default, the update request will ensure
+        # the user configures to not watch the page.
+
+        with mock_confluence_instance(self.config) as daemon:
+            daemon.register_get_rsp(200, self.std_space_connect_rsp)
+
+            publisher = ConfluencePublisher()
+            publisher.init(self.config)
+            publisher.connect()
+
+            # consume connect request
+            self.assertIsNotNone(daemon.pop_get_request())
+
+            # prepare response for a page id fetch
+            expected_page_id = 4568
+            mocked_version = 45
+
+            page_fetch_rsp = {
+                'id': str(expected_page_id),
+                'title': 'mock page',
+                'type': 'page',
+                'version': {
+                    'number': str(mocked_version),
+                },
+            }
+            daemon.register_get_rsp(200, page_fetch_rsp)
+
+            # prepare response for update event
+            daemon.register_put_rsp(200, dict(page_fetch_rsp))
+
+            # prepare response for unwatch event
+            daemon.register_delete_rsp(200)
+
+            # perform page update request
+            data = {
+                'content': 'dummy page data',
+                'labels': [],
+            }
+            page_id = publisher.store_page_by_id(
+                'dummy-name', expected_page_id, data)
+
+            # check expected page id returned
+            self.assertEqual(page_id, expected_page_id)
+
+            # check that the provided page id is set in the request
+            fetch_req = daemon.pop_get_request()
+            self.assertIsNotNone(fetch_req)
+            req_path, _ = fetch_req
+
+            expected_request = '/rest/api/content/{}?'.format(expected_page_id)
+            self.assertTrue(req_path.startswith(expected_request))
+
+            # check that an update request is processed
+            update_req = daemon.pop_put_request()
+            self.assertIsNotNone(update_req)
+
+            # check that the page is unwatched
+            unwatch_req = daemon.pop_delete_request()
+            self.assertIsNotNone(unwatch_req)
+            req_path, _ = unwatch_req
+            ereq = '/rest/api/user/watch/content/{}'.format(expected_page_id)
+            self.assertEqual(req_path, ereq)
+
+            # verify that no other request was made
+            self.assertFalse(daemon.check_unhandled_requests())
+
+    def test_publisher_page_store_page_id_dryrun(self):
+        """validate publisher suppress store a page by id with dryrun"""
+        #
+        # Verify that a publisher will handle a id-page update request
+        # properly when the dryrun flag is set.
+
+        config = self.config.clone()
+        config.confluence_publish_dryrun = True
+
+        with mock_confluence_instance(config) as daemon:
+            daemon.register_get_rsp(200, self.std_space_connect_rsp)
+
+            publisher = ConfluencePublisher()
+            publisher.init(config)
+            publisher.connect()
+
+            # consume connect request
+            self.assertIsNotNone(daemon.pop_get_request())
+
+            # prepare response for a page id fetch
+            expected_page_id = 2
+
+            page_rsp = {
+                'id': expected_page_id,
+                'title': 'mock page',
+                'type': 'page',
+            }
+            daemon.register_get_rsp(200, page_rsp)
+
+            page_id = publisher.store_page_by_id(
+                'dummy-name', expected_page_id, {})
+
+            # check expected page id returned
+            self.assertEqual(page_id, expected_page_id)
+
+            # check that the provided page id is set in the request
+            fetch_req = daemon.pop_get_request()
+            self.assertIsNotNone(fetch_req)
+            req_path, _ = fetch_req
+
+            expected_request = '/rest/api/content/{}?'.format(expected_page_id)
+            self.assertTrue(req_path.startswith(expected_request))
+
+            # verify that no update request was made
+            self.assertFalse(daemon.check_unhandled_requests())


### PR DESCRIPTION
When a page is fetched by an identifier, it will cache the name directly on the returned page JSON structure. Unfortunately, the initial implementation of root page publishing feature introduced a get-page-by-id call with invalid implementation. The title value should be fetched from the page instance; correcting.

This pull request also adds some additional publisher unit tests, to help validate some of the original issued implementation.