### PR TITLE
Support jira substitutions

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -771,7 +771,7 @@ class ConfluenceBuilder(Builder):
 
         for node in doctree.traverse(confluence_metadata):
             labels = metadata.setdefault('labels', [])
-            labels.extend(node['params']['labels'])
+            labels.extend(node.params['labels'])
             node.parent.remove(node)
 
     def _find_title_element(self, doctree):

--- a/sphinxcontrib/confluencebuilder/directives.py
+++ b/sphinxcontrib/confluencebuilder/directives.py
@@ -65,10 +65,9 @@ class ConfluenceMetadataDirective(Directive):
 
     def run(self):
         node = confluence_metadata()
-        params = node.setdefault('params', {})
 
         for k, v in self.options.items():
-            params[kebab_case_to_camel_case(k)] = v
+            node.params[kebab_case_to_camel_case(k)] = v
 
         return [node]
 

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -7,7 +7,28 @@
 from docutils import nodes
 
 
-class confluence_expand(nodes.Element):
+class ConfluenceParams(nodes.Element):
+    """
+    confluence parameter-holding node
+
+    A utility node class which helps setup tracking "parameters" entries inside
+    a Element's attribute list, which can be forwarded to parameter entries
+    for Confluence macro building.
+
+    Args:
+        rawsource: raw text from which this element was constructed
+        *children: list of child nodes
+        **attributes: dictionary of attribute to apply to the element
+
+    Attributes:
+        params: the tracked confluence parameters
+    """
+    def __init__(self, rawsource='', *children, **attributes):
+        nodes.Element.__init__(self, rawsource, *children, **attributes)
+        self.params = self.attributes.setdefault('confluence-params', {})
+
+
+class confluence_expand(nodes.Body, nodes.Element):
     """
     confluence expand node
 
@@ -16,7 +37,7 @@ class confluence_expand(nodes.Element):
     """
 
 
-class confluence_footer(nodes.General, nodes.Element):
+class confluence_footer(nodes.Decorative, nodes.Element):
     """
     confluence footer node
 
@@ -26,7 +47,7 @@ class confluence_footer(nodes.General, nodes.Element):
     """
 
 
-class confluence_header(nodes.General, nodes.Element):
+class confluence_header(nodes.Decorative, nodes.Element):
     """
     confluence header node
 
@@ -36,7 +57,7 @@ class confluence_header(nodes.General, nodes.Element):
     """
 
 
-class confluence_metadata(nodes.Element):
+class confluence_metadata(nodes.Invisible, nodes.Special, ConfluenceParams):
     """
     confluence metadata node
 
@@ -45,7 +66,7 @@ class confluence_metadata(nodes.Element):
     """
 
 
-class confluence_newline(nodes.Element):
+class confluence_newline(nodes.Structural, nodes.Element):
     """
     confluence newline node
 
@@ -65,62 +86,29 @@ class confluence_page_generation_notice(nodes.TextElement):
     """
 
 
-class confluence_source_link(nodes.Element, nodes.Structural):
+class confluence_source_link(nodes.Structural, ConfluenceParams):
     """
     confluence source link node
 
     Provides a source link node to hint at the creation of a reference which
     points to a generation document's original source document (or source
     location).
-
-    Args:
-        rawsource: raw text from which this element was constructed
-        *children: list of child nodes
-        **attributes: dictionary of attribute to apply to the element
-
-    Attributes:
-        params: dictionary of parameters to configure the node
     """
-    def __init__(self, rawsource='', *children, **attributes):
-        nodes.Element.__init__(self, rawsource, *children, **attributes)
-        self.params = {}
 
 
-class jira(nodes.Element, nodes.Structural):
+class jira(nodes.Inline, ConfluenceParams):
     """
     jira (query) node
 
     Defines a "JIRA" node to represent a Confluence JIRA macro configured to
     display a prepared JQL query.
-
-    Args:
-        rawsource: raw text from which this element was constructed
-        *children: list of child nodes
-        **attributes: dictionary of attribute to apply to the element
-
-    Attributes:
-        params: dictionary of parameters to pass into a jira macro
     """
-    def __init__(self, rawsource='', *children, **attributes):
-        nodes.Element.__init__(self, rawsource, *children, **attributes)
-        self.params = {}
 
 
-class jira_issue(nodes.Element, nodes.Structural):
+class jira_issue(nodes.Inline, ConfluenceParams):
     """
     jira (single) issue node
 
     Defines a "JIRA" node to represent a Confluence JIRA macro configured to
     display a single JIRA issue.
-
-    Args:
-        rawsource: raw text from which this element was constructed
-        *children: list of child nodes
-        **attributes: dictionary of attribute to apply to the element
-
-    Attributes:
-        params: dictionary of parameters to pass into a jira macro
     """
-    def __init__(self, rawsource='', *children, **attributes):
-        nodes.Element.__init__(self, rawsource, *children, **attributes)
-        self.params = {}

--- a/tests/unit-tests/datasets/jira/valid-substitution/index.rst
+++ b/tests/unit-tests/datasets/jira/valid-substitution/index.rst
@@ -1,0 +1,25 @@
+:orphan:
+
+jira
+----
+
+.. substitution for single jira issue
+
+.. |TEST-1| jira_issue:: TEST-1
+
+|TEST-1|
+
+.. substitution for jira search
+
+.. |MY_JIRA_LIST| jira:: project = "TESTPRJ"
+    :columns: key,summary,status,resolution
+    :count: false
+    :maximum-issues: 8
+
+|MY_JIRA_LIST|
+
+.. substitution for jira role
+
+.. |TEST-2| replace:: :jira:`TEST-2`
+
+|TEST-2|

--- a/tests/unit-tests/test_confluence_jira.py
+++ b/tests/unit-tests/test_confluence_jira.py
@@ -135,7 +135,7 @@ class TestConfluenceJira(unittest.TestCase):
         # build attempt should not throw an exception/error
         build_sphinx(dataset, **opts)
 
-    def test_storage_confluence_jira_role_expected(self):
+    def test_storage_confluence_jira_role_default_expected(self):
         dataset = os.path.join(self.container, 'valid-role')
 
         out_dir = build_sphinx(dataset, config=self.config)
@@ -154,3 +154,48 @@ class TestConfluenceJira(unittest.TestCase):
             summary = macro.find('ac:parameter', {'ac:name': 'showSummary'})
             self.assertIsNotNone(summary)
             self.assertEqual(summary.text, 'false')
+
+    def test_storage_confluence_jira_substitution_expected(self):
+        dataset = os.path.join(self.container, 'valid-substitution')
+
+        out_dir = build_sphinx(dataset, config=self.config)
+
+        with parse('index', out_dir) as data:
+            jira_macros = data.find_all('ac:structured-macro',
+                {'ac:name': 'jira'})
+            self.assertIsNotNone(jira_macros)
+            self.assertEqual(len(jira_macros), 3)
+
+            # jira_issue substitution
+            jira_macro = jira_macros.pop(0)
+
+            key = jira_macro.find('ac:parameter', {'ac:name': 'key'})
+            self.assertIsNotNone(key)
+            self.assertEqual(key.text, 'TEST-1')
+
+            # jira substitution
+            jira_macro = jira_macros.pop(0)
+
+            cols = jira_macro.find('ac:parameter', {'ac:name': 'columns'})
+            self.assertIsNotNone(cols)
+            self.assertEqual(cols.text, 'key,summary,status,resolution')
+
+            count = jira_macro.find('ac:parameter', {'ac:name': 'count'})
+            self.assertIsNotNone(count)
+            self.assertEqual(count.text, 'false')
+
+            jql = jira_macro.find('ac:parameter', {'ac:name': 'jqlQuery'})
+            self.assertIsNotNone(jql)
+            self.assertEqual(jql.text, 'project = "TESTPRJ"')
+
+            max_issues = jira_macro.find(
+                'ac:parameter', {'ac:name': 'maximumIssues'})
+            self.assertIsNotNone(max_issues)
+            self.assertEqual(max_issues.text, '8')
+
+            # jira (role) substitution
+            jira_macro = jira_macros.pop(0)
+
+            key = jira_macro.find('ac:parameter', {'ac:name': 'key'})
+            self.assertIsNotNone(key)
+            self.assertEqual(key.text, 'TEST-2')


### PR DESCRIPTION
Adjusts a series of custom node types to inherit from more proper definitions. When attempting to perform JIRA directive substitutions, it was observed that the substitution declarations were not considered valid. One of the main reasons for this is that substitutions only work on inlined nodes, which neither JIRA node type inherited from. Consulting the docutils documentation on elements \[1\], nodes have been updated to inherit from more appropriate types.

While JIRA nodes are marked as inline now, another issue with their definitions is that the internal `params` attribute would not be properly copied when needed -- specifically, when substitutions are at play. To improve support in tracking Confluence-specific parameter key-value pairs (for macro parameter injection), this information will now be stored inside a Element node's attributes dictionary. The `attributes` attribute is properly managed/copied when needed, which should ensure Confluence-specific parameters will be copied as well. This will be managed inside a new `ConfluenceParams` node type, which JIRA nodes (as well as the source-link node) can inherit from.

\[1\]: https://docutils.sourceforge.io/docs/ref/doctree.html