### PR TITLE
drop macro restriction support

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/__init__.py
+++ b/sphinxcontrib/confluencebuilder/storage/__init__.py
@@ -42,7 +42,7 @@ def encode_storage_format(data):
     return data
 
 
-def intern_uri_anchor_value(config, docname, refuri):
+def intern_uri_anchor_value(docname, refuri):
     """
     determine the anchor value for an internal uri point
 
@@ -53,7 +53,6 @@ def intern_uri_anchor_value(config, docname, refuri):
     will be provided. If not, the parsed/raw anchor value will be returned.
 
     Args:
-        config: the active configuration
         docname: the docname of the page to link to
         refuri: the uri
 
@@ -71,10 +70,9 @@ def intern_uri_anchor_value(config, docname, refuri):
         target = ConfluenceState.target(target_name)
         if target:
             anchor_value = target
-        elif 'anchor' not in config.confluence_adv_restricted:
+        else:
             anchor_value = anchor
 
-        if anchor_value:
-            anchor_value = encode_storage_format(anchor_value)
+        anchor_value = encode_storage_format(anchor_value)
 
     return anchor_value

--- a/sphinxcontrib/confluencebuilder/storage/index.py
+++ b/sphinxcontrib/confluencebuilder/storage/index.py
@@ -120,6 +120,6 @@ def process_doclink(config, refuri):
 
     docname = posixpath.normpath(os.path.splitext(refuri.split('#')[0])[0])
     doctitle = ConfluenceState.title(docname)
-    anchor_value = intern_uri_anchor_value(config, docname, refuri)
+    anchor_value = intern_uri_anchor_value(docname, refuri)
 
     return doctitle, anchor_value

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -368,8 +368,8 @@ def mock_confluence_instance(config=None, ignore_requests=False):
         if serve_thread:
             daemon.shutdown()
             serve_thread.join()
-        else:
-            daemon.socket.close()
+
+        daemon.server_close()
 
 
 @contextmanager

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -195,11 +195,11 @@ class TestConfluenceValidation(unittest.TestCase):
         config['confluence_header_file'] = os.path.join(dataset, 'header.tpl')
         config['confluence_footer_file'] = os.path.join(dataset, 'footer.tpl')
 
-        # inject a navdoc from the last "standard (no macro)" page, to the
+        # inject a navdoc from the last "standard" page, to the
         # hierarchy example start page
         def navdocs_transform(builder, docnames):
             builder.state.register_title(
-                '_validation_prev', 'Verification of content (nomacro)', None)
+                '_validation_prev', 'Verification of content', None)
             docnames.insert(0, '_validation_prev')
             builder.state.register_title(
                 '_validation_next', 'Hierarchy example', None)
@@ -215,8 +215,8 @@ class TestConfluenceValidation(unittest.TestCase):
         config['confluence_page_hierarchy'] = True
         config['confluence_sourcelink']['container'] += 'hierarchy/'
 
-        # inject a navdoc from the last "standard (no macro)" page, to the
-        # hierarchy example start page
+        # inject a navdoc from the last "Header/footer" page, to the
+        # markdown start page
         def navdocs_transform(builder, docnames):
             builder.state.register_title(
                 '_validation_prev', 'Header/footer example (page c)', None)
@@ -240,8 +240,8 @@ class TestConfluenceValidation(unittest.TestCase):
         dataset = os.path.join(self.datasets, 'markdown')
         doc_dir = prepare_dirs('validation-set-markdown')
 
-        # inject a navdoc from the last "standard (no macro)" page, to the
-        # hierarchy example start page
+        # inject a navdoc from the last hierarchy example page, to the
+        # extensions start page
         def navdocs_transform(builder, docnames):
             builder.state.register_title(
                 '_validation_prev', 'Hierarchy example (d)', None)
@@ -261,42 +261,10 @@ class TestConfluenceValidation(unittest.TestCase):
         dataset = os.path.join(self.datasets, 'standard')
         doc_dir = prepare_dirs('validation-set-standard')
 
-        # inject a navdoc to the "standard (no macro)" page
+        # inject a navdoc to the header/footer start page
         def navdocs_transform(builder, docnames):
             builder.state.register_title(
                 '_validation_prev', self.test_key, None)
-            docnames.insert(0, '_validation_prev')
-            builder.state.register_title(
-                '_validation_next', 'Standard (nomacro)', None)
-            docnames.append('_validation_next')
-            return docnames
-        config['confluence_navdocs_transform'] = navdocs_transform
-
-        build_sphinx(dataset, config=config, out_dir=doc_dir)
-
-    def test_standard_macro_restricted(self):
-        config = self.config.clone()
-        config['confluence_sourcelink']['container'] += 'standard/'
-
-        dataset = os.path.join(self.datasets, 'standard')
-        doc_dir = prepare_dirs('validation-set-standard-nm')
-
-        config['confluence_adv_restricted'] = [
-            'anchor',
-            'children',
-            'code',
-            'info',
-            'viewfile',
-            'jira'
-        ]
-        config['confluence_header_file'] = os.path.join(dataset, 'no-macro.tpl')
-        config['confluence_publish_postfix'] = ' (nomacro)'
-
-        # inject a navdoc from the last "standard" page, to the header/footer
-        # start page
-        def navdocs_transform(builder, docnames):
-            builder.state.register_title(
-                '_validation_prev', 'Verification of content', None)
             docnames.insert(0, '_validation_prev')
             builder.state.register_title(
                 '_validation_next', 'Header/footer example', None)


### PR DESCRIPTION
Restricting subset of macros is an undocumented feature. It was added to help deal with scenarios with a Confluence instance may have some macros disabled by an administrator; providing a way for users to still generate/publish documentation if a specific macro was disabled.

Newer Confluence instances do not support disabling core macros with standard installs anymore ~ this includes all Confluence instances that are supported by this extension (LTS versions). Since the likelihood that these core macros are never disabled and that this feature was undocumented, removing support for it. This should reduce some implementation to minimize maintenance and validation time.