### PR TITLE
improve rate limiting handling

### DIFF
--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -201,7 +201,7 @@ please inform the maintainers of this extension.
 
 
 class ConfluenceRateLimited(ConfluenceError):
-    def __init__(self, delay=None):
+    def __init__(self):
         super(ConfluenceRateLimited, self).__init__('''
 ---
 Request has been rate limited
@@ -211,10 +211,6 @@ are being made and has instructed to client to limit the amount of
 requests to make at this time.
 ---
 ''')
-        try:
-            self.delay = int(delay)
-        except (TypeError, ValueError):
-            self.delay = None
 
 
 class ConfluenceSeraphAuthenticationFailedUrlError(ConfluenceError):

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -18,7 +18,7 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluencePublishAncestor
 from sphinxcontrib.confluencebuilder.exceptions import ConfluencePublishSelfAncestorError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceUnreconciledPageError
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
-from sphinxcontrib.confluencebuilder.rest import RestRateLimited
+from sphinxcontrib.confluencebuilder.rest import Rest
 import json
 import logging
 import time
@@ -60,7 +60,7 @@ class ConfluencePublisher:
             self.can_labels = 'labels' not in config.confluence_adv_restricted
 
     def connect(self):
-        self.rest_client = RestRateLimited(self.config)
+        self.rest_client = Rest(self.config)
         server_url = self.config.confluence_server_url
 
         try:


### PR DESCRIPTION
The following reworks the rate-limit handling this extension performs when interacting with a Confluence instance. The initial implementation would wait for a 429 error before attempting to limit calls, instead of proactively delaying API calls which Confluence hints the client to perform. The new implementation will now check for the retry-after header option after each API request made, and apply this delay on a subsequent API call.

This commit reworks the Rest and related implementation a bit. Instead of using a `RestRateLimited` class to capture failed API requests, the implementation has been switched to using decorators. This cleans up the implementation a bit and helps manage rate limiting data all in the `Rest` class.

In addition, a `requests_exception_wrappers` decorator was introduced as well to minimize the common implementation for the various REST calls.