### PR TITLE
tests: introduce confluence test case class

### DIFF
--- a/tests/lib/testcase.py
+++ b/tests/lib/testcase.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from functools import wraps
+from tests.lib import build_sphinx
+from tests.lib import prepare_conf
+from tests.lib import prepare_sphinx
+import os
+import unittest
+
+# default builder to test against
+DEFAULT_BUILDER = 'confluence'
+
+
+class ConfluenceTestCase(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        """
+        confluence test case
+
+        Provides a test case for unit testing which includes helper calls to
+        build/prepare Sphinx environments and helps managing parsing. Unit
+        tests can take advantage of available decorators to help configure
+        their setups.
+
+        For example:
+
+            @setup_builder('confluence')
+            def test_storage_example(self):
+                out_dir = self.build(self.dataset)
+
+                ...
+        """
+
+        super(ConfluenceTestCase, self).__init__(*args, **kwargs)
+
+        self.builder = DEFAULT_BUILDER
+
+    @classmethod
+    def setUpClass(cls):
+        # always prepare a dummy configuration a unit test could use
+        cls.config = prepare_conf()
+
+        # provide a reference to common directories
+        lib_dir = os.path.dirname(os.path.realpath(__file__))
+        tests_dir = os.path.join(lib_dir, os.pardir)
+        unit_tests_dir = os.path.join(tests_dir, 'unit-tests')
+
+        cls.assets_dir = os.path.join(unit_tests_dir, 'assets')
+        cls.datasets = os.path.join(unit_tests_dir, 'datasets')
+        cls.templates_dir = os.path.join(unit_tests_dir, 'templates')
+
+    def build(self, *args, **kwargs):
+        """
+        helper to invoke `build_sphinx` with decorator configured options
+
+        Args:
+            *args: argument values to forward
+            **kwargs: kw-argument values to forward
+        """
+
+        new_kwargs = dict(kwargs)
+        new_kwargs.setdefault('builder', self.builder)
+        new_kwargs.setdefault('config', self.config)
+
+        return build_sphinx(*args, **new_kwargs)
+
+    def prepare(self, *args, **kwargs):
+        """
+        helper to invoke `prepare_sphinx` with decorator configured options
+
+        Args:
+            *args: argument values to forward
+            **kwargs: kw-argument values to forward
+        """
+
+        new_kwargs = dict(kwargs)
+        new_kwargs.setdefault('builder', self.builder)
+        new_kwargs.setdefault('config', self.config)
+
+        return prepare_sphinx(*args, **new_kwargs)
+
+
+def setup_builder(builder):
+    """
+    prepare a confluence unit test for a specific builder configuration
+
+    A utility "decorator" to help setup builder options for a unit test. This
+    avoids the need to explicitly configure a builder options directly in a
+    build/prepare call for a unit test testing against a dataset.
+
+    Args:
+        builder: the builder to use
+    """
+
+    def _decorator(func):
+        @wraps(func)
+        def _wrapper(self, *args, **kwargs):
+            self.builder = builder
+
+            return func(self, *args, **kwargs)
+        return _wrapper
+    return _decorator

--- a/tests/unit-tests/test_config_header_footer.py
+++ b/tests/unit-tests/test_config_header_footer.py
@@ -1,35 +1,34 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceConfigHeaderFooter(unittest.TestCase):
+class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
-        cls.template_dir = os.path.join(test_dir, 'templates')
+        super(TestConfluenceConfigHeaderFooter, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'header-footer',
         ]
 
+    @setup_builder('confluence')
     def test_storage_config_headerfooter_absolute(self):
         config = dict(self.config)
-        footer_tpl = os.path.join(self.template_dir, 'sample-footer.tpl')
-        header_tpl = os.path.join(self.template_dir, 'sample-header.tpl')
+        footer_tpl = os.path.join(self.templates_dir, 'sample-footer.tpl')
+        header_tpl = os.path.join(self.templates_dir, 'sample-header.tpl')
         config['confluence_footer_file'] = footer_tpl
         config['confluence_header_file'] = header_tpl
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('header-footer', out_dir) as data:
@@ -43,12 +42,13 @@ class TestConfluenceConfigHeaderFooter(unittest.TestCase):
             footer_data = body.nextSibling.strip()
             self.assertEqual(footer_data, 'footer content')
 
+    @setup_builder('confluence')
     def test_storage_config_headerfooter_relative(self):
         config = dict(self.config)
         config['confluence_footer_file'] = '../../templates/sample-footer.tpl'
         config['confluence_header_file'] = '../../templates/sample-header.tpl'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('header-footer', out_dir) as data:

--- a/tests/unit-tests/test_config_hierarchy.py
+++ b/tests/unit-tests/test_config_hierarchy.py
@@ -1,30 +1,29 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
 import re
-import unittest
 
 
-class TestConfluenceConfigPrevNext(unittest.TestCase):
+class TestConfluenceConfigPrevNext(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
+        super(TestConfluenceConfigPrevNext, cls).setUpClass()
+
         cls.config['confluence_max_doc_depth'] = 1
         cls.config['confluence_page_hierarchy'] = True
 
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'hierarchy')
+        cls.dataset = os.path.join(cls.datasets, 'hierarchy')
 
     def test_config_hierarchy_max_depth(self):
-        out_dir = build_sphinx(self.dataset, config=self.config, relax=True)
+        out_dir = self.build(self.dataset, relax=True)
 
         index = os.path.join(out_dir, 'index.conf')
         self.assertTrue(os.path.exists(index),
@@ -44,7 +43,7 @@ class TestConfluenceConfigPrevNext(unittest.TestCase):
 
     def test_config_hierarchy_parent_registration(self):
         ConfluenceState.reset()
-        build_sphinx(self.dataset, config=self.config, relax=True)
+        self.build(self.dataset, relax=True)
 
         # root toctree should not have a parent
         root_doc = ConfluenceState.parent_docname('index')
@@ -63,8 +62,9 @@ class TestConfluenceConfigPrevNext(unittest.TestCase):
         parent_doc = ConfluenceState.parent_docname('toctree-doc2a')
         self.assertEqual(parent_doc, 'toctree-doc2')
 
+    @setup_builder('confluence')
     def test_storage_config_hierarchy_max_depth(self):
-        out_dir = build_sphinx(self.dataset, config=self.config, relax=True)
+        out_dir = self.build(self.dataset, relax=True)
 
         # ensure data is merged in when capping the depth
         doc2_expected_headers = [

--- a/tests/unit-tests/test_config_prev_next.py
+++ b/tests/unit-tests/test_config_prev_next.py
@@ -1,29 +1,27 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
 from __future__ import unicode_literals
-from tests.lib import build_sphinx
-from tests.lib import prepare_conf
+from tests.lib.testcase import ConfluenceTestCase
 import io
 import os
-import unittest
 
 
-class TestConfluenceConfigPrevNext(unittest.TestCase):
+class TestConfluenceConfigPrevNext(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'prevnext')
+        super(TestConfluenceConfigPrevNext, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'prevnext')
 
     def test_config_prevnext_bottom(self):
         config = dict(self.config)
         config['confluence_prev_next_buttons_location'] = 'bottom'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         self._character_check('index',  out_dir, {'←': 0, '→': 1})
         self._character_check('middle', out_dir, {'←': 1, '→': 1})
@@ -33,7 +31,7 @@ class TestConfluenceConfigPrevNext(unittest.TestCase):
         config = dict(self.config)
         config['confluence_prev_next_buttons_location'] = 'both'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         self._character_check('index',  out_dir, {'←': 0, '→': 2})
         self._character_check('middle', out_dir, {'←': 2, '→': 2})
@@ -43,7 +41,7 @@ class TestConfluenceConfigPrevNext(unittest.TestCase):
         config = dict(self.config)
         config['confluence_prev_next_buttons_location'] = None
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         self._character_check('index',  out_dir, {'←': 0, '→': 0})
         self._character_check('middle', out_dir, {'←': 0, '→': 0})
@@ -53,7 +51,7 @@ class TestConfluenceConfigPrevNext(unittest.TestCase):
         config = dict(self.config)
         config['confluence_prev_next_buttons_location'] = 'top'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         self._character_check('index',  out_dir, {'←': 0, '→': 1})
         self._character_check('middle', out_dir, {'←': 1, '→': 1})

--- a/tests/unit-tests/test_config_sourcelink.py
+++ b/tests/unit-tests/test_config_sourcelink.py
@@ -1,23 +1,23 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceConfigSourceLink(unittest.TestCase):
+class TestConfluenceConfigSourceLink(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'minimal')
+        super(TestConfluenceConfigSourceLink, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'minimal')
+
+    @setup_builder('confluence')
     def test_storage_sourcelink_custom_text(self):
         """validate sourcelink can handle custom options (storage)"""
         #
@@ -30,13 +30,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
             'url': 'dummy',
         }
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             text = a_tag.find(string=True, recursive=False)
             self.assertEqual(text, 'custom text')
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_custom_url(self):
         """validate sourcelink can handle custom options (storage)"""
         #
@@ -50,13 +51,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
             'version': 'v8',
         }
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], 'ftp://example.com/test-docs/v8')
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_docvalues(self):
         """validate sourcelink is given page/suffix values (storage)"""
         #
@@ -68,13 +70,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
             'url': '{page}{suffix}',
         }
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], 'index.rst')
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_simple(self):
         """validate sourcelink can accept a simple url value (storage)"""
         #
@@ -86,13 +89,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
             'url': 'https://git.example.net/mydocs',
         }
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], 'https://git.example.net/mydocs')
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_template_bitbucket_default(self):
         """validate sourcelink bitbucket default options (storage)"""
         #
@@ -110,13 +114,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
 
         expected = 'https://bitbucket.org/example-owner/example-prj/src/v1.0/subfolder/index.rst?mode=view'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], expected)
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_template_bitbucket_edit_mode(self):
         """validate sourcelink bitbucket edit-mode (storage)"""
         #
@@ -135,13 +140,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
 
         expected = 'https://bitbucket.org/example-owner/example-prj2/src/main/doc/index.rst?mode=edit'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], expected)
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_template_bitbucket_host_protocol(self):
         """validate sourcelink bitbucket custom host (storage)"""
         #
@@ -160,13 +166,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
 
         expected = 'http://example.com/owner/prj-q/src/feature-one/index.rst?mode=view'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], expected)
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_template_github_default(self):
         """validate sourcelink github default options (storage)"""
         #
@@ -184,13 +191,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
 
         expected = 'https://github.com/example-owner/example-prj/blob/v1.0/Documentation/index.rst'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], expected)
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_template_github_edit_mode(self):
         """validate sourcelink github edit-mode (storage)"""
         #
@@ -209,13 +217,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
 
         expected = 'https://github.com/example-owner/example-prj2/edit/main/doc/index.rst'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], expected)
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_template_github_host_protocol(self):
         """validate sourcelink github custom host (storage)"""
         #
@@ -235,13 +244,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
 
         expected = 'http://example.com/owner/prj/blob/bugfix/alpha/docs/index.rst'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], expected)
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_template_gitlab_default(self):
         """validate sourcelink gitlab default options (storage)"""
         #
@@ -259,13 +269,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
 
         expected = 'https://gitlab.com/example-owner/prj3/blob/2-7/Documentation/index.rst'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], expected)
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_template_gitlab_edit_mode(self):
         """validate sourcelink gitlab edit-mode (storage)"""
         #
@@ -283,13 +294,14 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
 
         expected = 'https://gitlab.com/my-owner/my-project/edit/master/index.rst'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')
             self.assertTrue(a_tag.has_attr('href'))
             self.assertEqual(a_tag['href'], expected)
 
+    @setup_builder('confluence')
     def test_storage_sourcelink_template_gitlab_host_protocol(self):
         """validate sourcelink gitlab custom host (storage)"""
         #
@@ -309,7 +321,7 @@ class TestConfluenceConfigSourceLink(unittest.TestCase):
 
         expected = 'http://example.net/owner4/prj/blob/bugfix/beta/docs/index.rst'
 
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             a_tag = data.find('a')

--- a/tests/unit-tests/test_config_titlefix.py
+++ b/tests/unit-tests/test_config_titlefix.py
@@ -1,31 +1,30 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceConfigTitlefix(unittest.TestCase):
+class TestConfluenceConfigTitlefix(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
+        super(TestConfluenceConfigTitlefix, cls).setUpClass()
+
         cls.config['root_doc'] = 'titlefix'
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'titlefix',
             'titlefix-child',
         ]
 
+    @setup_builder('confluence')
     def test_storage_config_titlefix_none(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('titlefix', out_dir) as data:
             page_ref = data.find('ri:page')
@@ -38,11 +37,12 @@ class TestConfluenceConfigTitlefix(unittest.TestCase):
             self.assertIsNotNone(page_ref)
             self.assertEqual(page_ref['ri:content-title'], 'titlefix')
 
+    @setup_builder('confluence')
     def test_storage_config_titlefix_postfix(self):
         config = dict(self.config)
         config['confluence_publish_postfix'] = '-mypostfix'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('titlefix', out_dir) as data:
@@ -56,11 +56,12 @@ class TestConfluenceConfigTitlefix(unittest.TestCase):
             self.assertIsNotNone(page_ref)
             self.assertEqual(page_ref['ri:content-title'], 'titlefix-mypostfix')
 
+    @setup_builder('confluence')
     def test_storage_config_titlefix_prefix(self):
         config = dict(self.config)
         config['confluence_publish_prefix'] = 'myprefix-'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('titlefix', out_dir) as data:
@@ -74,12 +75,13 @@ class TestConfluenceConfigTitlefix(unittest.TestCase):
             self.assertIsNotNone(page_ref)
             self.assertEqual(page_ref['ri:content-title'], 'myprefix-titlefix')
 
+    @setup_builder('confluence')
     def test_storage_config_titlefix_prefix_and_postfix(self):
         config = dict(self.config)
         config['confluence_publish_prefix'] = 'myprefix-'
         config['confluence_publish_postfix'] = '-mypostfix'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('titlefix', out_dir) as data:
@@ -94,13 +96,14 @@ class TestConfluenceConfigTitlefix(unittest.TestCase):
             self.assertEqual(page_ref['ri:content-title'],
                 'myprefix-titlefix-mypostfix')
 
+    @setup_builder('confluence')
     def test_storage_config_titlefix_ignore_root(self):
         config = dict(self.config)
         config['confluence_ignore_titlefix_on_index'] = True
         config['confluence_publish_postfix'] = '-mypostfix'
         config['confluence_publish_prefix'] = 'myprefix-'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('titlefix', out_dir) as data:

--- a/tests/unit-tests/test_confluence_expand.py
+++ b/tests/unit-tests/test_confluence_expand.py
@@ -4,22 +4,22 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceExpand(unittest.TestCase):
+class TestConfluenceExpand(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'expand')
+        super(TestConfluenceExpand, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'expand')
+
+    @setup_builder('confluence')
     def test_storage_confluence_expand_directive_expected(self):
-        out_dir = build_sphinx(self.dataset, config=self.config)
+        out_dir = self.build(self.dataset)
 
         with parse('index', out_dir) as data:
             expand_macros = data.find_all('ac:structured-macro',

--- a/tests/unit-tests/test_confluence_jira.py
+++ b/tests/unit-tests/test_confluence_jira.py
@@ -1,60 +1,67 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2019-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2019-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from sphinx.errors import SphinxWarning
-from tests.lib import build_sphinx
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceJira(unittest.TestCase):
+class TestConfluenceJira(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.container = os.path.join(test_dir, 'datasets', 'jira')
+        super(TestConfluenceJira, cls).setUpClass()
+
+        cls.container = os.path.join(cls.datasets, 'jira')
 
     def test_confluence_jira_directive_bad_sid(self):
         dataset = os.path.join(self.container, 'bad-sid')
 
         with self.assertRaises(SphinxWarning):
-            build_sphinx(dataset, config=self.config)
+            self.build(dataset)
 
     def test_confluence_jira_directive_conflicting_server_id(self):
         dataset = os.path.join(self.container, 'conflicting-server-id')
 
         with self.assertRaises(SphinxWarning):
-            build_sphinx(dataset, config=self.config)
+            self.build(dataset)
 
     def test_confluence_jira_directive_conflicting_server_name(self):
         dataset = os.path.join(self.container, 'conflicting-server-name')
 
         with self.assertRaises(SphinxWarning):
-            build_sphinx(dataset, config=self.config)
+            self.build(dataset)
 
     def test_confluence_jira_directive_missing_server_entry(self):
         dataset = os.path.join(self.container, 'missing-server-entry')
 
         with self.assertRaises(SphinxWarning):
-            build_sphinx(dataset, config=self.config)
+            self.build(dataset)
 
     def test_confluence_jira_directive_missing_server_id(self):
         dataset = os.path.join(self.container, 'missing-server-id')
 
         with self.assertRaises(SphinxWarning):
-            build_sphinx(dataset, config=self.config)
+            self.build(dataset)
 
     def test_confluence_jira_directive_missing_server_name(self):
         dataset = os.path.join(self.container, 'missing-server-name')
 
         with self.assertRaises(SphinxWarning):
-            build_sphinx(dataset, config=self.config)
+            self.build(dataset)
 
+    @setup_builder('html')
+    def test_html_confluence_jira_directive_ignore(self):
+        dataset = os.path.join(self.container, 'valid')
+
+        # build attempt should not throw an exception/error
+        self.build(dataset, relax=True)
+
+    @setup_builder('confluence')
     def test_storage_confluence_jira_directive_expected(self):
         dataset = os.path.join(self.container, 'valid')
 
@@ -66,7 +73,7 @@ class TestConfluenceJira(unittest.TestCase):
             }
         }
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('index', out_dir) as data:
             jira_macros = data.find_all('ac:structured-macro',
@@ -124,21 +131,11 @@ class TestConfluenceJira(unittest.TestCase):
             self.assertIsNotNone(sid)
             self.assertEqual(sid.text, '00000000-0000-9876-0000-000000000000')
 
-    def test_storage_confluence_jira_directive_ignore(self):
-        dataset = os.path.join(self.container, 'valid')
-        opts = {
-            'builder': 'html',
-            'config': self.config,
-            'relax': True,
-        }
-
-        # build attempt should not throw an exception/error
-        build_sphinx(dataset, **opts)
-
+    @setup_builder('confluence')
     def test_storage_confluence_jira_role_default_expected(self):
         dataset = os.path.join(self.container, 'valid-role')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             p_tag = data.find('p')
@@ -155,10 +152,11 @@ class TestConfluenceJira(unittest.TestCase):
             self.assertIsNotNone(summary)
             self.assertEqual(summary.text, 'false')
 
+    @setup_builder('confluence')
     def test_storage_confluence_jira_substitution_expected(self):
         dataset = os.path.join(self.container, 'valid-substitution')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             jira_macros = data.find_all('ac:structured-macro',

--- a/tests/unit-tests/test_confluence_metadata.py
+++ b/tests/unit-tests/test_confluence_metadata.py
@@ -1,22 +1,21 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import prepare_conf
-from tests.lib import prepare_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import prepare_sphinx_filenames
 import os
-import unittest
 
 
-class TestConfluenceMetadata(unittest.TestCase):
+class TestConfluenceMetadata(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceMetadata, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = prepare_sphinx_filenames(cls.dataset,
             [
                 'metadata',
@@ -24,7 +23,7 @@ class TestConfluenceMetadata(unittest.TestCase):
             configs=[cls.config])
 
     def test_confluence_metadata_directive_expected(self):
-        with prepare_sphinx(self.dataset, config=self.config) as app:
+        with self.prepare(self.dataset) as app:
             app.build(filenames=self.filenames)
             builder_metadata = app.builder.metadata
 
@@ -40,12 +39,8 @@ class TestConfluenceMetadata(unittest.TestCase):
             self.assertTrue('tag-a' in labels)
             self.assertTrue('tag-c' in labels)
 
-    def test_confluence_metadata_directive_ignore(self):
-        opts = {
-            'builder': 'html',
-            'config': self.config,
-            'relax': True,
-        }
-        with prepare_sphinx(self.dataset, **opts) as app:
+    @setup_builder('html')
+    def test_html_confluence_metadata_directive_ignore(self):
+        with self.prepare(self.dataset, relax=True) as app:
             # build attempt should not throw an exception/error
             app.build(filenames=self.filenames)

--- a/tests/unit-tests/test_confluence_newline.py
+++ b/tests/unit-tests/test_confluence_newline.py
@@ -4,22 +4,22 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceNewline(unittest.TestCase):
+class TestConfluenceNewline(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'newline')
+        super(TestConfluenceNewline, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'newline')
+
+    @setup_builder('confluence')
     def test_storage_confluence_newline_directive_expected(self):
-        out_dir = build_sphinx(self.dataset, config=self.config)
+        out_dir = self.build(self.dataset)
 
         with parse('index', out_dir) as data:
             # expect three tags | p, br, p

--- a/tests/unit-tests/test_extension.py
+++ b/tests/unit-tests/test_extension.py
@@ -1,26 +1,19 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
+from tests.lib.testcase import ConfluenceTestCase
 from tests.lib import EXT_NAME
-from tests.lib import prepare_conf
-from tests.lib import prepare_sphinx
 import os
-import unittest
 
 
-class TestConfluenceExtension(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.config = prepare_conf()
-        cls.test_dir = os.path.dirname(os.path.realpath(__file__))
-
+class TestConfluenceExtension(ConfluenceTestCase):
     def test_extension_registration(self):
-        mock_ds = os.path.join(self.test_dir, 'datasets', 'common')
+        mock_ds = os.path.join(self.datasets, 'common')
 
-        with prepare_sphinx(mock_ds, config=self.config) as app:
+        with self.prepare(mock_ds) as app:
             if hasattr(app, 'extensions'):
                 extensions = list(app.extensions.keys())
             else:

--- a/tests/unit-tests/test_rst_admonitions.py
+++ b/tests/unit-tests/test_rst_admonitions.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstAdmonitions(unittest.TestCase):
+class TestConfluenceRstAdmonitions(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstAdmonitions, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'admonitions',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_admonitions(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('admonitions', out_dir) as data:
             self._verify_storage_tags(data, 'attention', 'note')

--- a/tests/unit-tests/test_rst_attribution.py
+++ b/tests/unit-tests/test_rst_attribution.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstAttribution(unittest.TestCase):
+class TestConfluenceRstAttribution(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstAttribution, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'attribution',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_attribution(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('attribution', out_dir) as data:
             quote = data.find('blockquote')

--- a/tests/unit-tests/test_rst_bibliographic.py
+++ b/tests/unit-tests/test_rst_bibliographic.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstBibliographic(unittest.TestCase):
+class TestConfluenceRstBibliographic(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstBibliographic, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'bibliographic',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_bibliographic_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('bibliographic', out_dir) as data:
             biblio_table = data.find('table')

--- a/tests/unit-tests/test_rst_block_quotes.py
+++ b/tests/unit-tests/test_rst_block_quotes.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstBlockQuotes(unittest.TestCase):
+class TestConfluenceRstBlockQuotes(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstBlockQuotes, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'block-quotes',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_block_quotes(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         css_margin_indent = 'margin-left: 30px'
 

--- a/tests/unit-tests/test_rst_citations.py
+++ b/tests/unit-tests/test_rst_citations.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstCitations(unittest.TestCase):
+class TestConfluenceRstCitations(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstCitations, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'citations',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_citations(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('citations', out_dir) as data:
             # ##########################################################

--- a/tests/unit-tests/test_rst_contents.py
+++ b/tests/unit-tests/test_rst_contents.py
@@ -1,23 +1,22 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
 import re
-import unittest
 
 
-class TestConfluenceRstContents(unittest.TestCase):
+class TestConfluenceRstContents(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstContents, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
 
         cls.expected_header_text = [
             'section',
@@ -27,10 +26,11 @@ class TestConfluenceRstContents(unittest.TestCase):
             'newsection',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_contents_backlinks_entry(self):
         expected_header_text = self.expected_header_text[:]
 
-        out_dir = build_sphinx(self.dataset, config=self.config,
+        out_dir = self.build(self.dataset,
             filenames=['contents-backlinks-entry'])
 
         with parse('contents-backlinks-entry', out_dir) as data:
@@ -51,10 +51,11 @@ class TestConfluenceRstContents(unittest.TestCase):
                 self.assertIsNotNone(link_body)
                 self.assertEqual(link_body.text, expected)
 
+    @setup_builder('confluence')
     def test_storage_rst_contents_backlinks_none(self):
         expected_header_text = self.expected_header_text[:]
 
-        out_dir = build_sphinx(self.dataset, config=self.config,
+        out_dir = self.build(self.dataset,
             filenames=['contents-backlinks-none'])
 
         with parse('contents-backlinks-none', out_dir) as data:
@@ -65,10 +66,11 @@ class TestConfluenceRstContents(unittest.TestCase):
             for header, expected in zip(headers, expected_header_text):
                 self.assertEqual(header.text, expected)
 
+    @setup_builder('confluence')
     def test_storage_rst_contents_backlinks_top(self):
         expected_header_text = self.expected_header_text[:]
 
-        out_dir = build_sphinx(self.dataset, config=self.config,
+        out_dir = self.build(self.dataset,
             filenames=['contents-backlinks-top'])
 
         with parse('contents-backlinks-top', out_dir) as data:
@@ -89,20 +91,21 @@ class TestConfluenceRstContents(unittest.TestCase):
                 self.assertIsNotNone(link_body)
                 self.assertEqual(link_body.text, expected)
 
+    @setup_builder('confluence')
     def test_storage_rst_contents_caption(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['contents-caption'])
+        out_dir = self.build(self.dataset, filenames=['contents-caption'])
 
         with parse('contents-caption', out_dir) as data:
             caption = data.find(re.compile('^h[1-6]$'),
                 text='table of contents')
             self.assertIsNotNone(caption)
 
+    @setup_builder('confluence')
     def test_storage_rst_contents_default_title(self):
         config = dict(self.config)
         config['confluence_remove_title'] = False
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=['contents'])
 
         with parse('contents', out_dir) as data:
@@ -118,9 +121,9 @@ class TestConfluenceRstContents(unittest.TestCase):
             self.assertIsNotNone(link_body)
             self.assertEqual(link_body.text, 'contents')
 
+    @setup_builder('confluence')
     def test_storage_rst_contents_default_top(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['contents'])
+        out_dir = self.build(self.dataset, filenames=['contents'])
 
         with parse('contents', out_dir) as data:
             # there should be no ac-link for the contents page
@@ -134,12 +137,12 @@ class TestConfluenceRstContents(unittest.TestCase):
             self.assertEqual(root_link['href'], '#top')
             self.assertEqual(root_link.text, 'contents')
 
+    @setup_builder('confluence')
     def test_storage_rst_contents_links(self):
         expected_header_text = self.expected_header_text[:]
         expected_header_text.remove('toc')  # skip toc header
 
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['contents'])
+        out_dir = self.build(self.dataset, filenames=['contents'])
 
         with parse('contents', out_dir) as data:
             toc = data.find('ul')
@@ -157,9 +160,9 @@ class TestConfluenceRstContents(unittest.TestCase):
                 self.assertIsNotNone(link_body)
                 self.assertEqual(link_body.text, expected)
 
+    @setup_builder('confluence')
     def test_storage_rst_contents_local(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['contents-local'])
+        out_dir = self.build(self.dataset, filenames=['contents-local'])
 
         with parse('contents-local', out_dir) as data:
             toc = data.find('ul')

--- a/tests/unit-tests/test_rst_definition_lists.py
+++ b/tests/unit-tests/test_rst_definition_lists.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstDefinitionLists(unittest.TestCase):
+class TestConfluenceRstDefinitionLists(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstDefinitionLists, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'definition-lists',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_definition_lists(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('definition-lists', out_dir) as data:
             def_list = data.find('dl')

--- a/tests/unit-tests/test_rst_epigraph.py
+++ b/tests/unit-tests/test_rst_epigraph.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstEpigraph(unittest.TestCase):
+class TestConfluenceRstEpigraph(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstEpigraph, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'epigraph',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_epigraph(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('epigraph', out_dir) as data:
             quote = data.find('blockquote')

--- a/tests/unit-tests/test_rst_figure.py
+++ b/tests/unit-tests/test_rst_figure.py
@@ -5,26 +5,25 @@
 """
 
 from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_ALIGNMENT
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstFigure(unittest.TestCase):
+class TestConfluenceRstFigure(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstFigure, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'figure',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_figure_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('figure', out_dir) as data:
             figures = data.find_all('p', recursive=False)

--- a/tests/unit-tests/test_rst_footnotes.py
+++ b/tests/unit-tests/test_rst_footnotes.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstFootnotes(unittest.TestCase):
+class TestConfluenceRstFootnotes(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstFootnotes, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'footnotes',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_footnotes(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('footnotes', out_dir) as data:
             # ##########################################################

--- a/tests/unit-tests/test_rst_headings.py
+++ b/tests/unit-tests/test_rst_headings.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstHeadings(unittest.TestCase):
+class TestConfluenceRstHeadings(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstHeadings, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'headings',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_headings_default(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('headings', out_dir) as data:
             header_lvl1 = data.find('h1')
@@ -51,11 +50,12 @@ class TestConfluenceRstHeadings(unittest.TestCase):
             self.assertIsNotNone(header_lvl6)
             self.assertEqual(len(header_lvl6), 6)
 
+    @setup_builder('confluence')
     def test_storage_rst_headings_with_title(self):
         config = dict(self.config)
         config['confluence_remove_title'] = False
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('headings', out_dir) as data:

--- a/tests/unit-tests/test_rst_highlights.py
+++ b/tests/unit-tests/test_rst_highlights.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstHighlights(unittest.TestCase):
+class TestConfluenceRstHighlights(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstHighlights, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'highlights',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_highlights(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('highlights', out_dir) as data:
             quote = data.find('blockquote')

--- a/tests/unit-tests/test_rst_image.py
+++ b/tests/unit-tests/test_rst_image.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstImage(unittest.TestCase):
+class TestConfluenceRstImage(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstImage, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'image',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_image_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('image', out_dir) as data:
             images = data.find_all('ac:image', recursive=False)

--- a/tests/unit-tests/test_rst_list_table.py
+++ b/tests/unit-tests/test_rst_list_table.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstListTable(unittest.TestCase):
+class TestConfluenceRstListTable(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstListTable, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'list-table',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_listtable(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('list-table', out_dir) as data:
             root_tags = data.find_all(recursive=False)

--- a/tests/unit-tests/test_rst_lists.py
+++ b/tests/unit-tests/test_rst_lists.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstLists(unittest.TestCase):
+class TestConfluenceRstLists(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstLists, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'lists',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_lists(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('lists', out_dir) as data:
             root_tags = data.find_all(recursive=False)

--- a/tests/unit-tests/test_rst_literal.py
+++ b/tests/unit-tests/test_rst_literal.py
@@ -1,27 +1,26 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
 from bs4 import CData
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstLiteral(unittest.TestCase):
+class TestConfluenceRstLiteral(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstLiteral, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'common')
+
+    @setup_builder('confluence')
     def test_storage_rst_literal_blocks(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['literal-blocks'])
+        out_dir = self.build(self.dataset, filenames=['literal-blocks'])
 
         with parse('literal-blocks', out_dir) as data:
             code_macros = data.find_all('ac:structured-macro',
@@ -42,9 +41,9 @@ class TestConfluenceRstLiteral(unittest.TestCase):
                 self.assertIsNotNone(lang)
                 self.assertEqual(lang.text, 'python')
 
+    @setup_builder('confluence')
     def test_storage_rst_literal_includes(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['literal-includes'])
+        out_dir = self.build(self.dataset, filenames=['literal-includes'])
 
         with parse('literal-includes', out_dir) as data:
             code_macros = data.find_all('ac:structured-macro',

--- a/tests/unit-tests/test_rst_markup.py
+++ b/tests/unit-tests/test_rst_markup.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstMarkup(unittest.TestCase):
+class TestConfluenceRstMarkup(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstMarkup, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'markup',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_markup(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('markup', out_dir) as data:
             emphasis = data.find('em', text='emphasis')

--- a/tests/unit-tests/test_rst_option_lists.py
+++ b/tests/unit-tests/test_rst_option_lists.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstOptionLists(unittest.TestCase):
+class TestConfluenceRstOptionLists(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstOptionLists, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'option-lists',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_option_lists(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('option-lists', out_dir) as data:
             options_table = data.find('table')

--- a/tests/unit-tests/test_rst_parsed_literal.py
+++ b/tests/unit-tests/test_rst_parsed_literal.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstParsedLiteral(unittest.TestCase):
+class TestConfluenceRstParsedLiteral(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstParsedLiteral, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'parsed-literal',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_parsedliteral_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('parsed-literal', out_dir) as data:
             container_block = data.find('pre')

--- a/tests/unit-tests/test_rst_pull_quote.py
+++ b/tests/unit-tests/test_rst_pull_quote.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstPullQuote(unittest.TestCase):
+class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceConfigHeaderFooter, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'pull-quote',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_pull_quote(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('pull-quote', out_dir) as data:
             quote = data.find('blockquote')

--- a/tests/unit-tests/test_rst_raw.py
+++ b/tests/unit-tests/test_rst_raw.py
@@ -1,26 +1,25 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstRaw(unittest.TestCase):
+class TestConfluenceRstRaw(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstRaw, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'common')
+
+    @setup_builder('confluence')
     def test_storage_rst_raw_default(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['raw-storage'])
+        out_dir = self.build(self.dataset, filenames=['raw-storage'])
 
         with parse('raw-storage', out_dir) as data:
             strong = data.find('strong')

--- a/tests/unit-tests/test_rst_references.py
+++ b/tests/unit-tests/test_rst_references.py
@@ -1,31 +1,30 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstReferences(unittest.TestCase):
+class TestConfluenceRstReferences(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
+        super(TestConfluenceRstReferences, cls).setUpClass()
+
         cls.config['root_doc'] = 'references'
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'references',
             'references-ref',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_references(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('references', out_dir) as data:
             a_tags = data.find_all('a')

--- a/tests/unit-tests/test_rst_tables.py
+++ b/tests/unit-tests/test_rst_tables.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstTables(unittest.TestCase):
+class TestConfluenceRstTables(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstTables, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'tables',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_tables_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('tables', out_dir) as data:
             tables = data.find_all('table', recursive=False)

--- a/tests/unit-tests/test_rst_transitions.py
+++ b/tests/unit-tests/test_rst_transitions.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceRstTransitions(unittest.TestCase):
+class TestConfluenceRstTransitions(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceRstTransitions, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'transitions',
         ]
 
+    @setup_builder('confluence')
     def test_storage_rst_transitions_default(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('transitions', out_dir) as data:
             hr = data.find('hr')

--- a/tests/unit-tests/test_sdoc_modindex.py
+++ b/tests/unit-tests/test_sdoc_modindex.py
@@ -1,47 +1,52 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestSdocModindex(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.container = os.path.join(test_dir, 'datasets')
-        cls.template_dir = os.path.join(test_dir, 'templates')
-
-    def test_storage_sdoc_modindex_default_missing(self):
+class TestSdocModindex(ConfluenceTestCase):
+    @setup_builder('confluence')
+    def test_sdoc_modindex_default_missing_confluence(self):
         """validate modindex is not added by default (storage)"""
 
-        dataset = os.path.join(self.container, 'minimal')
+        dataset = os.path.join(self.datasets, 'minimal')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         fname_check = os.path.join(out_dir, 'py-modindex.conf')
         self.assertFalse(os.path.exists(fname_check))
 
+    @setup_builder('singleconfluence')
+    def test_sdoc_modindex_default_missing_singleconfluence(self):
+        """validate modindex is not added by default (storage)"""
+
+        dataset = os.path.join(self.datasets, 'minimal')
+
+        out_dir = self.build(dataset)
+
+        fname_check = os.path.join(out_dir, 'py-modindex.conf')
+        self.assertFalse(os.path.exists(fname_check))
+
+    @setup_builder('confluence')
     def test_storage_sdoc_modindex_enabled(self):
         """validate modindex generation can be enabled (storage)"""
         #
         # Ensures the extension adds a "py-modindex" document when the domain
         # indices option is assigned to include the domain type.
 
-        dataset = os.path.join(self.container, 'sdoc', 'py-modindex')
+        dataset = os.path.join(self.datasets, 'sdoc', 'py-modindex')
         config = dict(self.config)
         config['confluence_domain_indices'] = [
             'py-modindex',
         ]
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('py-modindex', out_dir) as data:
             link_tags = data.find_all('ac:link')
@@ -58,17 +63,18 @@ class TestSdocModindex(unittest.TestCase):
             self.assertIsNotNone(link_body)
             self.assertEqual(link_body.text, 'Timer')
 
+    @setup_builder('confluence')
     def test_storage_sdoc_modindex_enabled_bool(self):
         """validate modindex generation can be bool-enabled (storage)"""
         #
         # Ensures the extension adds a "py-modindex" document when the domain
         # indices option is assigned to a `True` value.
 
-        dataset = os.path.join(self.container, 'sdoc', 'py-modindex')
+        dataset = os.path.join(self.datasets, 'sdoc', 'py-modindex')
         config = dict(self.config)
         config['confluence_domain_indices'] = True
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('py-modindex', out_dir) as data:
             link_tags = data.find_all('ac:link')
@@ -85,22 +91,23 @@ class TestSdocModindex(unittest.TestCase):
             self.assertIsNotNone(link_body)
             self.assertEqual(link_body.text, 'Timer')
 
+    @setup_builder('confluence')
     def test_storage_sdoc_modindex_header_footer(self):
         """validate modindex generation includes header/footer (storage)"""
         #
         # Ensures that when the extension adds a "modindex" document; any custom
         # defined header/footer data is also injected into the document.
 
-        dataset = os.path.join(self.container, 'sdoc', 'py-modindex')
-        footer_tpl = os.path.join(self.template_dir, 'sample-footer.tpl')
-        header_tpl = os.path.join(self.template_dir, 'sample-header.tpl')
+        dataset = os.path.join(self.datasets, 'sdoc', 'py-modindex')
+        footer_tpl = os.path.join(self.templates_dir, 'sample-footer.tpl')
+        header_tpl = os.path.join(self.templates_dir, 'sample-header.tpl')
 
         config = dict(self.config)
         config['confluence_domain_indices'] = True
         config['confluence_footer_file'] = footer_tpl
         config['confluence_header_file'] = header_tpl
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('py-modindex', out_dir) as data:
             header_data = data.find().previousSibling.strip()

--- a/tests/unit-tests/test_sdoc_search.py
+++ b/tests/unit-tests/test_sdoc_search.py
@@ -1,34 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestSdocSearch(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.container = os.path.join(test_dir, 'datasets')
-        cls.template_dir = os.path.join(test_dir, 'templates')
-
+class TestSdocSearch(ConfluenceTestCase):
+    @setup_builder('confluence')
     def test_storage_sdoc_search_default_missing(self):
         """validate search is not added by default (storage)"""
 
-        dataset = os.path.join(self.container, 'minimal')
+        dataset = os.path.join(self.datasets, 'minimal')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         fname_check = os.path.join(out_dir, 'search.conf')
         self.assertFalse(os.path.exists(fname_check))
 
+    @setup_builder('confluence')
     def test_storage_sdoc_search_explicit_disabled(self):
         """validate search generation can be disabled (storage)"""
         #
@@ -36,50 +30,52 @@ class TestSdocSearch(unittest.TestCase):
         # automatically generate its contents, by disabling the search option
         # explicitly, the original search document should not be touched.
 
-        dataset = os.path.join(self.container, 'sdoc', 'search-placeholder')
+        dataset = os.path.join(self.datasets, 'sdoc', 'search-placeholder')
         config = dict(self.config)
         config['confluence_include_search'] = False
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('search', out_dir) as data:
             placeholder = data.find('p')
             self.assertIsNotNone(placeholder)
             self.assertEqual(placeholder.text.strip(), 'placeholder')
 
+    @setup_builder('confluence')
     def test_storage_sdoc_search_explicit_enabled(self):
         """validate search generation can be enabled (storage)"""
         #
         # Ensures the extension adds a "search" document; even if its not in a
         # documentation set's toctree.
 
-        dataset = os.path.join(self.container, 'minimal')
+        dataset = os.path.join(self.datasets, 'minimal')
         config = dict(self.config)
         config['confluence_include_search'] = True
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('search', out_dir) as data:
             search_macro = data.find('ac:structured-macro',
                 {'ac:name': 'livesearch'})
             self.assertIsNotNone(search_macro)
 
+    @setup_builder('confluence')
     def test_storage_sdoc_search_header_footer(self):
         """validate search generation includes header/footer (storage)"""
         #
         # Ensures that when the extension adds a "search" document; any custom
         # defined header/footer data is also injected into the document.
 
-        dataset = os.path.join(self.container, 'minimal')
-        footer_tpl = os.path.join(self.template_dir, 'sample-footer.tpl')
-        header_tpl = os.path.join(self.template_dir, 'sample-header.tpl')
+        dataset = os.path.join(self.datasets, 'minimal')
+        footer_tpl = os.path.join(self.templates_dir, 'sample-footer.tpl')
+        header_tpl = os.path.join(self.templates_dir, 'sample-header.tpl')
 
         config = dict(self.config)
         config['confluence_include_search'] = True
         config['confluence_footer_file'] = footer_tpl
         config['confluence_header_file'] = header_tpl
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('search', out_dir) as data:
             header_data = data.find().previousSibling.strip()
@@ -88,15 +84,16 @@ class TestSdocSearch(unittest.TestCase):
             footer_data = data.find_all(recursive=False)[-1].nextSibling.strip()
             self.assertEqual(footer_data, 'footer content')
 
+    @setup_builder('confluence')
     def test_storage_sdoc_search_implicit_enabled_toctree(self):
         """validate search generation is auto-added via toctree (storage)"""
         #
         # If a "search" document is found in the documentation set's toctree,
         # the document should be generated.
 
-        dataset = os.path.join(self.container, 'sdoc', 'search-placeholder')
+        dataset = os.path.join(self.datasets, 'sdoc', 'search-placeholder')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         with parse('search', out_dir) as data:
             search_macro = data.find('ac:structured-macro',

--- a/tests/unit-tests/test_shared_asset.py
+++ b/tests/unit-tests/test_shared_asset.py
@@ -1,25 +1,25 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSharedAsset(unittest.TestCase):
+class TestConfluenceSharedAsset(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'shared-asset')
+        super(TestConfluenceSharedAsset, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'shared-asset')
+
+    @setup_builder('confluence')
     def test_storage_sharedasset_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config)
+        out_dir = self.build(self.dataset)
 
         with parse('doc-a', out_dir) as data:
             image = data.find('ac:image')
@@ -49,10 +49,11 @@ class TestConfluenceSharedAsset(unittest.TestCase):
             self.assertTrue(page_ref.has_attr('ri:content-title'))
             self.assertEqual(page_ref['ri:content-title'], 'shared asset')
 
+    @setup_builder('confluence')
     def test_storage_sharedasset_force_standalone(self):
         config = dict(self.config)
         config['confluence_asset_force_standalone'] = True
-        out_dir = build_sphinx(self.dataset, config=config)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('doc-a', out_dir) as data:
             image = data.find('ac:image')
@@ -78,8 +79,9 @@ class TestConfluenceSharedAsset(unittest.TestCase):
             page_ref = attachment.find('ri:page')
             self.assertIsNone(page_ref)
 
+    @setup_builder('confluence')
     def test_storage_sharedasset_no_newline_assets(self):
-        out_dir = build_sphinx(self.dataset, config=self.config)
+        out_dir = self.build(self.dataset)
 
         # confluence (error 500) attachment newline check
         #

--- a/tests/unit-tests/test_singlepage_assets.py
+++ b/tests/unit-tests/test_singlepage_assets.py
@@ -1,32 +1,30 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSinglepageAssets(unittest.TestCase):
+class TestConfluenceSinglepageAssets(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'shared-asset')
+        super(TestConfluenceSinglepageAssets, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'shared-asset')
+
+    @setup_builder('singleconfluence')
     def test_storage_singlepage_asset_defaults(self):
         """validate single page assets are self-contained (storage)"""
         #
         # Ensure when generating a single page that all assets on a page are
         # pointing (implicitly) to itself (i.e. no `ri:page` entry).
 
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            builder=SingleConfluenceBuilder.name)
+        out_dir = self.build(self.dataset)
 
         with parse('index', out_dir) as data:
             images = data.find_all('ac:image')
@@ -41,6 +39,7 @@ class TestConfluenceSinglepageAssets(unittest.TestCase):
                 page_ref = attachment.find('ri:page')
                 self.assertIsNone(page_ref)
 
+    @setup_builder('singleconfluence')
     def test_storage_singlepage_asset_force_standalone(self):
         """validate single page assets are self-contained alt (storage)"""
         #
@@ -50,8 +49,7 @@ class TestConfluenceSinglepageAssets(unittest.TestCase):
 
         config = dict(self.config)
         config['confluence_asset_force_standalone'] = True
-        out_dir = build_sphinx(self.dataset, config=config,
-            builder=SingleConfluenceBuilder.name)
+        out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
             images = data.find_all('ac:image')

--- a/tests/unit-tests/test_singlepage_docref.py
+++ b/tests/unit-tests/test_singlepage_docref.py
@@ -1,28 +1,21 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSinglepageToctree(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.config = prepare_conf()
-        cls.test_dir = os.path.dirname(os.path.realpath(__file__))
-
+class TestConfluenceSinglepageToctree(ConfluenceTestCase):
+    @setup_builder('singleconfluence')
     def test_storage_singlepage_docref_pageref(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'singlepage-docref')
+        dataset = os.path.join(self.datasets, 'singlepage-docref')
 
-        out_dir = build_sphinx(dataset, config=self.config,
-            builder=SingleConfluenceBuilder.name)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             links = data.find_all('ac:link')
@@ -37,11 +30,11 @@ class TestConfluenceSinglepageToctree(unittest.TestCase):
             self.assertTrue(link.has_attr('ac:anchor'))
             self.assertEqual(link['ac:anchor'], 'pageb2')
 
+    @setup_builder('singleconfluence')
     def test_storage_singlepage_docref_index_no_title(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'singlepage-docref')
+        dataset = os.path.join(self.datasets, 'singlepage-docref')
 
-        out_dir = build_sphinx(dataset, config=self.config,
-            builder=SingleConfluenceBuilder.name)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             links = data.find_all('a')
@@ -53,14 +46,14 @@ class TestConfluenceSinglepageToctree(unittest.TestCase):
             self.assertTrue(link.has_attr('href'))
             self.assertEqual(link['href'], '#top')
 
+    @setup_builder('singleconfluence')
     def test_storage_singlepage_docref_index_with_title(self):
         config = dict(self.config)
         config['confluence_remove_title'] = False
 
-        dataset = os.path.join(self.test_dir, 'datasets', 'singlepage-docref')
+        dataset = os.path.join(self.datasets, 'singlepage-docref')
 
-        out_dir = build_sphinx(dataset, config=config,
-            builder=SingleConfluenceBuilder.name)
+        out_dir = self.build(dataset, config=config)
 
         with parse('index', out_dir) as data:
             links = data.find_all('ac:link')

--- a/tests/unit-tests/test_singlepage_toctree.py
+++ b/tests/unit-tests/test_singlepage_toctree.py
@@ -1,28 +1,21 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSinglepageToctree(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.config = prepare_conf()
-        cls.test_dir = os.path.dirname(os.path.realpath(__file__))
-
+class TestConfluenceSinglepageToctree(ConfluenceTestCase):
+    @setup_builder('singleconfluence')
     def test_storage_singlepage_toctree_default(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-default')
+        dataset = os.path.join(self.datasets, 'toctree-default')
 
-        out_dir = build_sphinx(dataset, config=self.config,
-            builder=SingleConfluenceBuilder.name)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             tags = data.find_all()
@@ -80,11 +73,11 @@ class TestConfluenceSinglepageToctree(unittest.TestCase):
             self.assertEqual(content.name, 'p')
             self.assertEqual(content.text, 'content b1')
 
+    @setup_builder('singleconfluence')
     def test_storage_singlepage_toctree_numbered(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-numbered')
+        dataset = os.path.join(self.datasets, 'toctree-numbered')
 
-        out_dir = build_sphinx(dataset, config=self.config,
-            builder=SingleConfluenceBuilder.name)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             tags = data.find_all()

--- a/tests/unit-tests/test_sphinx_alignment.py
+++ b/tests/unit-tests/test_sphinx_alignment.py
@@ -1,37 +1,38 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
 from pkg_resources import parse_version
 from sphinx.__init__ import __version__ as sphinx_version
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
 import unittest
 
 
-class TestConfluenceSphinxAlignment(unittest.TestCase):
+class TestConfluenceSphinxAlignment(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
+        super(TestConfluenceSphinxAlignment, cls).setUpClass()
+
         # skip alignment tests pre-sphinx 2.1 as 'default' hints do not exist
         if parse_version(sphinx_version) < parse_version('2.1'):
             raise unittest.SkipTest('default hints not supported in sphinx')
 
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'alignment',
         ]
 
+    @setup_builder('confluence')
     def test_storage_sphinx_alignment_center(self):
         config = dict(self.config)
         config['confluence_default_alignment'] = 'center'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('alignment', out_dir) as data:
@@ -40,9 +41,9 @@ class TestConfluenceSphinxAlignment(unittest.TestCase):
             self.assertTrue(image.has_attr('ac:align'))
             self.assertEqual(image['ac:align'], 'center')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_alignment_default(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('alignment', out_dir) as data:
             image = data.find('ac:image')
@@ -50,11 +51,12 @@ class TestConfluenceSphinxAlignment(unittest.TestCase):
             self.assertTrue(image.has_attr('ac:align'))
             self.assertEqual(image['ac:align'], 'center')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_alignment_left(self):
         config = dict(self.config)
         config['confluence_default_alignment'] = 'left'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('alignment', out_dir) as data:
@@ -63,11 +65,12 @@ class TestConfluenceSphinxAlignment(unittest.TestCase):
             self.assertTrue(image.has_attr('ac:align'))
             self.assertEqual(image['ac:align'], 'left')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_alignment_right(self):
         config = dict(self.config)
         config['confluence_default_alignment'] = 'right'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('alignment', out_dir) as data:

--- a/tests/unit-tests/test_sphinx_codeblock.py
+++ b/tests/unit-tests/test_sphinx_codeblock.py
@@ -1,36 +1,35 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
 from bs4 import CData
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxCodeblock(unittest.TestCase):
+class TestConfluenceSphinxCodeblock(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceSphinxCodeblock, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'common')
+
+    @setup_builder('confluence')
     def test_storage_sphinx_codeblock_caption(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['code-block-caption'])
+        out_dir = self.build(self.dataset, filenames=['code-block-caption'])
 
         with parse('code-block-caption', out_dir) as data:
             title_param = data.find('ac:parameter', {'ac:name': 'title'})
             self.assertIsNotNone(title_param)
             self.assertEqual(title_param.text, 'code caption test')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_codeblock_default(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['code-block'])
+        out_dir = self.build(self.dataset, filenames=['code-block'])
 
         with parse('code-block', out_dir) as data:
             code_macros = data.find_all('ac:structured-macro')

--- a/tests/unit-tests/test_sphinx_codeblock_highlight.py
+++ b/tests/unit-tests/test_sphinx_codeblock_highlight.py
@@ -1,30 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
 from pkg_resources import parse_version
 from sphinx.__init__ import __version__ as sphinx_version
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
 import unittest
 
 
-class TestConfluenceSphinxCodeblockHighlight(unittest.TestCase):
+class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceSphinxCodeblockHighlight, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'common')
+
+    @setup_builder('confluence')
     def test_storage_sphinx_codeblock_highlight_default(self):
-        config = dict(self.config)
-        config['highlight_language'] = 'none'
-
-        out_dir = build_sphinx(self.dataset, config=self.config,
+        out_dir = self.build(self.dataset,
             filenames=['code-block-highlight'])
 
         with parse('code-block-highlight', out_dir) as data:
@@ -40,13 +38,14 @@ class TestConfluenceSphinxCodeblockHighlight(unittest.TestCase):
             languages = data.find_all('ac:parameter', {'ac:name': 'language'})
             self._verify_set_languages(languages, expected)
 
+    @setup_builder('confluence')
     def test_storage_sphinx_codeblock_highlight_linenothreshold(self):
         # skip code-block tests in Sphinx v1.8.x due to regression
         #  https://github.com/sphinx-contrib/confluencebuilder/issues/148
         if parse_version(sphinx_version) < parse_version('2.0'):
             raise unittest.SkipTest('not supported in sphinx-1.8.x')
 
-        out_dir = build_sphinx(self.dataset, config=self.config,
+        out_dir = self.build(self.dataset,
             filenames=['code-block-linenothreshold'])
 
         with parse('code-block-linenothreshold', out_dir) as data:
@@ -73,11 +72,12 @@ class TestConfluenceSphinxCodeblockHighlight(unittest.TestCase):
             self.assertIsNotNone(linenumbers)
             self.assertEqual(linenumbers.text, 'true')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_codeblock_highlight_none(self):
         config = dict(self.config)
         config['highlight_language'] = 'none'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=['code-block-highlight'])
 
         with parse('code-block-highlight', out_dir) as data:
@@ -93,6 +93,7 @@ class TestConfluenceSphinxCodeblockHighlight(unittest.TestCase):
             languages = data.find_all('ac:parameter', {'ac:name': 'language'})
             self._verify_set_languages(languages, expected)
 
+    @setup_builder('confluence')
     def test_storage_sphinx_codeblock_highlight_override(self):
         config = dict(self.config)
 
@@ -103,7 +104,7 @@ class TestConfluenceSphinxCodeblockHighlight(unittest.TestCase):
             return 'custom'
         config['confluence_lang_transform'] = test_override_lang_method
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=['code-block-highlight'])
 
         with parse('code-block-highlight', out_dir) as data:

--- a/tests/unit-tests/test_sphinx_deprecated.py
+++ b/tests/unit-tests/test_sphinx_deprecated.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxDeprecated(unittest.TestCase):
+class TestConfluenceSphinxDeprecated(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceSphinxDeprecated, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'deprecated',
         ]
 
+    @setup_builder('confluence')
     def test_storage_sphinx_deprecated_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('deprecated', out_dir) as data:
             note_macro = data.find('ac:structured-macro', {'ac:name': 'note'})

--- a/tests/unit-tests/test_sphinx_domains.py
+++ b/tests/unit-tests/test_sphinx_domains.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
 from pkg_resources import parse_version
 from sphinx.__init__ import __version__ as sphinx_version
 from sphinx.locale import _
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxDomains(unittest.TestCase):
+class TestConfluenceSphinxDomains(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceSphinxDomains, cls).setUpClass()
 
+        cls.dataset = os.path.join(cls.datasets, 'common')
+
+    @setup_builder('confluence')
     def test_storage_sphinx_domain_c(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['domains-c'])
+        out_dir = self.build(self.dataset, filenames=['domains-c'])
 
         with parse('domains-c', out_dir) as data:
             definition = data.find('dl')
@@ -47,9 +46,9 @@ class TestConfluenceSphinxDomains(unittest.TestCase):
             self.assertIsNotNone(desc)
             self.assertEqual(desc.text, '')  # no description in this example
 
+    @setup_builder('confluence')
     def test_storage_sphinx_domain_cpp(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['domains-cpp'])
+        out_dir = self.build(self.dataset, filenames=['domains-cpp'])
 
         with parse('domains-cpp', out_dir) as data:
             definition = data.find('dl')
@@ -68,9 +67,9 @@ class TestConfluenceSphinxDomains(unittest.TestCase):
             self.assertIsNotNone(desc)
             self.assertEqual(desc.text, '')  # no description in this example
 
+    @setup_builder('confluence')
     def test_storage_sphinx_domain_js(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['domains-js'])
+        out_dir = self.build(self.dataset, filenames=['domains-js'])
 
         with parse('domains-js', out_dir) as data:
             definition = data.find('dl')
@@ -117,9 +116,9 @@ class TestConfluenceSphinxDomains(unittest.TestCase):
             for tag, expected in zip(stronged, expected_stronged):
                 self.assertEqual(tag.text.strip(), expected)
 
+    @setup_builder('confluence')
     def test_storage_sphinx_domain_py(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['domains-py'])
+        out_dir = self.build(self.dataset, filenames=['domains-py'])
 
         with parse('domains-py', out_dir) as data:
             definition = data.find('dl')
@@ -137,9 +136,9 @@ class TestConfluenceSphinxDomains(unittest.TestCase):
             desc = definition.find('dd', recursive=False)
             self.assertIsNotNone(desc)
 
+    @setup_builder('confluence')
     def test_storage_sphinx_domain_rst(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=['domains-rst'])
+        out_dir = self.build(self.dataset, filenames=['domains-rst'])
 
         with parse('domains-rst', out_dir) as data:
             definition = data.find('dl')

--- a/tests/unit-tests/test_sphinx_download.py
+++ b/tests/unit-tests/test_sphinx_download.py
@@ -1,30 +1,29 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
 from bs4 import CData
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxDownload(unittest.TestCase):
+class TestConfluenceSphinxDownload(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceSphinxDownload, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'download',
         ]
 
+    @setup_builder('confluence')
     def test_storage_sphinx_download_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('download', out_dir) as data:
             # view-file

--- a/tests/unit-tests/test_sphinx_glossary.py
+++ b/tests/unit-tests/test_sphinx_glossary.py
@@ -1,31 +1,30 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxDomains(unittest.TestCase):
+class TestConfluenceSphinxDomains(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
+        super(TestConfluenceSphinxDomains, cls).setUpClass()
+
         cls.config['root_doc'] = 'glossary'
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'glossary',
             'glossary-ref',
         ]
 
+    @setup_builder('confluence')
     def test_storage_sphinx_glossary_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('glossary', out_dir) as data:
             # glossary list

--- a/tests/unit-tests/test_sphinx_image_candidate.py
+++ b/tests/unit-tests/test_sphinx_image_candidate.py
@@ -1,32 +1,24 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
 from sphinxcontrib.confluencebuilder.std.confluence import SUPPORTED_IMAGE_TYPES
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 from tests.lib import prepare_dirs
 import mimetypes
 import os
 import shutil
 import sys
-import unittest
 
 
-class TestConfluenceSphinxImageCandidate(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.config = prepare_conf()
-        cls.test_dir = os.path.dirname(os.path.realpath(__file__))
-
+class TestConfluenceSphinxImageCandidate(ConfluenceTestCase):
+    @setup_builder('confluence')
     def test_storage_sphinx_image_candidate(self):
-        config = prepare_conf()
-
-        assets_dir = os.path.join(self.test_dir, 'assets')
-        sample_img = os.path.join(assets_dir, 'test.png')
+        sample_img = os.path.join(self.assets_dir, 'test.png')
 
         for mime_type in SUPPORTED_IMAGE_TYPES:
             ext = mimetypes.guess_extension(mime_type)
@@ -60,7 +52,7 @@ class TestConfluenceSphinxImageCandidate(unittest.TestCase):
             shutil.copyfile(sample_img, dummy_img_file)
 
             # build and check
-            build_sphinx(doc_dir, config=config, out_dir=out_dir)
+            self.build(doc_dir, out_dir=out_dir)
 
             with parse('index', out_dir) as data:
                 image = data.find('ac:image')

--- a/tests/unit-tests/test_sphinx_manpage.py
+++ b/tests/unit-tests/test_sphinx_manpage.py
@@ -1,31 +1,31 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxManpage(unittest.TestCase):
+class TestConfluenceSphinxManpage(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceSphinxManpage, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'manpage',
         ]
 
+    @setup_builder('confluence')
     def test_storage_sphinx_manpage_config(self):
         config = dict(self.config)
         config['manpages_url'] = 'https://manpages.example.com/{path}'
 
-        out_dir = build_sphinx(self.dataset, config=config,
+        out_dir = self.build(self.dataset, config=config,
             filenames=self.filenames)
 
         with parse('manpage', out_dir) as data:
@@ -38,9 +38,9 @@ class TestConfluenceSphinxManpage(unittest.TestCase):
             self.assertEqual(link['href'], 'https://manpages.example.com/ls(1)')
             self.assertEqual(link.text, 'ls(1)')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_manpage_noconfig(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('manpage', out_dir) as data:
             em = data.find('em')

--- a/tests/unit-tests/test_sphinx_productionlist.py
+++ b/tests/unit-tests/test_sphinx_productionlist.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxProductionList(unittest.TestCase):
+class TestConfluenceSphinxProductionList(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceSphinxProductionList, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'production-list',
         ]
 
+    @setup_builder('confluence')
     def test_storage_sphinx_productionlist_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('production-list', out_dir) as data:
             container = data.find('pre')

--- a/tests/unit-tests/test_sphinx_toctree.py
+++ b/tests/unit-tests/test_sphinx_toctree.py
@@ -1,25 +1,20 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxToctree(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.config = prepare_conf()
-        cls.test_dir = os.path.dirname(os.path.realpath(__file__))
-
+class TestConfluenceSphinxToctree(ConfluenceTestCase):
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_caption(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-caption')
-        out_dir = build_sphinx(dataset, config=self.config)
+        dataset = os.path.join(self.datasets, 'toctree-caption')
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             root_toc = data.find('ul', recursive=False)
@@ -29,8 +24,9 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             self.assertIsNotNone(caption)
             self.assertEqual(caption.text, 'toctree caption')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_child_macro(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-default')
+        dataset = os.path.join(self.datasets, 'toctree-default')
 
         config = dict(self.config)
         config['confluence_adv_hierarchy_child_macro'] = True
@@ -38,7 +34,7 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
 
         # relax due to this test (confluence_adv_hierarchy_child_macro) being
         # deprecated
-        out_dir = build_sphinx(dataset, config=config, relax=True)
+        out_dir = self.build(dataset, config=config, relax=True)
 
         with parse('index', out_dir) as data:
             macro = data.find('ac:structured-macro', recursive=False)
@@ -52,10 +48,11 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             self.assertEqual(all_param['ac:name'], 'all')
             self.assertEqual(all_param.text, 'true')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_default(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-default')
+        dataset = os.path.join(self.datasets, 'toctree-default')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             root_toc = data.find('ul', recursive=False)
@@ -97,19 +94,21 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             self.assertEqual(len(sub_docs), 1)
             self._verify_link(sub_docs[0], 'doc-b1')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_hidden(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-hidden')
+        dataset = os.path.join(self.datasets, 'toctree-hidden')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             # expect no content with a hidden toctree
             self.assertEqual(data.text, '')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_maxdepth(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-maxdepth')
+        dataset = os.path.join(self.datasets, 'toctree-maxdepth')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             root_toc = data.find('ul', recursive=False)
@@ -125,10 +124,11 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             self.assertEqual(len(doc_tags), 1)  # no other links beyond depth
             self._verify_link(doc, 'doc')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_numbered_default(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-numbered')
+        dataset = os.path.join(self.datasets, 'toctree-numbered')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             root_toc = data.find('ul', recursive=False)
@@ -172,10 +172,11 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             doc = docs[0]
             self._verify_link(doc, '1.1. child')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_numbered_depth(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-numbered-depth')
+        dataset = os.path.join(self.datasets, 'toctree-numbered-depth')
 
-        out_dir = build_sphinx(dataset, config=self.config)
+        out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
             root_toc = data.find('ul', recursive=False)
@@ -207,13 +208,14 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             doc = docs[0]
             self._verify_link(doc, 'child')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_numbered_disable(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-numbered')
+        dataset = os.path.join(self.datasets, 'toctree-numbered')
 
         config = dict(self.config)
         config['confluence_add_secnumbers'] = False
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('index', out_dir) as data:
             root_toc = data.find('ul', recursive=False)
@@ -254,18 +256,19 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             doc = docs[0]
             self._verify_link(doc, 'child')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_numbered_secnumbers_suffix_empty(self):
         """validate toctree secnumber supports empty str (storage)"""
         #
         # Ensure that the toctree secnumber suffix value can be set to an
         # empty string.
 
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-numbered')
+        dataset = os.path.join(self.datasets, 'toctree-numbered')
 
         config = dict(self.config)
         config['confluence_secnumber_suffix'] = ''
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('index', out_dir) as data:
             root_toc = data.find('ul', recursive=False)
@@ -309,13 +312,14 @@ class TestConfluenceSphinxToctree(unittest.TestCase):
             doc = docs[0]
             self._verify_link(doc, '1.1child')
 
+    @setup_builder('confluence')
     def test_storage_sphinx_toctree_numbered_secnumbers_suffix_set(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'toctree-numbered')
+        dataset = os.path.join(self.datasets, 'toctree-numbered')
 
         config = dict(self.config)
         config['confluence_secnumber_suffix'] = '!Z /+4'
 
-        out_dir = build_sphinx(dataset, config=config)
+        out_dir = self.build(dataset, config=config)
 
         with parse('index', out_dir) as data:
             root_toc = data.find('ul', recursive=False)

--- a/tests/unit-tests/test_sphinx_versionadded.py
+++ b/tests/unit-tests/test_sphinx_versionadded.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxVersionAdded(unittest.TestCase):
+class TestConfluenceSphinxVersionAdded(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceSphinxVersionAdded, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'versionadded',
         ]
 
+    @setup_builder('confluence')
     def test_storage_sphinx_versionadded_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('versionadded', out_dir) as data:
             note_macro = data.find('ac:structured-macro', {'ac:name': 'info'})

--- a/tests/unit-tests/test_sphinx_versionchanged.py
+++ b/tests/unit-tests/test_sphinx_versionchanged.py
@@ -1,29 +1,28 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceSphinxVersionChanged(unittest.TestCase):
+class TestConfluenceSphinxVersionChanged(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        super(TestConfluenceSphinxVersionChanged, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
         cls.filenames = [
             'versionchanged',
         ]
 
+    @setup_builder('confluence')
     def test_storage_sphinx_versionchanged_defaults(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('versionchanged', out_dir) as data:
             note_macro = data.find('ac:structured-macro', {'ac:name': 'note'})

--- a/tests/unit-tests/test_svg.py
+++ b/tests/unit-tests/test_svg.py
@@ -1,23 +1,22 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 import xml.etree.ElementTree as xml_et
 
 
-class TestSvg(unittest.TestCase):
+class TestSvg(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'svg')
+        super(TestSvg, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'svg')
 
     def _extract_svg_size(self, fname):
         with open(fname, 'rb') as f:
@@ -26,8 +25,9 @@ class TestSvg(unittest.TestCase):
         svg_root = xml_et.fromstring(svg_data)
         return int(svg_root.attrib['width']), int(svg_root.attrib['height'])
 
+    @setup_builder('confluence')
     def test_storage_svgs(self):
-        out_dir = build_sphinx(self.dataset, config=self.config)
+        out_dir = self.build(self.dataset)
 
         with parse('index', out_dir) as data:
             images = data.find_all('ac:image', recursive=False)

--- a/tests/unit-tests/test_usecase_nested_ref.py
+++ b/tests/unit-tests/test_usecase_nested_ref.py
@@ -1,31 +1,30 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
-from tests.lib import build_sphinx
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
 from tests.lib import parse
-from tests.lib import prepare_conf
 import os
-import unittest
 
 
-class TestConfluenceUseCaseNestedRef(unittest.TestCase):
+class TestConfluenceUseCaseNestedRef(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
+        super(TestConfluenceUseCaseNestedRef, cls).setUpClass()
+
         cls.config['root_doc'] = 'nested-ref-contents'
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'use-cases')
+        cls.dataset = os.path.join(cls.datasets, 'use-cases')
         cls.filenames = [
             'nested-ref-contents',
             'nested-ref-external',
         ]
 
-    def test_usecase_nestedref(self):
-        out_dir = build_sphinx(self.dataset, config=self.config,
-            filenames=self.filenames)
+    @setup_builder('confluence')
+    def test_usecase_storage_nestedref(self):
+        out_dir = self.build(self.dataset, filenames=self.filenames)
 
         with parse('nested-ref-contents', out_dir) as data:
             # contents link to header (via anchor)


### PR DESCRIPTION
Introduces a new class `ConfluenceTestCase` to provide common capabilities across multiple unit tests which prepare/build a Sphinx dataset. This new class aims to do two things (in this initial implementation):

1) Provide default initialization for common settings/paths. The class can default generate a valid initial configuration for unit tests to use without needing to explicit create a common/dummy configuration. The attribute `config` will be always available for a unit test class. In addition, common directories will be populated as well. The attributes `assets_dir`, `datasets` and `templates_dir` will be available without having each class needing to determine the proper pathing for these directories.
  
2) Provide an easy way to define builder options (and in the future, parser options). When preparing a Sphinx setup or invoke a Sphinx builder, configuration and build options need to be explicitly set in the argument options for these calls. There is a desire to minimize the need to explicitly inject configuration options if a unit test does not need to override/set defaults. Using the new test base's `build`/`prepare` calls, the configuration used can be the class instance's prepare configuration if not explicitly set.
\
  There is also a desire to define which builder type (and in the future, editor/parser type) using decorators, without needing to explicit pass in these options in the build/prepare calls. Using a decorator-like style, it should be easier to define tests as we introduce newer builders/formats to test/parse against.

Refactor various unit tests to use the newly added `ConfluenceTestCase` class, in an attempt to simplify the testing logic.