### PR TITLE
translator-storage: handle additional myst table alignment hints

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -202,7 +202,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         # attribute; if set, attempt to apply the style
         if isinstance(node.parent, nodes.entry):
             for class_ in node.parent.get('classes', []):
-                if class_.startswith('text-align:'):
+                if 'text-center' == class_:
+                    attribs['style'] = 'text-align: center;'
+                elif 'text-right' == class_:
+                    attribs['style'] = 'text-align: right;'
+                # (legacy)
+                elif class_.startswith('text-align:'):
                     attribs['style'] = self.encode(class_)
                     break
 


### PR DESCRIPTION
Previous testing/support of Markdown with MyST provides table alignment hints through `text-align:<value>` class identifiers. Recent testing shows that explicitly alignment classes are now used (for example, `text-right`). Tweaking the implementation a bit to support both types of alignment hints.