### PR TITLE
documentation cleanup (2022-02-20)

### DIFF
--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -22,6 +22,7 @@
 </p>
 <div class="quick-grab-container">
     <input
+        aria-readonly="true"
         class="quick-grab"
         readonly="readonly"
         spellcheck="false"
@@ -33,6 +34,7 @@
 </p>
 <div class="quick-grab-container">
     <input
+        aria-readonly="true"
         class="quick-grab"
         readonly="readonly"
         spellcheck="false"
@@ -44,6 +46,7 @@
 </p>
 <div class="quick-grab-container">
     <input
+        aria-readonly="true"
         class="quick-grab"
         readonly="readonly"
         spellcheck="false"
@@ -51,6 +54,7 @@
 </div>
 <div class="quick-grab-container">
     <input
+        aria-readonly="true"
         class="quick-grab"
         readonly="readonly"
         spellcheck="false"

--- a/doc/_themes/sphinx13b/layout.html
+++ b/doc/_themes/sphinx13b/layout.html
@@ -54,7 +54,10 @@ $(window).scroll(function() {
 
 {% block rootrellink %}
     <li><a href="{{ pathto('index') }}">Home</a>&#160;|</li>
-    <li><a href="{{ pathto('contents') }}">Documentation</a> &#187;</li>
+    <li>
+        <a href="{{ pathto('contents') }}">Documentation</a>
+        <span aria-hidden="true">&#187;</span>
+    </li>
 {% endblock %}
 
 {% block header %}

--- a/doc/_themes/sphinx13b/static/sphinx13b.css
+++ b/doc/_themes/sphinx13b/static/sphinx13b.css
@@ -460,6 +460,19 @@ div.viewcode-block:target {
     margin: 0px;
 }
 
+.toctree-wrapper ul {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.toctree-wrapper:first-of-type {
+    margin-top: 0.8em;
+}
+
+.toctree-wrapper:last-of-type {
+    margin-bottom: 0.8em;
+}
+
 code.literal {
     border: #ccc 1px solid;
     padding: 0px 4px;

--- a/doc/_themes/sphinx13b/static/sphinx13b.css
+++ b/doc/_themes/sphinx13b/static/sphinx13b.css
@@ -199,16 +199,20 @@ div.section:target > h2:first-of-type,
 div.section:target > h3:first-of-type,
 div.section:target > h4:first-of-type,
 div.section:target > h5:first-of-type,
-div.section:target > h6:first-of-type {
-    background-color: #fbe54e;
-}
-
+div.section:target > h6:first-of-type,
 section:target > h1:first-of-type,
 section:target > h2:first-of-type,
 section:target > h3:first-of-type,
 section:target > h4:first-of-type,
 section:target > h5:first-of-type,
-section:target > h6:first-of-type {
+section:target > h6:first-of-type,
+span:target + h1:first-of-type,
+span:target + h2:first-of-type,
+span:target + h3:first-of-type,
+span:target + h4:first-of-type,
+span:target + h5:first-of-type,
+span:target + h6:first-of-type,
+span:target + dl.confval > dt {
     background-color: #fbe54e;
 }
 

--- a/doc/_themes/sphinx13b/theme.conf
+++ b/doc/_themes/sphinx13b/theme.conf
@@ -1,4 +1,4 @@
 [theme]
 inherit = basic
-stylesheet = sphinx13b.css?2021130
+stylesheet = sphinx13b.css?20220220
 pygments_style = trac

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1413,6 +1413,11 @@ Advanced processing configuration
         .. jira_issue:: TEST-151
             :server: server-1
 
+    See also:
+
+    - :ref:`Jira directives <jira-directives>`
+    - :ref:`Jira roles <jira-roles>`.
+
 .. confval:: confluence_lang_transform
 
     A function to override the translation of literal block-based directive

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -5,14 +5,30 @@ Documentation contents
     :maxdepth: 1
 
     install
+
+.. toctree::
+    :maxdepth: 2
+
     tutorial
     configuration
+
+.. toctree::
+    :maxdepth: 1
+
     builders
     directives
     roles
+
+.. toctree::
+    :maxdepth: 2
+
     features
     tips
     guides
+
+.. toctree::
+    :maxdepth: 1
+
     changelog
 
 Indices and tables

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -231,7 +231,7 @@ Confluence documents.
                 :server-id: d005bcc2-ca4e-4065-8ce8-49ff5ac5857d
                 :server-name: MyAwesomeJiraServer
 
-    See also :ref:`Jira roles <jira-roles>`.
+See also :ref:`Jira roles <jira-roles>`.
 
 .. _latex-directives:
 

--- a/doc/guide-ci.rst
+++ b/doc/guide-ci.rst
@@ -1,0 +1,50 @@
+.. _tip_manage_publish_subset:
+
+.. index:: Continuous integration
+
+Publishing with CI
+==================
+
+.. note::
+
+    If running in a ``tox``/``virtualenv`` setup, ensure any environment
+    variables used are configured to be passed through to the virtual
+    environment.
+
+For users performing automatic publishing through a CI system, they may wish to
+authenticate their publish event with a secret key. A common approach to
+applying a secret key is through an environment variable. For example, if
+authenticating with an API key (see `API tokens`_), the following can be used:
+
+.. code-block:: python
+
+    import os
+
+    ...
+
+    confluence_server_user = 'api-key-uid'
+    confluence_server_pass = os.getenv('SECRET_KEY')
+
+Or, if using a personal access token (see `Using Personal Access Tokens`_),
+the following can be used:
+
+.. code-block:: python
+
+    import os
+
+    ...
+
+    confluence_publish_token = os.getenv('SECRET_KEY')
+
+Both examples above will read an environment variable ``SECRET_KEY`` prepared
+in a CI environment to be used for authentication.
+
+See ``confluence_server_pass`` (:ref:`ref<confluence_server_pass>`) and
+``confluence_publish_token`` (:ref:`ref<confluence_publish_token>`) for more
+information.
+
+
+.. references ------------------------------------------------------------------
+
+.. _API tokens: https://confluence.atlassian.com/cloud/api-tokens-938839638.html
+.. _Using Personal Access Tokens: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html

--- a/doc/guides.rst
+++ b/doc/guides.rst
@@ -8,3 +8,4 @@ the Confluence Builder extension in a Sphinx-enabled environment.
     :maxdepth: 1
 
     guide-math
+    guide-ci

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -8,7 +8,7 @@ The following outlines additional `roles`_ supported by this extension.
 Jira
 ----
 
-The following roles can be used to help include Jira macros into generated
+The following role can be used to help include Jira macros into generated
 Confluence documents.
 
 .. index:: Jira; Adding a single Jira link (role)
@@ -24,7 +24,7 @@ Confluence documents.
 
         See :jira:`TEST-123` for more details.
 
-    See also :ref:`Jira directives <jira-directives>`.
+See also :ref:`Jira directives <jira-directives>`.
 
 .. _latex-roles:
 

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -79,35 +79,6 @@ By default, this extension does not define any timeouts for a publish event. It
 is recommended to provide a timeout value based on the environment being used
 (see ``confluence_timeout``; :ref:`ref<confluence_timeout>`).
 
-.. _tip_manage_publish_subset:
-
-.. index:: Continuous integration
-
-Publishing with a CI secret key
--------------------------------
-
-.. note::
-
-    If running in a ``tox``/``virtualenv`` setup, ensure any environment
-    variables used are configured to be passed through to the virtual
-    environment.
-
-For users performing automatic publishing through a CI system, they may wish to
-authenticate their publish event with a secret key. A common approach to
-applying a secret key is through an environment variable. For example:
-
-.. code-block:: python
-
-    import os
-
-    ...
-
-    confluence_server_pass = os.getenv('SECRET_KEY')
-
-The above will read an environment variable ``SECRET_KEY`` prepared by a CI
-script which will be set on the ``confluence_server_pass``
-(:ref:`ref<confluence_server_pass>`) configuration.
-
 .. index:: Wiping a space
 .. index:: Page removal; Wiping a space
 


### PR DESCRIPTION
### doc: cleanup/improve jira related documentation

Cleanup the location of "see also" content for Jira directive/roles. In addition, add some "see also" entries in the `confluence_jira_servers` configuration option's section.

### doc: improve toctree depth for certain documents

Provide a series of toctree tweaks to mix which document's will include a depth larger than one -- with the intent to better reflect more important sub-sections to users browsing the main content page.

### doc: move ci information into its own guide page

Moves the CI publishing information into its own guide document. In addition, improve this guide by providing examples on how a user would deal with authentication from using either API tokens to PATs.

### doc: improve link target background color

Expand the conditions where the gold background color is applied for link targets. This should help provide the desired target effect for reference jumps which target anchored entries.

### doc: improve support for screen readers

Adjusting the breadcrumb separator to avoid screen reader interaction; and hint that the sidebar quick-input options are read-only inputs.

### doc: trigger cache update on theme updates

The documentation's stylesheet has been updated. Appending a datetime to the stylesheet reference to help promote a cache refresh.