### PR TITLE
publisher: forward explicit space type when updating homepage

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 
 See also:

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -26,6 +26,7 @@ import time
 class ConfluencePublisher:
     def __init__(self):
         self.space_display_name = None
+        self.space_type = None
         self._ancestors_cache = set()
         self._name_cache = {}
 
@@ -118,8 +119,9 @@ class ConfluencePublisher:
             raise ConfluenceBadServerUrlError(server_url,
                 'server did not provide an expected response (no name)')
 
-        # track the space's display name
+        # track required space information
         self.space_display_name = result['name']
+        self.space_type = result['type']
 
     def disconnect(self):
         self.rest_client.close()
@@ -768,7 +770,8 @@ class ConfluencePublisher:
             self.rest_client.put('space', self.space_key, {
                 'key': self.space_key,
                 'name': self.space_display_name,
-                'homepage': page
+                'homepage': page,
+                'type': self.space_type,
             })
         except ConfluencePermissionError:
             raise ConfluencePermissionError(

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -110,6 +110,7 @@ class TestConfluencePublisherConnect(unittest.TestCase):
             'size': 1,
             'results': [{
                 'name': std_space_name,
+                'type': 'global',
             }],
         }
 
@@ -118,6 +119,7 @@ class TestConfluencePublisherConnect(unittest.TestCase):
             'size': 1,
             'results': [{
                 'name': proxy_space_name,
+                'type': 'global',
             }],
         }
 
@@ -223,6 +225,7 @@ class TestConfluencePublisherConnect(unittest.TestCase):
             'size': 1,
             'results': [{
                 'name': space_name,
+                'type': 'global',
             }],
         }
 

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -20,6 +20,7 @@ class TestConfluencePublisherPage(unittest.TestCase):
             'size': 1,
             'results': [{
                 'name': 'Mock Space',
+                'type': 'global',
             }],
         }
 


### PR DESCRIPTION
When a user configures `confluence_root_homepage` to adjust the homepage for a personal space on Confluence Cloud, the instance will implicitly attempt to adjust the space type to `global` instead of its original `personal` type. Confluence will automatically fail the REST attempt with the message:

    Cannot change space type from personal to global or vice versa

To prevent this, explicitly configure the space's type field to the original once detected when querying the space information during initialization.