### PR TITLE
add publish debugging option

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1088,6 +1088,19 @@ Advanced publishing configuration
 
     See also |confluence_publish_denylist|_.
 
+.. confval:: confluence_publish_debug
+
+    .. versionadded:: 1.8
+
+    A boolean value to whether or not to print debug requests made to a
+    Confluence instance. This can be helpful for users attempting to debug
+    their connection to a Confluence instance. By default, this option is
+    disabled with a value of ``False``.
+
+    .. code-block:: python
+
+        confluence_publish_debug = True
+
 .. confval:: confluence_publish_delay
 
     .. versionadded:: 1.8

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -155,6 +155,8 @@ def setup(app):
     app.add_config_value('confluence_proxy', None, '')
     # Subset of documents which are allowed to be published.
     app.add_config_value('confluence_publish_allowlist', None, '')
+    # Enable debugging for publish requests.
+    app.add_config_value('confluence_publish_debug', None, '')
     # Duration (in seconds) to delay each API request.
     app.add_config_value('confluence_publish_delay', None, '')
     # Subset of documents which are denied to be published.

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -66,6 +66,7 @@ def apply_defaults(conf):
         'confluence_master_homepage',
         'confluence_page_generation_notice',
         'confluence_page_hierarchy',
+        'confluence_publish_debug',
         'confluence_publish_dryrun',
         'confluence_publish_onlynew',
         'confluence_purge',

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -20,6 +20,7 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluenceUnreconciledPag
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.rest import RestRateLimited
 import json
+import logging
 import time
 
 
@@ -34,6 +35,7 @@ class ConfluencePublisher:
         self.config = config
         self.append_labels = config.confluence_append_labels
         self.can_labels = True
+        self.debug = config.confluence_publish_debug
         self.dryrun = config.confluence_publish_dryrun
         self.notify = not config.confluence_disable_notifications
         self.onlynew = config.confluence_publish_onlynew
@@ -46,6 +48,13 @@ class ConfluencePublisher:
         # append labels by default
         if self.append_labels is None:
             self.append_labels = True
+
+        # if debugging, enable requests (urllib3) logging
+        if self.debug:
+            logging.basicConfig()
+            logging.getLogger().setLevel(logging.DEBUG)
+            rlog = logging.getLogger('requests.packages.urllib3')
+            rlog.setLevel(logging.DEBUG)
 
         if config.confluence_adv_restricted is not None:
             self.can_labels = 'labels' not in config.confluence_adv_restricted


### PR DESCRIPTION
Provides a configuration option for users to print out requests made to a Confluence instance (GET's, PUT's, etc.). This is to help provide additional information to users attempting to debug their connections, without having them have to manually configure more complex debug logging in their Sphinx configuration.