### PR TITLE
test additional custom directives (expand; newline)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,35 +32,35 @@ jobs:
         include:
             - { os:  ubuntu-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx35, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx40, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx42, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx43, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx35, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx40, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx42, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx43, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx35, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx40, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx42, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx43, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx35, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx40, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx42, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx43, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx43, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx44, cache: ~/.cache/pip }
             - { os:   macos-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~/Library/Caches/pip }
-            - { os:   macos-latest, python: "3.10", toxenv: py310-sphinx43, cache: ~/Library/Caches/pip }
+            - { os:   macos-latest, python: "3.10", toxenv: py310-sphinx44, cache: ~/Library/Caches/pip }
             - { os: windows-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~\AppData\Local\pip\Cache }
-            - { os: windows-latest, python: "3.10", toxenv: py310-sphinx43, cache: ~\AppData\Local\pip\Cache }
+            - { os: windows-latest, python: "3.10", toxenv: py310-sphinx44, cache: ~\AppData\Local\pip\Cache }
             - { os:  ubuntu-latest, python: "3.10", toxenv:         flake8, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv:         pylint, cache: ~/.cache/pip }
 

--- a/tests/unit-tests/datasets/expand/index.rst
+++ b/tests/unit-tests/datasets/expand/index.rst
@@ -1,0 +1,11 @@
+expand
+======
+
+.. confluence_expand::
+
+    no title content
+
+.. confluence_expand::
+    :title: my title
+
+    with title content

--- a/tests/unit-tests/datasets/newline/index.rst
+++ b/tests/unit-tests/datasets/newline/index.rst
@@ -1,0 +1,8 @@
+newline
+=======
+
+line1
+
+.. confluence_newline::
+
+line2

--- a/tests/unit-tests/test_confluence_expand.py
+++ b/tests/unit-tests/test_confluence_expand.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib import build_sphinx
+from tests.lib import parse
+from tests.lib import prepare_conf
+import os
+import unittest
+
+
+class TestConfluenceExpand(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config = prepare_conf()
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        cls.dataset = os.path.join(test_dir, 'datasets', 'expand')
+
+    def test_storage_confluence_expand_directive_expected(self):
+        out_dir = build_sphinx(self.dataset, config=self.config)
+
+        with parse('index', out_dir) as data:
+            expand_macros = data.find_all('ac:structured-macro',
+                {'ac:name': 'expand'})
+            self.assertIsNotNone(expand_macros)
+            self.assertEqual(len(expand_macros), 2)
+
+            # expand macro without a title
+            expand_macro = expand_macros.pop(0)
+
+            rich_body = expand_macro.find('ac:rich-text-body')
+            self.assertIsNotNone(rich_body)
+
+            title = expand_macro.find('ac:parameter', {'ac:name': 'title'})
+            self.assertIsNone(title)
+
+            contents = rich_body.text.strip()
+            self.assertIsNotNone(contents)
+            self.assertEqual(contents, 'no title content')
+
+            # expand macro with a title
+            expand_macro = expand_macros.pop(0)
+
+            rich_body = expand_macro.find('ac:rich-text-body')
+            self.assertIsNotNone(rich_body)
+
+            title = expand_macro.find('ac:parameter', {'ac:name': 'title'})
+            self.assertIsNotNone(title)
+            self.assertEqual(title.text, 'my title')
+
+            contents = rich_body.text.strip()
+            self.assertIsNotNone(contents)
+            self.assertEqual(contents, 'with title content')

--- a/tests/unit-tests/test_confluence_newline.py
+++ b/tests/unit-tests/test_confluence_newline.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib import build_sphinx
+from tests.lib import parse
+from tests.lib import prepare_conf
+import os
+import unittest
+
+
+class TestConfluenceNewline(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config = prepare_conf()
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        cls.dataset = os.path.join(test_dir, 'datasets', 'newline')
+
+    def test_storage_confluence_newline_directive_expected(self):
+        out_dir = build_sphinx(self.dataset, config=self.config)
+
+        with parse('index', out_dir) as data:
+            # expect three tags | p, br, p
+            tags = data.find_all()
+            self.assertEqual(len(tags), 3)
+
+            para = tags[0]
+            self.assertEqual(para.name, 'p')
+            self.assertEqual(para.text, 'line1')
+
+            para = tags[1]
+            self.assertEqual(para.name, 'br')
+
+            para = tags[2]
+            self.assertEqual(para.name, 'p')
+            self.assertEqual(para.text, 'line2')

--- a/tox.ini
+++ b/tox.ini
@@ -3,20 +3,19 @@ envlist =
     flake8
     pylint
     py{27,36,37,38,39,310}-sphinx{18}
-    py{36,37,38,39}-sphinx{35,40,41,42,43}
-    py{310}-sphinx{42,43}
+    py{36,37,38,39}-sphinx{40,41,42,43,44}
+    py{310}-sphinx{42,43,44}
 
 [testenv]
 deps =
     -r{toxinidir}/requirements_dev.txt
     sphinx18: docutils<0.18
     sphinx18: sphinx>=1.8,<2.0
-    sphinx35: docutils<0.18
-    sphinx35: sphinx>=3.5,<3.6
     sphinx40: sphinx>=4.0,<4.1
     sphinx41: sphinx>=4.1,<4.2
     sphinx42: sphinx>=4.2,<4.3
     sphinx43: sphinx>=4.3,<4.4
+    sphinx44: sphinx>=4.4,<4.5
 commands =
     {envpython} -m tests {posargs}
 setenv =


### PR DESCRIPTION
### tests: newline directive testing

Adding a unit test to sanity check support for the `confluence_newline` directive.

### tests: expand directive testing

Adding a unit test to sanity check support for the `confluence_expand` directive.

### tox: adjust for new sphinx versions (v4.4.x)

Sphinx provides a stable v4.4.x series; adjusting the tox configuration to support the new revision. Following maintenance guidelines, this allows a series of legacy Sphinx revisions to be dropped as well.
