### PR TITLE
Support content version.message / page history comment field

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1323,6 +1323,14 @@ Advanced publishing configuration
             'U_ID': '<username>',
         }
 
+.. confval:: confluence_version_comment
+
+    A string value to be added as a comment to Confluence's version history.
+
+    .. code-block:: python
+
+        confluence_version_comment = 'Automatically generated.'
+
 Advanced processing configuration
 ---------------------------------
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -173,6 +173,8 @@ def setup(app):
     app.add_config_value('confluence_server_auth', None, '')
     # Cookie(s) to use for Confluence REST interaction.
     app.add_config_value('confluence_server_cookies', None, '')
+    # Comment added to confluence version history.
+    app.add_config_value('confluence_version_comment', None, '')
 
     # (configuration - advanced processing)
     # Filename suffix for generated files.

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -684,6 +684,12 @@ value (e.g. 2).
 
     # ##################################################################
 
+    # confluence_version_comment
+    validator.conf('confluence_version_comment') \
+             .string()
+
+    # ##################################################################
+
     # confluence_watch
     validator.conf('confluence_watch') \
              .bool()

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -848,6 +848,7 @@ class ConfluencePublisher:
         update_page['id'] = page['id']
         update_page['version'] = {
             'number': last_version + 1,
+            'message': self.config.confluence_version_comment,
         }
 
         if self.can_labels:

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -897,3 +897,10 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_timeout'] = -1
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
+
+    def test_config_check_confluence_version_comment(self):
+        self.config['confluence_version_comment'] = ''
+        self._try_config()
+
+        self.config['confluence_version_comment'] = 'dummy'
+        self._try_config()


### PR DESCRIPTION
PR for #629
Allows using `confluence_version_comment` to add a comment to a version in the Confluence version history.