### PR TITLE
tests: improve the delay when building a mock confluence instance

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -15,6 +15,7 @@ from sphinx.util.console import nocolor
 from sphinx.util.docutils import docutils_namespace
 from sphinxcontrib.confluencebuilder import compat
 from sphinxcontrib.confluencebuilder import util
+from threading import Event
 from threading import Thread
 import inspect
 import json
@@ -334,14 +335,20 @@ def mock_confluence_instance(config=None, ignore_requests=False):
 
         # start accepting requests
         if not ignore_requests:
-            def serve_forever(daemon):
+            sync = Event()
+
+            def serve_forever(daemon, sync):
+                sync.set()
                 daemon.serve_forever()
 
-            serve_thread = Thread(target=serve_forever, args=(daemon,))
+            serve_thread = Thread(target=serve_forever, args=(daemon, sync,))
             serve_thread.start()
 
-        # yeild context for a moment to help threads to ready up
-        time.sleep(0)
+            # wait for the serving thread to be running
+            sync.wait()
+
+            # yeild context for a moment to help ensure the daemon is serving
+            time.sleep(0.1)
 
         yield daemon
 


### PR DESCRIPTION
It has been observed in some cases where attempting to mock a Confluence instance, the testing implementation may fail to connect to the instance with a connection reset event. The original implementation would attempt to yield the context by sleeping with a zero count; however, this does not ensure that the HTTP serving thread is ready set. To improve the chance that the test HTTP server is ready, first wait on the thread being started by synchronizing an `Event` type between the serving thread and the testing context. After confirming the thread is running, yield the context a bit to improve the chance of a `serve_forever` invoke to be ready.