### PR TITLE
drop undocumented child macro injection

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -199,8 +199,6 @@ def setup(app):
     # (configuration - undocumented)
     # Enablement for aggressive descendents search (for purge).
     app.add_config_value('confluence_adv_aggressive_search', None, '')
-    # Enablement of the children macro for hierarchy mode.
-    app.add_config_value('confluence_adv_hierarchy_child_macro', None, 'env')
     # List of node types to ignore if no translator support exists.
     app.add_config_value('confluence_adv_ignore_nodes', None, '')
     # Unknown node handler dictionary for advanced integrations.

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -56,12 +56,6 @@ def validate_configuration(builder):
 
     # ##################################################################
 
-    # confluence_adv_hierarchy_child_macro
-    validator.conf('confluence_adv_hierarchy_child_macro') \
-             .bool()
-
-    # ##################################################################
-
     # confluence_adv_permit_raw_html
     validator.conf('confluence_adv_permit_raw_html') \
              .bool()

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -59,7 +59,6 @@ def apply_defaults(conf):
     config2bool = [
         'confluence_add_secnumbers',
         'confluence_adv_aggressive_search',
-        'confluence_adv_hierarchy_child_macro',
         'confluence_adv_permit_raw_html',
         'confluence_adv_trace_data',
         'confluence_adv_writer_no_section_cap',

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -9,8 +9,6 @@ import mimetypes
 
 # dictionary of deprecated configuration entries and associated message
 DEPRECATED_CONFIGS = {
-    'confluence_adv_hierarchy_child_macro':
-        'to be removed in a future version',
     'confluence_adv_trace_data':
         'to be removed in a future version',
     'confluence_adv_writer_no_section_cap':

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -59,13 +59,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.colspecs = []
         self._tocdepth = self.state.toctree_depth(self.docname)
 
-        # helpers for dealing with disabled/unsupported features
-        if (config.confluence_page_hierarchy
-                and config.confluence_adv_hierarchy_child_macro):
-            self.apply_hierarchy_children_macro = True
-        else:
-            self.apply_hierarchy_children_macro = False
-
     def encode(self, text):
         text = encode_storage_format(text)
         return ConfluenceBaseTranslator.encode(self, text)
@@ -1577,21 +1570,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     # -----------------
 
     def visit_compound(self, node):
-        # If this has not been a manipulated toctree (refer to hierarchy mode
-        # and see builder's process_tree_structure) and the invoker wishes to
-        # use Confluence children macro instead, swap out of the toctree for the
-        # macro.
-        if 'toctree-wrapper' in node['classes']:
-            if self.apply_hierarchy_children_macro:
-                self.body.append(self._start_ac_macro(node, 'children'))
-                if self._tocdepth:
-                    self.body.append(self._build_ac_param(
-                        node, 'depth', str(self._tocdepth)))
-                else:
-                    self.body.append(self._build_ac_param(
-                        node, 'all', 'true'))
-                self.body.append(self._end_ac_macro(node))
-                raise nodes.SkipNode
+        pass
 
     def depart_compound(self, node):
         pass

--- a/tests/unit-tests/test_sphinx_toctree.py
+++ b/tests/unit-tests/test_sphinx_toctree.py
@@ -25,30 +25,6 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
             self.assertEqual(caption.text, 'toctree caption')
 
     @setup_builder('confluence')
-    def test_storage_sphinx_toctree_child_macro(self):
-        dataset = os.path.join(self.datasets, 'toctree-default')
-
-        config = dict(self.config)
-        config['confluence_adv_hierarchy_child_macro'] = True
-        config['confluence_page_hierarchy'] = True
-
-        # relax due to this test (confluence_adv_hierarchy_child_macro) being
-        # deprecated
-        out_dir = self.build(dataset, config=config, relax=True)
-
-        with parse('index', out_dir) as data:
-            macro = data.find('ac:structured-macro', recursive=False)
-            self.assertIsNotNone(macro)
-            self.assertTrue(macro.has_attr('ac:name'))
-            self.assertEqual(macro['ac:name'], 'children')
-
-            all_param = macro.find('ac:parameter', recursive=False)
-            self.assertIsNotNone(all_param)
-            self.assertTrue(all_param.has_attr('ac:name'))
-            self.assertEqual(all_param['ac:name'], 'all')
-            self.assertEqual(all_param.text, 'true')
-
-    @setup_builder('confluence')
     def test_storage_sphinx_toctree_default(self):
         dataset = os.path.join(self.datasets, 'toctree-default')
 


### PR DESCRIPTION
The `confluence_adv_hierarchy_child_macro` (undocumented) feature has been deprecated for a couple of releases. Any user wishing to utilize child-macros in their documentation are better served by using raw directives. Removing the configuration and its capabilities from this extension, to help reduce maintenance work.