### PR TITLE
ensure inline internal targets have text

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1101,10 +1101,10 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self._reference_context = []
 
     def visit_target(self, node):
-        if not self.can_anchor:
-            raise nodes.SkipNode
-
         if 'refid' in node:
+            if not self.can_anchor:
+                raise nodes.SkipNode
+
             anchor = ''.join(node['refid'].split())
 
             # only build an anchor if required (e.g. is a reference label
@@ -1116,10 +1116,13 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 self.body.append(self._build_ac_param(node, '', anchor))
                 self.body.append(self._end_ac_macro(node))
         elif 'ids' in node and 'refuri' not in node:
-            for id_ in node['ids']:
-                self.body.append(self._start_ac_macro(node, 'anchor'))
-                self.body.append(self._build_ac_param(node, '', id_))
-                self.body.append(self._end_ac_macro(node))
+            if self.can_anchor:
+                for id_ in node['ids']:
+                    self.body.append(self._start_ac_macro(node, 'anchor'))
+                    self.body.append(self._build_ac_param(node, '', id_))
+                    self.body.append(self._end_ac_macro(node))
+
+            self.body.append(self.encode(node.astext()))
 
         raise nodes.SkipNode
 

--- a/tests/unit-tests/datasets/common/targets.rst
+++ b/tests/unit-tests/datasets/common/targets.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+.. https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-internal-targets
+
+targets
+-------
+
+.. inline internal targets
+
+An _`inline target` example.

--- a/tests/unit-tests/test_rst_targets.py
+++ b/tests/unit-tests/test_rst_targets.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+from tests.lib import parse
+import os
+
+
+class TestConfluenceRstTargets(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestConfluenceRstTargets, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
+        cls.filenames = [
+            'targets',
+        ]
+
+    @setup_builder('confluence')
+    def test_storage_rst_targets_defaults(self):
+        out_dir = self.build(self.dataset, filenames=self.filenames)
+
+        with parse('targets', out_dir) as data:
+            # sanity check anchor creation
+            anchor_tag = data.find('ac:structured-macro')
+            self.assertIsNotNone(anchor_tag)
+            self.assertTrue(anchor_tag.has_attr('ac:name'))
+            self.assertEqual(anchor_tag['ac:name'], 'anchor')
+
+            anchor_param = anchor_tag.find('ac:parameter', recursive=False)
+            self.assertIsNotNone(anchor_param)
+            self.assertEqual(anchor_param.text, 'inline-target')
+
+            # before and after text
+            before_data = anchor_tag.previousSibling.strip()
+            self.assertEqual(before_data, 'An')
+
+            trailing_data = anchor_tag.nextSibling.strip()
+            self.assertEqual(trailing_data, 'inline target example.')


### PR DESCRIPTION
When targets are processed by the storage translator, the original implementation would only focus on building anchors (when needed) to support features like citations/footnotes; however, inline internal targets are never properly formed. While anchors are created, the text for these targets are skipped over.

This commit corrects these types of targets by ensuring the target's text is added into the body after creating the anchors associated to the text.