### PR TITLE
translator: encode uris

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+Development
+===========
+
+* fixed issue where external references with ampersands would fail to publish
+
 1.8.0 (2022-03-27)
 ==================
 

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1448,9 +1448,10 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             #       entity (although, currently, some (if not all) Confluence
             #       versions do not consider embedded images as valid URI values
             #       so users might see a "broken images" block).
+            uri = self.encode(node['uri'])
             self.body.append(self._start_ac_image(node, **attribs))
             self.body.append(self._start_tag(node, 'ri:url',
-                suffix=self.nl, empty=True, **{'ri:value': node['uri']}))
+                suffix=self.nl, empty=True, **{'ri:value': uri}))
             self.body.append(self._end_ac_image(node))
         else:
             hosted_doctitle = self.state.title(dochost, dochost)
@@ -2010,7 +2011,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             attribs['style'] = 'text-align: {};'.format(alignment)
 
         ri_url = self._start_tag(
-            node, 'ri:url', empty=True, **{'ri:value': uri})
+            node, 'ri:url', empty=True, **{'ri:value': self.encode(uri)})
 
         self.body.append(self._start_tag(node, 'div', **attribs))
         self.body.append(self._start_ac_macro(node, 'widget'))

--- a/tests/unit-tests/datasets/common/image.rst
+++ b/tests/unit-tests/datasets/common/image.rst
@@ -9,6 +9,10 @@ image
 
 .. image:: https://www.example.com/image.png
 
+.. external image with options
+
+.. image:: https://www.example.org/image.png?a=1&b=2
+
 .. internal image using a series of attributes
 
 .. image:: ../../assets/image01.png

--- a/tests/unit-tests/test_rst_image.py
+++ b/tests/unit-tests/test_rst_image.py
@@ -26,10 +26,10 @@ class TestConfluenceRstImage(ConfluenceTestCase):
 
         with parse('image', out_dir) as data:
             images = data.find_all('ac:image', recursive=False)
-            self.assertEqual(len(images), 6)
+            self.assertEqual(len(images), 7)
 
             # ##########################################################
-            # basic image
+            # external image
             # ##########################################################
             image = images.pop(0)
 
@@ -37,6 +37,19 @@ class TestConfluenceRstImage(ConfluenceTestCase):
             self.assertTrue(url.has_attr('ri:value'))
             self.assertEqual(url['ri:value'],
                 'https://www.example.com/image.png')
+            self.assertFalse(image.has_attr('ac:align'))
+
+            # ##########################################################
+            # external image with options
+            # ##########################################################
+            image = images.pop(0)
+
+            url = image.find('ri:url')
+            raw_url = str(url)
+            self.assertTrue(url.has_attr('ri:value'))
+            self.assertEqual(url['ri:value'],
+                'https://www.example.org/image.png?a=1&b=2')
+            self.assertIn('?a=1&amp;b=2', raw_url)
             self.assertFalse(image.has_attr('ac:align'))
 
             # ##########################################################


### PR DESCRIPTION
When preparing external URI image macros, the `ri:url` values need to be encoded. Updating each `ri:url` entry to ensure their values have been encoded.