### PR TITLE
test: active test server asap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,33 +30,8 @@ jobs:
     strategy:
       matrix:
         include:
-            - { os:  ubuntu-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx40, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx41, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx42, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx43, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx44, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx40, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx41, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx42, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx43, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx44, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx40, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx41, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx42, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx43, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx44, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx44, cache: ~/.cache/pip }
-            - { os:   macos-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~/Library/Caches/pip }
             - { os:   macos-latest, python: "3.10", toxenv: py310-sphinx44, cache: ~/Library/Caches/pip }
-            - { os: windows-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~\AppData\Local\pip\Cache }
             - { os: windows-latest, python: "3.10", toxenv: py310-sphinx44, cache: ~\AppData\Local\pip\Cache }
-            - { os:  ubuntu-latest, python: "3.10", toxenv:         flake8, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv:         pylint, cache: ~/.cache/pip }
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,4 @@ jobs:
     - name: tox
       env:
         TOXENV: ${{ matrix.toxenv }}
-      run: while tox -e py310-sphinx44 -- test_publisher_page_store_page_id_default; do sleep 1; done
+      run: tox -- test_publisher_page_store_page_id_default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,4 @@ jobs:
     - name: tox
       env:
         TOXENV: ${{ matrix.toxenv }}
-      run: tox
+      run: while tox -e py310-sphinx44 -- test_publisher_page_store_page_id_default; do sleep 1; done

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -335,8 +335,6 @@ def mock_confluence_instance(config=None, ignore_requests=False):
 
         # start accepting requests
         if not ignore_requests:
-            daemon.server_activate()
-
             sync = Event()
 
             def serve_forever(daemon, sync):

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -335,6 +335,8 @@ def mock_confluence_instance(config=None, ignore_requests=False):
 
         # start accepting requests
         if not ignore_requests:
+            daemon.server_activate()
+
             sync = Event()
 
             def serve_forever(daemon, sync):

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -192,7 +192,8 @@ class ConfluenceInstanceServer(server_socket.TCPServer):
         self.unittest_put_rsp.append((code, data))
 
 
-class ConfluenceInstanceRequestHandler(http_server.SimpleHTTPRequestHandler):
+class ConfluenceInstanceRequestHandler(server_socket.ThreadingMixIn,
+        http_server.SimpleHTTPRequestHandler):
     """
     confluence instance request handler
 

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -22,6 +22,7 @@ class TestConfluencePublisherConnect(unittest.TestCase):
     def setUpClass(cls):
         cls.config = prepare_conf()
         cls.config.confluence_timeout = 5
+        cls.config.confluence_publish_debug = True
 
     def test_publisher_connect_bad_response_code(self):
         """validate publisher can handle bad response code"""

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -21,7 +21,7 @@ class TestConfluencePublisherConnect(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = prepare_conf()
-        cls.config.confluence_timeout = 1
+        cls.config.confluence_timeout = 5
 
     def test_publisher_connect_bad_response_code(self):
         """validate publisher can handle bad response code"""

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -14,7 +14,8 @@ class TestConfluencePublisherPage(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = prepare_conf()
-        cls.config.confluence_timeout = 1
+        cls.config.confluence_timeout = 5
+        cls.config.confluence_publish_debug = True
 
         cls.std_space_connect_rsp = {
             'size': 1,


### PR DESCRIPTION
When preparing a dummy HTTP test server for mocked server validation, a quick client may observe connection resets if the server fails to activate before requests are issued. To help prevent this, explicitly active the server (when not ignoring requests) before creating a thread to serve requests.

---

This change is in response to observed GitHub action failures reporting (e.g. [run 5266167550](https://github.com/sphinx-contrib/confluencebuilder/runs/5266167550)):

```
ConnectionResetError: [Errno 54] Connection reset by peer
```

It is assumed that requests are being issues before sockets are completely activated (to accept connections); although, this is an assumption. It appears to only occur on Windows/OSX containers at this time, so there could be another issue being overlooked.