### PR TITLE
support personal access tokens

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -98,6 +98,11 @@ Essential configuration
 
 .. confval:: confluence_server_user
 
+    .. note::
+
+        If using a personal access token (PAT), this option does not need to
+        set (see |confluence_publish_token|_).
+
     The username value used to authenticate with the Confluence instance. If
     using Confluence Cloud, this value will most likely be the account's E-mail
     address. If using Confluence Server, this value will most likely be the
@@ -126,6 +131,11 @@ Essential configuration
         desired, this extension provides a method for prompting for a
         password (see |confluence_ask_password|_).
 
+    .. note::
+
+        If attempting to use a personal access token (PAT), use the
+        |confluence_publish_token|_ option instead.
+
     The password value used to authenticate with the Confluence instance. If
     using Confluence Cloud, it is recommended to use an API token for the
     configured username value (see `API tokens`_):
@@ -140,6 +150,35 @@ Essential configuration
     .. code-block:: python
 
         confluence_server_pass = 'myawesomepassword'
+
+.. |confluence_publish_token| replace:: ``confluence_publish_token``
+.. _confluence_publish_token:
+
+.. confval:: confluence_publish_token
+
+    .. versionadded:: 1.8
+
+    .. caution::
+
+        It is never recommended to store a personal access tokens (PAT) into a
+        committed/shared repository holding documentation.
+
+        A documentation's configuration can modified various ways with Python
+        to pull an authentication token for a publishing event such as
+        :ref:`reading from an environment variable <tip_manage_publish_subset>`,
+        reading from a local file or acquiring a token from ``getpass``.
+
+    .. note::
+
+        If attempting to use an API token, use the |confluence_server_pass|_
+        option instead.
+
+    The personal access token value used to authenticate with the Confluence
+    instance (see `Using Personal Access Tokens`_):
+
+    .. code-block:: python
+
+        confluence_publish_token = 'AbCdEfGhIjKlMnOpQrStUvWxY/z1234567890aBc'
 
 Generic configuration
 ---------------------
@@ -1478,6 +1517,7 @@ Deprecated options
 .. _Requests: https://pypi.python.org/pypi/requests
 .. _Sphinx configurations: https://www.sphinx-doc.org/en/master/usage/configuration.html
 .. _TLS/SSL wrapper for socket object: https://docs.python.org/3/library/ssl.html#ssl.create_default_context
+.. _Using Personal Access Tokens: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
 .. _api_tokens: https://confluence.atlassian.com/cloud/api-tokens-938839638.html
 .. _get_outdated_docs: https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder.get_outdated_docs
 .. _get_relative_uri: https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder.get_relative_uri

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -55,6 +55,8 @@ def setup(app):
     # (configuration - essential)
     # Enablement of publishing.
     app.add_config_value('confluence_publish', None, '')
+    # PAT to authenticate to Confluence API with.
+    app.add_config_value('confluence_publish_token', None, '')
     # API key/password to login to Confluence API with.
     app.add_config_value('confluence_server_pass', None, '')
     # URL of the Confluence instance to publish to.

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -208,6 +208,7 @@ def report_main(args_parser):
     # always sanitize out sensitive information
     sensitive_config('confluence_client_cert_pass')
     sensitive_config('confluence_publish_headers')
+    sensitive_config('confluence_publish_token')
     sensitive_config('confluence_server_pass')
 
     # optional sanitization

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -476,6 +476,12 @@ names are relative to the documentation's source directory.
 
     # ##################################################################
 
+    # confluence_publish_token
+    validator.conf('confluence_publish_token') \
+             .string()
+
+    # ##################################################################
+
     # confluence_purge
     validator.conf('confluence_purge') \
              .bool()

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -42,9 +42,10 @@ details for more information:
 
 
 class ConfluenceBadSpaceError(ConfluenceError):
-    def __init__(self, space_key, uname, pw_set, extras):
+    def __init__(self, space_key, uname, pw_set, token_set, extras):
         uname_value = uname if uname else '(empty)'
         pw_value = '<set>' if pw_set else '(empty)'
+        token_value = '<set>' if token_set else '(empty)'
         super(ConfluenceBadSpaceError, self).__init__('''
 ---
 Invalid Confluence URL detected
@@ -54,15 +55,16 @@ The configured Confluence space key does not appear to be valid:
     Space key: {space_key}
      Username: {uname}
      Password: {pw}
+        Token: {token}
 
 Ensure the instance is running and inspect that the configured
 Confluence URL is valid. Also ensure authentication options are properly
 set.
 
-Note: Confluence space keys are case-sensitive.
-{details}
+Note: Confluence space keys are case-sensitive.{details}
 ---
-'''.format(space_key=space_key, uname=uname_value, pw=pw_value, details=extras))
+'''.format(space_key=space_key, uname=uname_value, pw=pw_value,
+        token=token_value, details=extras))
 
 
 class ConfluenceBadServerUrlError(ConfluenceError):
@@ -124,7 +126,8 @@ class ConfluencePermissionError(ConfluenceError):
 Permission denied on Confluence ({desc})
 
 The configured user does not have permission to perform an action on the
-Confluence instance.
+Confluence instance. If the user should have access and this request is
+using a personal access token, ensure the token is not expired/revoked.
 ---
 '''.format(desc=details))
 

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -85,7 +85,7 @@ class ConfluencePublisher:
                 space_key = detected_space['space']['key']
                 space_name = detected_space['title']
                 extra_desc = \
-                    '''\n''' \
+                    '''\n\n''' \
                     '''There appears to be a space '{0}' which has a name ''' \
                     ''''{1}'. Did you mean to use this space?\n''' \
                     '''\n''' \
@@ -94,7 +94,7 @@ class ConfluencePublisher:
 
             elif rsp['size'] > 1:
                 extra_desc = \
-                    '''\n''' \
+                    '''\n\n''' \
                     '''Multiple spaces have been detected which use the ''' \
                     '''name '{}'. The unique key of the space should be ''' \
                     '''used instead. See also:\n\n''' \
@@ -102,10 +102,13 @@ class ConfluencePublisher:
                     ''''''.format(self.space_key)
 
             pw_set = bool(self.config.confluence_server_pass)
+            token_set = bool(self.config.confluence_publish_token)
+
             raise ConfluenceBadSpaceError(
                 self.space_key,
                 self.config.confluence_server_user,
                 pw_set,
+                token_set,
                 extra_desc)
 
         # sanity check that we have any result

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -75,6 +75,12 @@ class Rest(object):
                 'https': config.confluence_proxy,
             }
 
+        # add pat into header if provided
+        if config.confluence_publish_token:
+            session.headers.update({
+                'Authorization': 'Bearer ' + config.confluence_publish_token,
+            })
+
         # add custom header options based off the user's configuration
         if config.confluence_publish_headers:
             session.headers.update(config.confluence_publish_headers)

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -641,6 +641,13 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
+    def test_config_check_publish_token(self):
+        self.config['confluence_publish_token'] = ''
+        self._try_config()
+
+        self.config['confluence_publish_token'] = 'dummy'
+        self._try_config()
+
     def test_config_check_secnumber_suffix(self):
         self.config['confluence_secnumber_suffix'] = ''
         self._try_config()

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -129,8 +129,11 @@ class TestConfluencePublisherConnect(unittest.TestCase):
             first_request = daemon.pop_get_request()
             self.assertIsNotNone(first_request)
             _, headers = first_request
-            self.assertTrue('authorization' in headers)
-            self.assertEqual(headers['authorization'], expected_auth_value)
+            auth_header = headers.get('Authorization')
+            if not auth_header:
+                auth_header = headers.get('authorization')
+            self.assertIsNotNone(auth_header)
+            self.assertEqual(auth_header, expected_auth_value)
 
     def test_publisher_connect_proxy(self):
         """validate publisher can find a valid space"""

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -99,6 +99,39 @@ class TestConfluencePublisherConnect(unittest.TestCase):
             with self.assertRaises(ConfluenceBadServerUrlError):
                 publisher.connect()
 
+    def test_publisher_connect_pat(self):
+        """validate publisher issues a pat-authorization header"""
+        #
+        # Verify that a publisher will issue an `Authorization` header when
+        # configure to use a personal access token.
+
+        token = 'dummy-pat-value'
+        expected_auth_value = 'Bearer {}'.format(token)
+
+        config = self.config.clone()
+        config.confluence_publish_token = token
+
+        val = {
+            'size': 1,
+            'results': [{
+                'name': 'My Space',
+                'type': 'global',
+            }],
+        }
+
+        with mock_confluence_instance(config) as daemon:
+            daemon.register_get_rsp(200, val)
+
+            publisher = ConfluencePublisher()
+            publisher.init(config)
+            publisher.connect()
+
+            first_request = daemon.pop_get_request()
+            self.assertIsNotNone(first_request)
+            _, headers = first_request
+            self.assertTrue('authorization' in headers)
+            self.assertEqual(headers['authorization'], expected_auth_value)
+
     def test_publisher_connect_proxy(self):
         """validate publisher can find a valid space"""
         #


### PR DESCRIPTION
Provides a configuration option for users to easily user personal access tokens (PATs) for authentication. This avoids the need for a user to configure `confluence_publish_headers` and manually configure the `Authorization` header entry.