### PR TITLE
maintenance (2022-01-29)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,12 +31,6 @@ jobs:
       matrix:
         include:
             - { os:  ubuntu-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx40, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx41, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx42, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx43, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.6", toxenv:  py36-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx18, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx40, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx41, cache: ~/.cache/pip }

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Development
+===========
+
+* fixed issue where jira directives/role could not be substituted
+* improve support when using the sphinx-diagrams extension
+* removed informational macro styling on figures
+
 1.7.1 (2021-11-30)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ optionally publish them to a Confluence instance.
 Requirements
 ============
 
-* Python_ 2.7 or 3.6+
+* Python_ 2.7 or 3.7+
 * Requests_ 2.14.0+
 * Sphinx_ 1.8 or 3.5+
 

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Requirements
 
 If publishing:
 
-* Confluence_ Cloud or Data Center / Server 7.2+
+* Confluence_ Cloud or Data Center / Server 7.3+
 
 Installing
 ==========

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Requirements
 
 * Python_ 2.7 or 3.7+
 * Requests_ 2.14.0+
-* Sphinx_ 1.8 or 3.5+
+* Sphinx_ 1.8 or 4.0+
 
 If publishing:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,7 @@ release = sphinxcontrib.confluencebuilder.__version__
 
 supported_confluence_ver = '7.3+'
 supported_python_ver = '2.7 or 3.7+'
-supported_sphinx_ver = '1.8 or 3.5+'
+supported_sphinx_ver = '1.8 or 4.0+'
 
 root_doc = 'contents'
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
@@ -9,7 +9,7 @@ from sphinx.transforms.post_transforms import SphinxPostTransform
 import sphinxcontrib.confluencebuilder
 
 project = 'Sphinx Confluence Builder'
-copyright = '2021 Sphinx Confluence Builder Contributors'
+copyright = '2022 Sphinx Confluence Builder Contributors'
 author = 'Sphinx Confluence Builder Contributors'
 version = sphinxcontrib.confluencebuilder.__version__
 release = sphinxcontrib.confluencebuilder.__version__

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,7 @@ version = sphinxcontrib.confluencebuilder.__version__
 release = sphinxcontrib.confluencebuilder.__version__
 
 supported_confluence_ver = '7.3+'
-supported_python_ver = '2.7 or 3.6+'
+supported_python_ver = '2.7 or 3.7+'
 supported_sphinx_ver = '1.8 or 3.5+'
 
 root_doc = 'contents'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,7 @@ author = 'Sphinx Confluence Builder Contributors'
 version = sphinxcontrib.confluencebuilder.__version__
 release = sphinxcontrib.confluencebuilder.__version__
 
-supported_confluence_ver = '7.2+'
+supported_confluence_ver = '7.3+'
 supported_python_ver = '2.7 or 3.6+'
 supported_sphinx_ver = '1.8 or 3.5+'
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     pylint
-    py{27,36,37,38,39,310}-sphinx{18}
-    py{36,37,38,39}-sphinx{40,41,42,43,44}
+    py{27,37,38,39,310}-sphinx{18}
+    py{37,38,39}-sphinx{40,41,42,43,44}
     py{310}-sphinx{42,43,44}
 
 [testenv]
@@ -38,12 +38,12 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 pip_pre = true
 
-[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-,py311-}interactive]
+[testenv:{,py27-,py37-,py38-,py39-,py310-,py311-}interactive]
 commands =
     {envpython} -m sphinxcontrib.confluencebuilder {posargs}
 passenv = *
 
-[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-,py311-}prerelease]
+[testenv:{,py27-,py37-,py38-,py39-,py310-,py311-}prerelease]
 pip_pre = true
 
 [testenv:flake8]
@@ -67,14 +67,14 @@ commands =
     tests \
     setup.py
 
-[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-,py311-}sandbox]
+[testenv:{,py27-,py37-,py38-,py39-,py310-,py311-}sandbox]
 deps =
     -r{toxinidir}/sandbox/requirements.txt
 commands =
     {envpython} -m tests.test_sandbox {posargs}
 passenv = *
 
-[testenv:{,py27-,py36-,py37-,py38-,py39-,py310-,py311-}validation]
+[testenv:{,py27-,py37-,py38-,py39-,py310-,py311-}validation]
 deps = 
     {[testenv]deps}
     -r{toxinidir}/requirements_validation.txt


### PR DESCRIPTION
Performing a series of maintenance changes:

- Updating supported Python versions (dropped EOL v3.6).
- Updating supported Confluence versions (dropped EOL versions).
- Updating supported for Sphinx versions.
- Updating CHANGELOG.
- Copyright bump on the documentation.