### PR TITLE
control appending 'rest/api' to api calls by new config boolean 'confluence_disable_appending_rest_api_to_url' Signed-off-by: Hazem Elraffiee <hazem.farouk.elraffiee@gmail.com>

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -211,6 +211,8 @@ def setup(app):
     app.add_config_value('confluence_adv_trace_data', None, '')
     # Do not cap sections to a maximum of six (6) levels.
     app.add_config_value('confluence_adv_writer_no_section_cap', None, 'env')
+    # Disable Appending "rest/api" to api calls
+    app.add_config_value('confluence_disable_appending_rest_api_to_url', None, 'env')
 
     # (configuration - deprecated)
     # replaced by confluence_root_homepage

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -212,7 +212,7 @@ def setup(app):
     # Do not cap sections to a maximum of six (6) levels.
     app.add_config_value('confluence_adv_writer_no_section_cap', None, 'env')
     # Disable Appending "rest/api" to api calls
-    app.add_config_value('confluence_disable_appending_rest_api_to_url', None, 'env')
+    app.add_config_value('confluence_disable_api_endpoint_url', None, 'env')
 
     # (configuration - deprecated)
     # replaced by confluence_root_homepage

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -149,6 +149,8 @@ def setup(app):
     app.add_config_value('confluence_client_cert', None, '')
     # Password for client certificate to use for publishing
     app.add_config_value('confluence_client_cert_pass', None, '')
+    # Disable appending "rest/api" to API calls.
+    app.add_config_value('confluence_disable_api_endpoint_url', None, 'env')
     # Disable SSL validation with Confluence server.
     app.add_config_value('confluence_disable_ssl_validation', None, '')
     # Ignore adding a titlefix on the index document.
@@ -211,8 +213,6 @@ def setup(app):
     app.add_config_value('confluence_adv_trace_data', None, '')
     # Do not cap sections to a maximum of six (6) levels.
     app.add_config_value('confluence_adv_writer_no_section_cap', None, 'env')
-    # Disable Appending "rest/api" to api calls
-    app.add_config_value('confluence_disable_api_endpoint_url', None, 'env')
 
     # (configuration - deprecated)
     # replaced by confluence_root_homepage

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -173,6 +173,12 @@ default alignment for tables, figures, etc. Accepted values include 'left',
 
     # ##################################################################
 
+    # confluence_disable_api_endpoint_url
+    validator.conf('confluence_disable_api_endpoint_url') \
+        .bool()
+
+    # ##################################################################
+
     # confluence_disable_notifications
     validator.conf('confluence_disable_notifications') \
              .bool()
@@ -758,13 +764,6 @@ configured at the same time.
              .bool()
 
     # ##################################################################
-
-    # confluence_disable_api_endpoint_url
-    validator.conf('confluence_disable_api_endpoint_url') \
-             .bool()
-
-    # ##################################################################
-
 
     # inform users of additional configuration information
     deprecated(validator)

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -759,8 +759,8 @@ configured at the same time.
 
     # ##################################################################
 
-    # confluence_disable_appending_rest_api_to_url
-    validator.conf('confluence_disable_appending_rest_api_to_url') \
+    # confluence_disable_api_endpoint_url
+    validator.conf('confluence_disable_api_endpoint_url') \
              .bool()
 
     # ##################################################################

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -759,6 +759,13 @@ configured at the same time.
 
     # ##################################################################
 
+    # confluence_disable_appending_rest_api_to_url
+    validator.conf('confluence_disable_appending_rest_api_to_url') \
+             .bool()
+
+    # ##################################################################
+
+
     # inform users of additional configuration information
     deprecated(validator)
     warnings(validator)

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -56,6 +56,9 @@ def apply_defaults(conf):
     if conf.confluence_sourcelink is None:
         conf.confluence_sourcelink = {}
 
+    if conf.confluence_disable_appending_rest_api_to_url is None:
+        conf.confluence_disable_appending_rest_api_to_url = False
+
     config2bool = [
         'confluence_add_secnumbers',
         'confluence_adv_aggressive_search',
@@ -83,6 +86,7 @@ def apply_defaults(conf):
         'confluence_root_homepage',
         'confluence_watch',
         'singleconfluence_toctree',
+        'confluence_disable_appending_rest_api_to_url'
     ]
     for key in config2bool:
         if getattr(conf, key) is not None:

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -70,6 +70,7 @@ def apply_defaults(conf):
         'confluence_ask_user',
         'confluence_asset_force_standalone',
         'confluence_disable_autogen_title',
+        'confluence_disable_api_endpoint_url',
         'confluence_disable_notifications',
         'confluence_disable_ssl_validation',
         'confluence_ignore_titlefix_on_index',
@@ -86,7 +87,6 @@ def apply_defaults(conf):
         'confluence_root_homepage',
         'confluence_watch',
         'singleconfluence_toctree',
-        'confluence_disable_api_endpoint_url'
     ]
     for key in config2bool:
         if getattr(conf, key) is not None:

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -56,8 +56,8 @@ def apply_defaults(conf):
     if conf.confluence_sourcelink is None:
         conf.confluence_sourcelink = {}
 
-    if conf.confluence_disable_appending_rest_api_to_url is None:
-        conf.confluence_disable_appending_rest_api_to_url = False
+    if conf.confluence_disable_api_endpoint_url is None:
+        conf.confluence_disable_api_endpoint_url = False
 
     config2bool = [
         'confluence_add_secnumbers',
@@ -86,7 +86,7 @@ def apply_defaults(conf):
         'confluence_root_homepage',
         'confluence_watch',
         'singleconfluence_toctree',
-        'confluence_disable_appending_rest_api_to_url'
+        'confluence_disable_api_endpoint_url'
     ]
     for key in config2bool:
         if getattr(conf, key) is not None:

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -58,6 +58,7 @@ class Rest(object):
         self.session = self._setup_session(config)
         self.timeout = config.confluence_timeout
         self.verbosity = config.sphinx_verbosity
+        self.url_append = '' if config.confluence_disable_appending_rest_api_to_url else API_REST_BIND_PATH
 
     def __del__(self):
         self.session.close()
@@ -125,7 +126,7 @@ class Rest(object):
         return session
 
     def get(self, key, params):
-        rest_url = self.url + API_REST_BIND_PATH + '/' + key
+        rest_url = self.url + self.url_append + '/' + key
 
         try:
             rsp = self.session.get(
@@ -160,7 +161,7 @@ class Rest(object):
         return json_data
 
     def post(self, key, data, files=None):
-        rest_url = self.url + API_REST_BIND_PATH + '/' + key
+        rest_url = self.url + self.url_append + '/' + key
         try:
             rsp = self.session.post(
                 rest_url, json=data, files=files, timeout=self.timeout)
@@ -197,7 +198,7 @@ class Rest(object):
         return json_data
 
     def put(self, key, value, data):
-        rest_url = self.url + API_REST_BIND_PATH + '/' + key + '/' + str(value)
+        rest_url = self.url + self.url_append + '/' + key + '/' + str(value)
         try:
             rsp = self.session.put(rest_url, json=data, timeout=self.timeout)
         except requests.exceptions.Timeout:
@@ -233,7 +234,7 @@ class Rest(object):
         return json_data
 
     def delete(self, key, value):
-        rest_url = self.url + API_REST_BIND_PATH + '/' + key + '/' + str(value)
+        rest_url = self.url + self.url_append + '/' + key + '/' + str(value)
         try:
             rsp = self.session.delete(rest_url, timeout=self.timeout)
         except requests.exceptions.Timeout:
@@ -261,7 +262,7 @@ class Rest(object):
         err = ""
         err += "REQ: {0}\n".format(rsp.request.method)
         err += "RSP: " + str(rsp.status_code) + "\n"
-        err += "URL: " + self.url + API_REST_BIND_PATH + "\n"
+        err += "URL: " + self.url + self.url_append + "\n"
         err += "API: " + key + "\n"
         try:
             err += 'DATA: {}'.format(json.dumps(rsp.json(), indent=2))

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -158,7 +158,7 @@ class Rest(object):
         self.session = self._setup_session(config)
         self.timeout = config.confluence_timeout
         self.verbosity = config.sphinx_verbosity
-        self.url_append = '' if config.confluence_disable_appending_rest_api_to_url else API_REST_BIND_PATH
+        self.url_append = '' if config.confluence_disable_api_endpoint_url else API_REST_BIND_PATH
 
     def __del__(self):
         self.session.close()


### PR DESCRIPTION
control appending 'rest/api' to api calls by new config boolean 'confluence_disable_appending_rest_api_to_url'