### PR TITLE
support rate limiting

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1090,6 +1090,8 @@ Advanced publishing configuration
 
 .. confval:: confluence_publish_delay
 
+    .. versionadded:: 1.8
+
     Force a delay (in seconds) for any API calls made to a Confluence instance.
     By default, API requests will be made to a Confluence instance as soon as
     possible (or until Confluence reports that the client should be rate

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1088,6 +1088,19 @@ Advanced publishing configuration
 
     See also |confluence_publish_denylist|_.
 
+.. confval:: confluence_publish_delay
+
+    Force a delay (in seconds) for any API calls made to a Confluence instance.
+    By default, API requests will be made to a Confluence instance as soon as
+    possible (or until Confluence reports that the client should be rate
+    limiting). A user can use this option to reduce how fast this extension may
+    attempt to interact with the Confluence instance. For example, to delay each
+    API request by almost a 1/4 of a second, the following can be used:
+
+    .. code-block:: python
+
+        confluence_publish_delay = 0.25
+
 .. |confluence_publish_denylist| replace:: ``confluence_publish_denylist``
 .. _confluence_publish_denylist:
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -155,6 +155,8 @@ def setup(app):
     app.add_config_value('confluence_proxy', None, '')
     # Subset of documents which are allowed to be published.
     app.add_config_value('confluence_publish_allowlist', None, '')
+    # Duration (in seconds) to delay each API request.
+    app.add_config_value('confluence_publish_delay', None, '')
     # Subset of documents which are denied to be published.
     app.add_config_value('confluence_publish_denylist', None, '')
     # Header(s) to use for Confluence REST interaction.

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -436,6 +436,11 @@ names are relative to the documentation's source directory.
 
     # ##################################################################
 
+    validator.conf('confluence_publish_delay') \
+             .float_(positive=True)
+
+    # ##################################################################
+
     # confluence_publish_dryrun
     validator.conf('confluence_publish_dryrun') \
              .bool()

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -235,6 +235,47 @@ class ConfigurationValidation:
 
         return self
 
+    def float_(self, positive=False):
+        """
+        checks if a configuration is a float
+
+        After an instance has been set a configuration key (via `conf`), this
+        method can be used to check if the value (if any) configured with this
+        key is a float. If not, an `ConfluenceConfigurationError` exception
+        will be thrown.
+
+        In the event that the configuration is not set (e.g. a value of `None`),
+        this method will have no effect.
+
+        Args:
+            positive (optional): whether or not the float value must be a
+                                  positive value (default: False)
+
+        Returns:
+            the validator instance
+        """
+        value = self._value()
+
+        if value is not None:
+            if isinstance(value, basestring):
+                try:
+                    value = float(value)
+                except ValueError:
+                    raise ConfluenceConfigurationError(
+                        '%s is not a float string' % self.key)
+            elif isinstance(value, int):
+                value = float(value)
+
+            if positive:
+                if not isinstance(value, float) or value <= 0:
+                    raise ConfluenceConfigurationError(
+                        '%s is not a positive float' % self.key)
+            elif not isinstance(value, float) or value < 0:
+                raise ConfluenceConfigurationError(
+                    '%s is not a non-negative float' % self.key)
+
+        return self
+
     def int_(self, positive=False):
         """
         checks if a configuration is an integer

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -197,6 +197,23 @@ please inform the maintainers of this extension.
 '''.format(name=page_name))
 
 
+class ConfluenceRateLimited(ConfluenceError):
+    def __init__(self, delay=None):
+        super(ConfluenceRateLimited, self).__init__('''
+---
+Request has been rate limited
+
+The configured Confluence instance is reporting that too many requests
+are being made and has instructed to client to limit the amount of
+requests to make at this time.
+---
+''')
+        try:
+            self.delay = int(delay)
+        except (TypeError, ValueError):
+            self.delay = None
+
+
 class ConfluenceSeraphAuthenticationFailedUrlError(ConfluenceError):
     def __init__(self):
         super(ConfluenceSeraphAuthenticationFailedUrlError, self).__init__('''

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -18,7 +18,7 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluencePublishAncestor
 from sphinxcontrib.confluencebuilder.exceptions import ConfluencePublishSelfAncestorError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceUnreconciledPageError
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
-from sphinxcontrib.confluencebuilder.rest import Rest
+from sphinxcontrib.confluencebuilder.rest import RestRateLimited
 import json
 import time
 
@@ -51,7 +51,7 @@ class ConfluencePublisher:
             self.can_labels = 'labels' not in config.confluence_adv_restricted
 
     def connect(self):
-        self.rest_client = Rest(self.config)
+        self.rest_client = RestRateLimited(self.config)
         server_url = self.config.confluence_server_url
 
         try:

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -50,7 +50,7 @@ class SslAdapter(HTTPAdapter):
         return super(SslAdapter, self).init_poolmanager(*args, **kwargs)
 
 
-class Rest:
+class Rest(object):
     CONFLUENCE_DEFAULT_ENCODING = 'utf-8'
 
     def __init__(self, config):

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -136,7 +136,7 @@ class Rest(object):
             raise ConfluencePermissionError("REST GET")
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
-        if rsp.status_code == 429 or RSP_HEADER_RETRY_AFTER in rsp.headers:
+        if rsp.status_code == 429:
             raise ConfluenceRateLimited(rsp.headers.get(RSP_HEADER_RETRY_AFTER))
         if not rsp.ok:
             errdata = self._format_error(rsp, key)
@@ -170,7 +170,7 @@ class Rest(object):
             raise ConfluencePermissionError("REST POST")
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
-        if rsp.status_code == 429 or RSP_HEADER_RETRY_AFTER in rsp.headers:
+        if rsp.status_code == 429:
             raise ConfluenceRateLimited(rsp.headers.get(RSP_HEADER_RETRY_AFTER))
         if not rsp.ok:
             errdata = self._format_error(rsp, key)
@@ -206,7 +206,7 @@ class Rest(object):
             raise ConfluencePermissionError("REST PUT")
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
-        if rsp.status_code == 429 or RSP_HEADER_RETRY_AFTER in rsp.headers:
+        if rsp.status_code == 429:
             raise ConfluenceRateLimited(rsp.headers.get(RSP_HEADER_RETRY_AFTER))
         if not rsp.ok:
             errdata = self._format_error(rsp, key)
@@ -242,7 +242,7 @@ class Rest(object):
             raise ConfluencePermissionError("REST DELETE")
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
-        if rsp.status_code == 429 or RSP_HEADER_RETRY_AFTER in rsp.headers:
+        if rsp.status_code == 429:
             raise ConfluenceRateLimited(rsp.headers.get(RSP_HEADER_RETRY_AFTER))
         if not rsp.ok:
             errdata = self._format_error(rsp, key)

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -277,6 +277,8 @@ class RestRateLimited(Rest):
             config: the sphinx configuration
         """
         super(RestRateLimited, self).__init__(config)
+
+        self.forced_delay = config.confluence_publish_delay
         self.last_retry = 1
         self.max_retries = 5
         self.max_retry_duration = 30
@@ -298,6 +300,10 @@ class RestRateLimited(Rest):
         return self._process(method, *args, **kwargs)
 
     def _process(self, call, *args, **kwargs):
+        # apply any user-set delay on an api request
+        if self.forced_delay:
+            time.sleep(self.forced_delay)
+
         attempt = 1
         self.last_retry = max(self.last_retry / 2, 1)
         while True:

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -10,15 +10,21 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadServerUrlErr
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceCertificateError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluencePermissionError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceProxyPermissionError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceRateLimited
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceSeraphAuthenticationFailedUrlError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceSslError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceTimeoutError
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
 from sphinxcontrib.confluencebuilder.std.confluence import NOCHECK
+from sphinxcontrib.confluencebuilder.std.confluence import RSP_HEADER_RETRY_AFTER
 from requests.adapters import HTTPAdapter
 import json
+import math
+import random
 import requests
 import ssl
+import time
 
 
 class SslAdapter(HTTPAdapter):
@@ -130,6 +136,8 @@ class Rest:
             raise ConfluencePermissionError("REST GET")
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
+        if rsp.status_code == 429 or RSP_HEADER_RETRY_AFTER in rsp.headers:
+            raise ConfluenceRateLimited(rsp.headers.get(RSP_HEADER_RETRY_AFTER))
         if not rsp.ok:
             errdata = self._format_error(rsp, key)
             raise ConfluenceBadApiError(rsp.status_code, errdata)
@@ -162,6 +170,8 @@ class Rest:
             raise ConfluencePermissionError("REST POST")
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
+        if rsp.status_code == 429 or RSP_HEADER_RETRY_AFTER in rsp.headers:
+            raise ConfluenceRateLimited(rsp.headers.get(RSP_HEADER_RETRY_AFTER))
         if not rsp.ok:
             errdata = self._format_error(rsp, key)
             if self.verbosity > 0:
@@ -196,6 +206,8 @@ class Rest:
             raise ConfluencePermissionError("REST PUT")
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
+        if rsp.status_code == 429 or RSP_HEADER_RETRY_AFTER in rsp.headers:
+            raise ConfluenceRateLimited(rsp.headers.get(RSP_HEADER_RETRY_AFTER))
         if not rsp.ok:
             errdata = self._format_error(rsp, key)
             if self.verbosity > 0:
@@ -230,6 +242,8 @@ class Rest:
             raise ConfluencePermissionError("REST DELETE")
         if rsp.status_code == 407:
             raise ConfluenceProxyPermissionError
+        if rsp.status_code == 429 or RSP_HEADER_RETRY_AFTER in rsp.headers:
+            raise ConfluenceRateLimited(rsp.headers.get(RSP_HEADER_RETRY_AFTER))
         if not rsp.ok:
             errdata = self._format_error(rsp, key)
             raise ConfluenceBadApiError(rsp.status_code, errdata)
@@ -248,3 +262,68 @@ class Rest:
         except:  # noqa: E722
             err += 'DATA: <not-or-invalid-json>'
         return err
+
+
+class RestRateLimited(Rest):
+    def __init__(self, config):
+        """
+        a rest rate limited instance
+
+        The following is a utility class to handle the same REST API calls
+        provided by the `Rest` class, but attempt to handle rate-limited
+        retries if Confluence reports that API calls should be limited.
+
+        Args:
+            config: the sphinx configuration
+        """
+        super(RestRateLimited, self).__init__(config)
+        self.last_retry = 1
+        self.max_retries = 5
+        self.max_retry_duration = 30
+
+    def get(self, *args, **kwargs):
+        method = super(RestRateLimited, self).get
+        return self._process(method, *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        method = super(RestRateLimited, self).post
+        return self._process(method, *args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        method = super(RestRateLimited, self).put
+        return self._process(method, *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        method = super(RestRateLimited, self).delete
+        return self._process(method, *args, **kwargs)
+
+    def _process(self, call, *args, **kwargs):
+        attempt = 1
+        self.last_retry = max(self.last_retry / 2, 1)
+        while True:
+            try:
+                return call(*args, **kwargs)
+            except ConfluenceRateLimited as e:
+                # if max attempts have been reached, stop any more attempts
+                if attempt > self.max_retries:
+                    raise e
+
+                # determine the amount of delay to wait again -- either from the
+                # provided delay (if any) or exponential backoff
+                if e.delay:
+                    delay = e.delay
+                else:
+                    delay = 2 * self.last_retry
+
+                # cap delay to a maximum
+                delay = min(delay, self.max_retry_duration)
+
+                # add jitter
+                delay += random.uniform(0.3, 1.3)
+
+                # wait the calculated delay before retrying again
+                logger.warn('rate-limit response detected; '
+                            'waiting {} seconds...'.format(math.ceil(delay)))
+                time.sleep(delay)
+                self.last_retry = delay
+                attempt += 1

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -162,6 +162,15 @@ if 'CONFLUENCEBUILDER_LEGACY_NOCHECK' in os.environ:
 else:
     NOCHECK = 'no-check'
 
+# confluence api "retry after" header entry
+#
+# Confluence may response with a `Retry-After` when rate limiting has been
+# imposed on an API request. This entry keeps track of the header key entry
+# which reports the recommended duration till next retry.
+#
+# (see also: https://developer.atlassian.com/cloud/confluence/rate-limiting/)
+RSP_HEADER_RETRY_AFTER = 'Retry-After'
+
 # supported image types
 #
 # A list of image types (mostly) supported on a Confluence instance. This

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -487,6 +487,20 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
+    def test_config_check_publish_delay(self):
+        self.config['confluence_publish_delay'] = 0.3
+        self._try_config()
+
+        self.config['confluence_publish_delay'] = 1
+        self._try_config()
+
+        self.config['confluence_publish_delay'] = '0.7'
+        self._try_config()
+
+        self.config['confluence_publish_delay'] = -1
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
     def test_config_check_publish_headers(self):
         self.config['confluence_publish_headers'] = {}
         self._try_config()

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 


### PR DESCRIPTION
### support rate limiting

Provides an initial implementation to help limit API requests invoked to a Confluence instance is the instance reports that requests are being rate limited \[1\].

\[1\]: https://developer.atlassian.com/cloud/confluence/rate-limiting/

### provide user-hinted api delays

Introduces a new configuration option `confluence_publish_delay` to allow a user to force delays between API requests. This can help specific user environments which have either large data sets or want to limit a rapid series of API requests to a configured instance.