### PR TITLE
translator-storage: add div blocks for compound nodes

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2051,6 +2051,13 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     def depart_acronym(self, node):
         self.body.append(self.context.pop())  # acronym
 
+    def visit_container(self, node):
+        self.body.append(self._start_tag(node, 'div'))
+        self.context.append(self._end_tag(node))
+
+    def depart_container(self, node):
+        self.body.append(self.context.pop())  # div
+
     def depart_line(self, node):
         next_sibling = first(node.traverse(
             include_self=False, descend=False, siblings=True))


### PR DESCRIPTION
Injecting div's for compound nodes to help space out compound entries which may be generated from autodoc processing. docutils injects div blocks as well for these node types \[1\], so it is expected to cause no other issues with other capabilities. This can correct some visualization observed when processing documentation provided by Breathe -- specifically, having new lines between each include entry for C++/C sources.

\[1\]: https://repo.or.cz/docutils.git/blob/d169015ee0f412cffd69b33654d8a119d99bc0f3:/docutils/writers/html4css1/__init__.py#l285