### PR TITLE
storage-translator: remove information macro from figure structure

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :copyright: Copyright 2018-2020 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1349,27 +1349,17 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self.context.pop())  # p
 
     def visit_figure(self, node):
-        if self.can_admonition:
-            self.body.append(self._start_ac_macro(node, 'info'))
-            self.body.append(self._build_ac_param(node, 'icon', 'false'))
-            self.body.append(self._start_ac_rich_text_body_macro(node))
-            self.context.append(self._end_ac_rich_text_body_macro(node) +
-                self._end_ac_macro(node))
-        else:
-            self.body.append(self._start_tag(
-                node, 'hr', suffix=self.nl, empty=True))
-            self.body.append(self._start_tag(node, 'div'))
-            self.context.append(self._end_tag(node) + self._start_tag(
-                node, 'hr', suffix=self.nl, empty=True))
+        self.body.append(self._start_tag(node, 'p'))
+        self.context.append(self._end_tag(node))
 
     def depart_figure(self, node):
+        self.body.append(self.context.pop())  # p
+
         # force clear from a floating confluence image if not handled in caption
         if self._figure_context:
             self._figure_context.pop()
         else:
             self.body.append('<div style="clear: both"> </div>\n')
-
-        self.body.append(self.context.pop())  # <dynamic>
 
     def visit_image(self, node):
         if 'uri' not in node or not node['uri']:

--- a/tests/unit-tests/test_rst_figure.py
+++ b/tests/unit-tests/test_rst_figure.py
@@ -27,24 +27,15 @@ class TestConfluenceRstFigure(unittest.TestCase):
             filenames=self.filenames)
 
         with parse('figure', out_dir) as data:
-            figures = data.find_all('ac:structured-macro',
-                {'ac:name': 'info'}, recursive=False)
+            figures = data.find_all('p', recursive=False)
             self.assertEqual(len(figures), 5)
-
-            for figure in figures:
-                icon_param = figure.find('ac:parameter',
-                    {'ac:name': 'icon'}, recursive=False)
-                self.assertIsNotNone(icon_param)
-                self.assertEqual(icon_param.text, 'false')
 
             # ##########################################################
             # external image (default align; no caption)
             # ##########################################################
             figure = figures.pop(0)
-            figure_body = figure.find('ac:rich-text-body', recursive=False)
-            self.assertIsNotNone(figure_body)
 
-            image = figure_body.find('ac:image', recursive=False)
+            image = figure.find('ac:image', recursive=False)
             self.assertIsNotNone(image)
 
             self.assertTrue(image.has_attr('ac:alt'))
@@ -63,10 +54,8 @@ class TestConfluenceRstFigure(unittest.TestCase):
             # external image (default align)
             # ##########################################################
             figure = figures.pop(0)
-            figure_body = figure.find('ac:rich-text-body', recursive=False)
-            self.assertIsNotNone(figure_body)
 
-            image = figure_body.find('ac:image', recursive=False)
+            image = figure.find('ac:image', recursive=False)
             self.assertIsNotNone(image)
 
             self.assertFalse(image.has_attr('ac:alt'))
@@ -76,11 +65,11 @@ class TestConfluenceRstFigure(unittest.TestCase):
             self.assertEqual(url['ri:value'],
                 'https://www.example.org/image.png')
 
-            caption = figure_body.find('p', recursive=False)
+            caption = figure.find('p', recursive=False)
             self.assertIsNotNone(caption)
             self.assertIsNotNone(caption.text, 'caption 2')
 
-            legend = figure_body.find('div', recursive=False)
+            legend = figure.find('div', recursive=False)
             self.assertIsNotNone(legend)
             self.assertIsNotNone(legend.text, 'legend 2')
 
@@ -100,10 +89,8 @@ class TestConfluenceRstFigure(unittest.TestCase):
             # external image (left align)
             # ##########################################################
             figure = figures.pop(0)
-            figure_body = figure.find('ac:rich-text-body', recursive=False)
-            self.assertIsNotNone(figure_body)
 
-            image = figure_body.find('ac:image', recursive=False)
+            image = figure.find('ac:image', recursive=False)
             self.assertIsNotNone(image)
 
             self.assertTrue(image.has_attr('ac:align'))
@@ -111,11 +98,11 @@ class TestConfluenceRstFigure(unittest.TestCase):
             self.assertTrue(image.has_attr('ac:alt'))
             self.assertEqual(image['ac:alt'], 'alt text')
 
-            caption = figure_body.find('p', recursive=False)
+            caption = figure.find('p', recursive=False)
             self.assertIsNotNone(caption)
             self.assertIsNotNone(caption.text, 'caption 3')
 
-            legend = figure_body.find('div', recursive=False)
+            legend = figure.find('div', recursive=False)
             self.assertIsNotNone(legend)
             self.assertIsNotNone(legend.text, 'legend 3')
 
@@ -123,10 +110,8 @@ class TestConfluenceRstFigure(unittest.TestCase):
             # internal image (center align)
             # ##########################################################
             figure = figures.pop(0)
-            figure_body = figure.find('ac:rich-text-body', recursive=False)
-            self.assertIsNotNone(figure_body)
 
-            image = figure_body.find('ac:image', recursive=False)
+            image = figure.find('ac:image', recursive=False)
             self.assertIsNotNone(image)
 
             self.assertTrue(image.has_attr('ac:align'))
@@ -136,13 +121,13 @@ class TestConfluenceRstFigure(unittest.TestCase):
             self.assertTrue(attachment.has_attr('ri:filename'))
             self.assertEqual(attachment['ri:filename'], 'image02.png')
 
-            caption = figure_body.find('p', recursive=False)
+            caption = figure.find('p', recursive=False)
             self.assertIsNotNone(caption)
             self.assertIsNotNone(caption.text, 'caption 4')
             self.assertTrue(caption.has_attr('style'))
             self.assertTrue('text-align: center' in caption['style'])
 
-            legend = figure_body.find('div', recursive=False)
+            legend = figure.find('div', recursive=False)
             self.assertIsNotNone(legend)
             self.assertIsNotNone(legend.text, 'legend 4')
             self.assertTrue(legend.has_attr('style'))
@@ -152,10 +137,8 @@ class TestConfluenceRstFigure(unittest.TestCase):
             # internal image (right align)
             # ##########################################################
             figure = figures.pop(0)
-            figure_body = figure.find('ac:rich-text-body', recursive=False)
-            self.assertIsNotNone(figure_body)
 
-            image = figure_body.find('ac:image', recursive=False)
+            image = figure.find('ac:image', recursive=False)
             self.assertIsNotNone(image)
 
             self.assertTrue(image.has_attr('ac:align'))
@@ -165,13 +148,13 @@ class TestConfluenceRstFigure(unittest.TestCase):
             self.assertTrue(attachment.has_attr('ri:filename'))
             self.assertEqual(attachment['ri:filename'], 'image02.png')
 
-            caption = figure_body.find('p', recursive=False)
+            caption = figure.find('p', recursive=False)
             self.assertIsNotNone(caption)
             self.assertIsNotNone(caption.text, 'caption 5')
             self.assertTrue(caption.has_attr('style'))
             self.assertTrue('text-align: right' in caption['style'])
 
-            legend = figure_body.find('div', recursive=False)
+            legend = figure.find('div', recursive=False)
             self.assertIsNotNone(legend)
             self.assertIsNotNone(legend.text, 'legend 5')
             self.assertTrue(legend.has_attr('style'))
@@ -184,6 +167,9 @@ class TestConfluenceRstFigure(unittest.TestCase):
             images = data.find_all('ac:image')
             for image in images:
                 next_tag = image.find_next_sibling()
+                if not next_tag:
+                    next_tag = image.parent.find_next_sibling()
+
                 self.assertIsNotNone(next_tag)
                 self.assertTrue(next_tag.has_attr('style'))
                 self.assertTrue('clear: both' in next_tag['style'])

--- a/tests/unit-tests/test_rst_figure.py
+++ b/tests/unit-tests/test_rst_figure.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 


### PR DESCRIPTION
The original implementation added to support figures would wrap the contents inside an informational macro. This was a styling preference at the time (to produce a shaded background); however, it is not consistent with how figures are generated with other builds (like HTML). Adjusting the figure implementation to do what is common -- a simple paragraph grouping on the figure structure.