### PR TITLE
Pylint updates

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :copyright: Copyright 2007-2021 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -44,7 +44,7 @@ from sphinxcontrib.confluencebuilder.writer import ConfluenceWriter
 import io
 
 try:
-    basestring
+    basestring  # pylint: disable=E0601
 except NameError:
     basestring = str
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -12,7 +12,7 @@ from requests.auth import AuthBase
 import os
 
 try:
-    basestring
+    basestring  # pylint: disable=E0601
 except NameError:
     basestring = str
 

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -10,7 +10,7 @@ from sphinxcontrib.confluencebuilder.util import str2bool
 import os
 
 try:
-    basestring
+    basestring  # pylint: disable=E0601
 except NameError:
     basestring = str
 

--- a/sphinxcontrib/confluencebuilder/storage/__init__.py
+++ b/sphinxcontrib/confluencebuilder/storage/__init__.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2021-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
 
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 

--- a/sphinxcontrib/confluencebuilder/storage/__init__.py
+++ b/sphinxcontrib/confluencebuilder/storage/__init__.py
@@ -3,7 +3,7 @@
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 
 try:
-    unicode
+    unicode  # pylint: disable=E0601
 except NameError:
     unicode = str
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -383,10 +383,13 @@ def mock_getpass(mock):
 
     try:
         original = util.getpass2
-        util.getpass2 = _
-        yield
+        try:
+            util.getpass2 = _
+            yield
+        finally:
+            util.getpass2 = original
     finally:
-        util.getpass2 = original
+        pass
 
 
 @contextmanager
@@ -397,10 +400,13 @@ def mock_input(mock):
 
     try:
         original = compat.compat_input
-        compat.compat_input = _
-        yield
+        try:
+            compat.compat_input = _
+            yield
+        finally:
+            compat.compat_input = original
     finally:
-        compat.compat_input = original
+        pass
 
 
 @contextmanager

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
 [testenv:pylint]
 deps =
     {[testenv]deps}
-    pylint
+    pylint: pylint<2.7.3
 commands =
     pylint \
     --rcfile=setup.cfg \

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
 deps =
     -r{toxinidir}/requirements_dev.txt
     sphinx18: docutils<0.18
+    sphinx18: jinja2<=3.0.3
     sphinx18: sphinx>=1.8,<2.0
     sphinx40: sphinx>=4.0,<4.1
     sphinx41: sphinx>=4.1,<4.2


### PR DESCRIPTION
### suppress e601 for py27 compatibility imports

Add a series of pylint suppressions for Python 2.7.x compatibility import tests.

### ensure mocked fallbacks only set with the originals are overridden

Tweaking the `mock_getpass`/`mock_input` calls to only re-apply the original modules if the original module could be fetched.

### tox: restrict pylint to pre-2.7.3

pylint v2.7.3 has a regression issue (to be fixed in v2.7.4) causing the tox builds to fail. For the interim, restricting to an older version.