### PR TITLE
improved math/latex support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1427,6 +1427,47 @@ Advanced processing configuration
 
        confluence_lang_transform = my_language_translation
 
+.. |confluence_latex_macro| replace:: ``confluence_latex_macro``
+.. _confluence_latex_macro:
+
+.. confval:: confluence_latex_macro
+
+    .. note::
+
+        Confluence does not provide stock support for LaTeX macros.
+
+    The name of a LaTeX macro to use when wishing to render LaTeX content on
+    a Confluence instance. Stock Confluence instances do not support LaTeX
+    content by default. However, if an instance has installed a marketplace
+    add-on that supports LaTeX, this option can be used to hint to render LaTeX
+    content (such as mathematical notation) by configuring this option.
+
+    .. code-block:: python
+
+        confluence_latex_macro = 'macro-name'
+         (or)
+        confluence_latex_macro = {
+            'block-macro': 'block-macro-name',
+            'inline-macro': 'inline-macro-name',
+            'inline-macro-param': 'inline-macro-parameter', # (optional)
+        }
+
+    The name of a LaTeX macro will vary based on which add-on is installed.
+    For a list of known macro names or steps to determine the name of a
+    supported macro, consult the
+    :ref:`macro table/instructions <guide_math_macro_names>`
+    found in the math guide.
+
+    If this option is not set, any LaTeX content processed in a document will
+    instead be converted to images using dvipng/dvisvgm (see also
+    `sphinx.ext.imgmath`_ for additional information).
+
+    See also:
+
+    - :ref:`LaTeX directives <latex-directives>`
+    - :ref:`LaTeX roles <latex-roles>`
+    - :doc:`guide-math`
+
 .. |confluence_link_suffix| replace:: ``confluence_link_suffix``
 .. _confluence_link_suffix:
 
@@ -1536,5 +1577,6 @@ Deprecated options
 .. _get_relative_uri: https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder.get_relative_uri
 .. _root_doc: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-root_doc
 .. _sphinx-build: https://www.sphinx-doc.org/en/master/man/sphinx-build.html
+.. _sphinx.ext.imgmath: https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.imgmath
 .. _toctree: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree
 .. _write_doc: https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder.write_doc

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -12,6 +12,7 @@ Documentation contents
     roles
     features
     tips
+    guides
     changelog
 
 Indices and tables

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -233,6 +233,52 @@ Confluence documents.
 
     See also :ref:`Jira roles <jira-roles>`.
 
+.. _latex-directives:
+
+LaTeX
+-----
+
+.. note::
+
+    LaTeX support requires dvipng/dvisvgm to be installed on system; however,
+    if a Confluence instance supports a LaTeX macro, the
+    ``confluence_latex_macro`` (:ref:`ref<confluence_latex_macro>`) option can
+    be used instead. For more information, please read :doc:`guide-math`.
+
+The following directive can be used to help add LaTeX content into a
+Confluence page.
+
+.. rst:directive:: .. confluence_latex::
+
+    .. versionadded:: 1.8
+
+    The ``confluence_latex`` directive allows a user to add LaTeX content into
+    a document. For example:
+
+    .. code-block:: rst
+
+        .. confluence_latex::
+
+            $\mathfrak{H}$ello world!
+
+    This directive supports the following options:
+
+    .. rst:directive:option:: align: "left", "center", or "right"
+        :type: string
+
+        The alignment to apply on the LaTeX content. By default, the value is
+        set to ``center``.
+
+        .. code-block:: rst
+
+            .. confluence_latex::
+                :align: left
+
+                $\mathfrak{H}$ello world!
+
+See also :ref:`LaTeX roles <latex-roles>`.
+
+
 .. references ------------------------------------------------------------------
 
 .. _Expand Macro: https://confluence.atlassian.com/doc/expand-macro-223222352.html

--- a/doc/guide-math.rst
+++ b/doc/guide-math.rst
@@ -1,0 +1,189 @@
+Math support
+============
+
+.. versionchanged:: 1.8 Support for using Confluence-supported LaTeX macros.
+.. versionchanged:: 1.7 SVG-generated math images requires the
+                         ``sphinx.ext.imgmath`` extension to be explicitly
+                         registered to work.
+.. versionchanged:: 1.4 Support both block and inlined math elements.
+.. versionadded:: 1.2 Initial support for math.
+
+Mathematical notation is supported when using the Confluence builder extension.
+There are some limitations and special cases a user may wish to consider when
+trying to get the most our of their documentation/environment.
+
+The recommended approach for rendering math in Confluence is using Sphinx's
+`sphinx.ext.imgmath`_ extension. This extension renders math via LaTeX and uses
+either dvipng or dvisvgm to create PNG or SVG images which are published to
+Confluence (which requires installing a LaTeX engine alongside the Sphinx
+installation, such as a TeX suite/MiKTeX installation).
+
+Math can be defined using the ``:math:`` role or the ``.. math::`` directive.
+For example:
+
+.. code-block:: rst
+
+    The Pythagorean theorem formula is :math:`a^2 + b^2 = c^2`.
+
+    The mass–energy equivalence formula:
+
+    .. math::
+
+        E = mc^2
+
+The former case will generate math content in an inlined fashion, where the
+latter will generate a math block. Math defined in this way is supported on
+Sphinx's standard builders with the help of other Sphinx-provided math
+extensions.
+
+Recommended options for math
+----------------------------
+
+Ensure the `sphinx.ext.imgmath`_ extension is added to the documentation's
+extension list:
+
+.. code-block:: python
+
+    extensions = [
+        'sphinx.ext.imgmath',
+        'sphinxcontrib.confluencebuilder',
+    ]
+
+If loading the `sphinx.ext.imgmath`_ extension conflicts with other builders,
+the extension can be optionally included using an approach such as follows
+(but may require additional changes depending on the environment):
+
+.. code-block:: python
+
+    import sys
+
+    extensions = [
+        'sphinxcontrib.confluencebuilder',
+    ]
+
+    if any('confluence' in arg for arg in sys.argv):
+        extensions.append('sphinx.ext.imgmath')
+
+The following are the recommended options to use:
+
+.. code-block:: python
+
+    imgmath_font_size = 14
+    imgmath_image_format = 'svg'
+    imgmath_use_preview = True
+
+This configures the generated font size commonly observed on Confluence
+instances, hints that images are generated into SVG images (for ideal image
+scaling) and attempt to process the "depth" of an image to better align content
+alongside text.
+
+Support for LaTeX math
+----------------------
+
+.. note::
+
+    This section outlines how users can take advantage of LaTeX macros enabled
+    on their Confluence instance. The Confluence builder extension only helps
+    forward LaTeX-generated content directly into macros. How a LaTeX macro
+    decides to handle/render LaTeX content is up to the provider supporting the
+    macro.
+
+.. note::
+
+    Not all LaTeX macros support block and inline macros (normally, just the
+    former).
+
+.. note::
+
+    Confluence builder will attempt to support numbered equations by adding
+    a floating label alongside a rendered math block. The variety of LaTeX
+    macros which exist and limitations in how LaTeX macros are structured in
+    a page may prevent the ability to perfectly align these labels alongside
+    the rendered math content.
+
+A stock Confluence instance does not provided LaTeX support. This is the main
+reason why the Confluence builder extension promotes the use of
+`sphinx.ext.imgmath`_. However, if a user's Confluence instance supports a
+marketplace add-on which provides LaTeX macro support, math content can instead
+be injected into these macros instead.
+
+To use a LaTeX macro, the ``confluence_latex_macro``
+(:ref:`ref<confluence_latex_macro>`) configuration option can be used. This
+option accepts either the name of a macro to use or a dictionary of macro
+options to consider (the dictionary is for more complex configurations such as
+when attempting to support block-specific and inlined-specific macros). For
+example, to specify the macro to use for any LaTeX content, the following
+can be used:
+
+.. code-block:: python
+
+    confluence_latex_macro = 'macro-name'
+
+If an environment supports a macro which supports block and inlined content in
+different macros, the following can be used:
+
+.. code-block:: python
+
+    confluence_latex_macro = {
+        'block-macro': 'block-macro-name',
+        'inline-macro': 'inline-macro-name',
+        'inline-macro-param': 'inline-macro-parameter', # (optional)
+    }
+
+.. _guide_math_macro_names:
+
+LaTeX macro names
+~~~~~~~~~~~~~~~~~
+
+What macro names to use will vary based off which macro types are installed
+(if any). Please consult the following table for reported macro names:
+
+.. list-table::
+    :header-rows: 1
+    :widths: auto
+
+    * - Marketplace Application
+
+      - Configuration
+
+    * - Content Formatting Macros for Confluence
+
+      - .. code-block:: python
+
+            confluence_latex_macro = 'latex-formatting'
+
+    * - LaTeX for Confluence
+
+      - .. code-block:: python
+
+            confluence_latex_macro = 'orah-latex'
+
+    * - LaTeX Math
+
+      - .. code-block:: python
+
+            confluence_latex_macro = {
+                'block-macro': 'mathblock',
+                'inline-macro': 'mathinline',
+                'inline-macro-param': 'body',
+            }
+
+If a Confluence environment supports a different macro type, a user can
+determine the name of the macro by:
+
+1. Creating a new page on the Confluence instance
+2. Adding a LaTeX macro on the page and saving
+3. Selecting the page's option menu and selecting "View Storage format"
+4. Look for the corresponding macro name inside an ``ac:name`` attribute (in
+   this case, the macro's name is ``my-latex-macro``):
+
+   .. code-block:: none
+
+      <ac:structured-macro ac:name="my-latex-macro" ...>
+        ...
+      </ac:structured-macro>
+
+
+.. references ------------------------------------------------------------------
+
+.. _sphinx.ext.imgmath: https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.imgmath

--- a/doc/guides.rst
+++ b/doc/guides.rst
@@ -1,0 +1,10 @@
+Guides
+======
+
+The following contains a series of guides which may help a user using
+the Confluence Builder extension in a Sphinx-enabled environment.
+
+.. toctree::
+    :maxdepth: 1
+
+    guide-math

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -26,6 +26,35 @@ Confluence documents.
 
     See also :ref:`Jira directives <jira-directives>`.
 
+.. _latex-roles:
+
+LaTeX
+-----
+
+.. note::
+
+    LaTeX support requires dvipng/dvisvgm to be installed on system; however,
+    if a Confluence instance supports a LaTeX macro, the
+    ``confluence_latex_macro`` (:ref:`ref<confluence_latex_macro>`) option can
+    be used instead. For more information, please read :doc:`guide-math`.
+
+The following role can be used to help include LaTeX content into generated
+Confluence documents.
+
+.. rst:role:: confluence_latex
+
+    .. versionadded:: 1.8
+
+    The ``confluence_latex`` role allows a user to build inlined LaTeX
+    content. For example:
+
+    .. code-block:: rst
+
+        This is a :confluence_latex:`$\\mathfrak{t}$est`.
+
+See also :ref:`LaTeX directives <latex-directives>`.
+
+
 .. references ------------------------------------------------------------------
 
 .. _roles: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -72,17 +72,6 @@ See also the :ref:`dry run capability <confluence_publish_dryrun>` and the
 
 .. index:: Math (recommended options)
 
-Recommended options for math
-----------------------------
-
-The following are recommended options to use when using `sphinx.ext.imgmath`_:
-
-.. code-block:: python
-
-    imgmath_font_size = 14
-    imgmath_use_preview = True
-    imgmath_image_format = 'svg'
-
 Setting a publishing timeout
 ----------------------------
 
@@ -191,7 +180,3 @@ report, run the following command from the documentation directory:
     (confluence instance)
      ...
     ------------[ cut here ]------------
-
-.. references ------------------------------------------------------------------
-
-.. _sphinx.ext.imgmath: https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.imgmath

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -181,6 +181,8 @@ def setup(app):
     app.add_config_value('confluence_jira_servers', None, 'env')
     # Translation of a raw language to code block macro language.
     app.add_config_value('confluence_lang_transform', None, 'env')
+    # Macro configuration for Confluence-managed LaTeX content.
+    app.add_config_value('confluence_latex_macro', None, 'env')
     # Link suffix for generated files.
     app.add_config_value('confluence_link_suffix', None, 'env')
     # Translation of docname to a (partial) URI.

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -9,6 +9,7 @@ from sphinx.util import docutils
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.config import handle_config_inited
 from sphinxcontrib.confluencebuilder.directives import ConfluenceExpandDirective
+from sphinxcontrib.confluencebuilder.directives import ConfluenceLatexDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceMetadataDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceNewline
 from sphinxcontrib.confluencebuilder.directives import JiraDirective
@@ -19,6 +20,7 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.nodes import jira
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
+from sphinxcontrib.confluencebuilder.roles import ConfluenceLatexRole
 from sphinxcontrib.confluencebuilder.roles import JiraRole
 from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
 
@@ -258,12 +260,14 @@ def confluence_builder_inited(app):
 
     # register directives
     app.add_directive('confluence_expand', ConfluenceExpandDirective)
+    app.add_directive('confluence_latex', ConfluenceLatexDirective)
     app.add_directive('confluence_metadata', ConfluenceMetadataDirective)
     app.add_directive('confluence_newline', ConfluenceNewline)
     app.add_directive('jira', JiraDirective)
     app.add_directive('jira_issue', JiraIssueDirective)
 
     # register roles
+    app.add_role('confluence_latex', ConfluenceLatexRole)
     app.add_role('jira', JiraRole)
 
     # inject compatible autosummary nodes if the extension is available/loaded

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -314,6 +314,42 @@ dictionaries with keys 'id' and 'name' which identify the Jira instances.
 
     # ##################################################################
 
+    # confluence_latex_macro
+    try:
+        validator.conf('confluence_latex_macro').string()
+    except ConfluenceConfigurationError:
+        try:
+            validator.conf('confluence_latex_macro').dict_str_str()
+
+        except ConfluenceConfigurationError:
+            raise ConfluenceConfigurationError('''\
+confluence_latex_macro is not a string or dictionary of strings
+
+The option 'confluence_latex_macro' has been provided to indicate that a
+LaTeX content should be rendered with a LaTeX macro supported on a Confluence
+instance. This value can either be set to a string of the macro to be used or
+set to a dictionary of key-value strings for advanced options.
+''')
+
+        if config.confluence_latex_macro:
+            conf_keys = config.confluence_latex_macro.keys()
+
+            required_keys = [
+                'block-macro',
+                'inline-macro',
+            ]
+
+            if not all(name in conf_keys for name in required_keys):
+                raise ConfluenceConfigurationError('''\
+missing keys in confluence_latex_macro
+
+The following keys are required:
+
+ - {}
+'''.format('\n - '.join(required_keys)))
+
+    # ##################################################################
+
     # confluence_link_suffix
     validator.conf('confluence_link_suffix') \
              .string()

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -40,6 +40,13 @@ def apply_defaults(conf):
     if conf.confluence_jira_servers is None:
         conf.confluence_jira_servers = {}
 
+    if conf.confluence_latex_macro and \
+            not isinstance(conf.confluence_latex_macro, dict):
+        conf.confluence_latex_macro = {
+            'block-macro': conf.confluence_latex_macro,
+            'inline-macro': conf.confluence_latex_macro,
+        }
+
     if conf.confluence_remove_title is None:
         conf.confluence_remove_title = True
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/directives.py
+++ b/sphinxcontrib/confluencebuilder/directives.py
@@ -7,6 +7,7 @@
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 from sphinxcontrib.confluencebuilder.nodes import confluence_expand
+from sphinxcontrib.confluencebuilder.nodes import confluence_latex_block
 from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.nodes import confluence_newline
 from sphinxcontrib.confluencebuilder.nodes import jira
@@ -53,6 +54,22 @@ class ConfluenceExpandDirective(Directive):
             node['title'] = self.options['title']
 
         self.state.nested_parse(self.content, self.content_offset, node)
+        return [node]
+
+
+class ConfluenceLatexDirective(Directive):
+    has_content = True
+    option_spec = {
+        'align': directives.unchanged,
+    }
+
+    def run(self):
+        self.assert_has_content()
+        text = '\n'.join(self.content)
+
+        node = confluence_latex_block(rawsource=text, text=text)
+        node['align'] = self.options.get('align', 'center')
+
         return [node]
 
 

--- a/sphinxcontrib/confluencebuilder/directives.py
+++ b/sphinxcontrib/confluencebuilder/directives.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -76,6 +76,24 @@ class confluence_newline(nodes.Structural, nodes.Element):
     """
 
 
+class confluence_latex_block(nodes.TextElement):
+    """
+    confluence latex block node
+
+    A Confluence builder defined LaTeX block node, used to help manage LaTeX
+    content designed for a block/section.
+    """
+
+
+class confluence_latex_inline(nodes.Inline, nodes.TextElement):
+    """
+    confluence latex inline node
+
+    A Confluence builder defined LaTeX inline node, used to help manage LaTeX
+    content designed for an inlined section of a paragraph.
+    """
+
+
 class confluence_page_generation_notice(nodes.TextElement):
     """
     confluence page generation notice node

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2019-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2019-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/roles.py
+++ b/sphinxcontrib/confluencebuilder/roles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 
 See also docutils roles:

--- a/sphinxcontrib/confluencebuilder/roles.py
+++ b/sphinxcontrib/confluencebuilder/roles.py
@@ -8,7 +8,33 @@ See also docutils roles:
     https://docutils.sourceforge.io/docs/howto/rst-roles.html#define-the-role-function
 """
 
+from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
+
+
+def ConfluenceLatexRole(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """
+    a confluence latex role
+
+    Defines an inline Confluence LaTeX role where users can inject inlined
+    LaTeX content, if their instance supports a LaTeX macro.
+
+    Args:
+        name: local name of the interpreted text role
+        rawtext: the entire interpreted text construct
+        text: the interpreted text content
+        lineno: the line number where the interpreted text beings
+        inliner: inliner object that called the role function
+        options: dictionary of directive options for customization
+        content: list of strings, the directive content for customization
+
+    Returns:
+        returns a tuple include a list of nodes and a list of system messages
+    """
+
+    node = confluence_latex_inline(rawsource=text, text=text)
+
+    return [node], []
 
 
 def JiraRole(name, rawtext, text, lineno, inliner, options=None, content=None):

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -8,6 +8,8 @@ from docutils import nodes
 from os import path
 from sphinx.util.math import wrap_displaymath
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
+from sphinxcontrib.confluencebuilder.nodes import confluence_latex_block
+from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
 from sphinxcontrib.confluencebuilder.svg import confluence_supported_svg
 from sphinxcontrib.confluencebuilder.svg import svg_initialize
 from sphinxcontrib.confluencebuilder.transmute.ext_sphinx_diagrams import replace_sphinx_diagrams_nodes
@@ -220,9 +222,37 @@ def replace_math_blocks(builder, doctree):
         doctree: the doctree to replace blocks on
     """
 
+    # phase 1 -- convert math blocks into Confluence LaTeX blocks
+    for node in itertools.chain(doctree.traverse(nodes.math),
+            doctree.traverse(nodes.math_block)):
+        if not isinstance(node, nodes.math):
+            if node['nowrap']:
+                latex = node.astext()
+            else:
+                latex = wrap_displaymath(node.astext(), None, False)
+            new_node_type = confluence_latex_block
+        else:
+            latex = '$' + node.astext() + '$'
+            new_node_type = confluence_latex_inline
+
+        new_node = new_node_type(latex, latex, **node.attributes)
+        new_node['from_math'] = True
+
+        if not isinstance(node, nodes.math):
+            new_node['align'] = 'center'
+
+        node.replace_self(new_node)
+
+    # disable automatic conversion of latex blocks to images if a latex
+    # macro is configured
+    if builder.config.confluence_latex_macro:
+        return
+
     if imgmath is None:
         return
 
+    # phase 2 -- convert Confluence LaTeX blocks into image blocks
+    #
     # imgmath's render_math call expects a translator to be passed
     # in; mock a translator tied to our builder
     class MockTranslator:
@@ -230,18 +260,10 @@ def replace_math_blocks(builder, doctree):
             self.builder = builder
     mock_translator = MockTranslator(builder)
 
-    for node in itertools.chain(doctree.traverse(nodes.math),
-            doctree.traverse(nodes.math_block)):
+    for node in itertools.chain(doctree.traverse(confluence_latex_inline),
+            doctree.traverse(confluence_latex_block)):
         try:
-            if not isinstance(node, nodes.math):
-                if node['nowrap']:
-                    latex = node.astext()
-                else:
-                    latex = wrap_displaymath(node.astext(), None, False)
-            else:
-                latex = '$' + node.astext() + '$'
-
-            mf, depth = imgmath.render_math(mock_translator, latex)
+            mf, depth = imgmath.render_math(mock_translator, node.astext())
             if not mf:
                 continue
 
@@ -249,11 +271,10 @@ def replace_math_blocks(builder, doctree):
                 candidates={'?'},
                 uri=path.join(builder.outdir, mf),
                 **node.attributes)
-            new_node['from_math'] = True
-            if not isinstance(node, nodes.math):
-                new_node['align'] = 'center'
+
             if depth is not None:
                 new_node['math_depth'] = depth
+
             node.replace_self(new_node)
         except imgmath.MathExtError as exc:
             ConfluenceLogger.warn('inline latex {}: {}'.format(

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -400,6 +400,49 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
+    def test_config_check_latex_macro(self):
+        self.config['confluence_latex_macro'] = 'macro-name'
+        self._try_config()
+
+        self.config['confluence_latex_macro'] = {
+            'block-macro': 'block-macro-name',
+            'inline-macro': 'inline-macro-name',
+        }
+        self._try_config()
+
+        self.config['confluence_latex_macro'] = {
+            'block-macro': 'block-macro-name',
+            'inline-macro': 'inline-macro-name',
+            'inline-macro-param': 'inline-macro-parameter',
+        }
+        self._try_config()
+
+        self.config['confluence_latex_macro'] = {
+            'block-macro': 'block-macro-name',
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_latex_macro'] = {
+            'inline-macro': 'inline-macro-name',
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_latex_macro'] = {
+            'block-macro': 'block-macro-name',
+            'inline-macro': None,
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_latex_macro'] = {
+            'block-macro': None,
+            'inline-macro': 'inline-macro-name',
+        }
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
     def test_config_check_link_suffix(self):
         self.config['confluence_link_suffix'] = '.conf'
         self._try_config()


### PR DESCRIPTION
### support rendering math using latex macros

Adds the ability for users to tailor their documentation generation to use a Confluence-provided LaTeX macro. Confluence does not support LaTeX by default; however, a Confluence instance may support LaTeX if a marketplace add-on provides a macro supporting this.

This commit processing math blocks in a similar fashion as before -- math content is defined in a document, the content is converted into LaTeX and this extension will use the imgmath extension to generate images. This change adds some conditions to stop the conversion from LaTex to images if a user specifies a `confluence_latex_macro` option. When set, a macro will be generated instead (using the value of this option as the name of the macro).

### adding latex directive/role support

Adding support for users to inject LaTeX content into Confluence. LaTeX content will by default rendered into images (in the same manner as math content is generated), or users can take advantage of the `confluence_latex_macro` option.

### add/improve documentation for latex/math support

Adds information on the recently added LaTeX directive/role support, and provides more information on the math capabilities supported by this extension. More in-depth math information is now provided in its own separate guide document.