### PR TITLE
translator: correct code-block's caption check

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1274,7 +1274,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             include_self=False, descend=False, siblings=True))
         if isinstance(next_sibling, nodes.literal_block):
             # anything that is not a parsed literals
-            if node.rawsource == node.astext() or 'source' in node:
+            if next_sibling.rawsource == next_sibling.astext() or \
+                    'source' in next_sibling:
                 next_sibling['scb-caption'] = node.astext()
                 raise nodes.SkipNode
 

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1939,9 +1939,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self._start_ac_macro(node, 'widget'))
         self.body.append(self._build_ac_param(node, 'url', ri_url))
         if height:
-            self.body.append(self._build_ac_param(node, 'height', height))
+            self.body.append(self._build_ac_param(node, 'height', str(height)))
         if width:
-            self.body.append(self._build_ac_param(node, 'width', width))
+            self.body.append(self._build_ac_param(node, 'width', str(width)))
         self.body.append(self._end_ac_macro(node))
         self.body.append(self._end_tag(node))
 
@@ -2129,7 +2129,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             the content
         """
         return (self._start_tag(node, 'ac:parameter', **{'ac:name': name}) +
-            str(value) + self._end_tag(node))
+            value + self._end_tag(node))
 
     def _start_ac_image(self, node, **kwargs):
         """

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -19,6 +19,7 @@ from threading import Event
 from threading import Lock
 from threading import Thread
 import inspect
+import io
 import json
 import os
 import shutil
@@ -433,7 +434,7 @@ def parse(filename, dirname=None):
 
     target += '.conf'
 
-    with open(target, 'r') as fp:
+    with io.open(target, encoding='utf-8') as fp:
         soup = BeautifulSoup(fp, 'html.parser')
         yield soup
 

--- a/tests/unit-tests/datasets/code-block/code-block-caption.rst
+++ b/tests/unit-tests/datasets/code-block/code-block-caption.rst
@@ -5,3 +5,9 @@
 
     import myexample
     myexample.invoke()
+
+.. code-block:: python
+    :caption: code caption test "two"
+
+    import myexample2
+    myexample2.invoke()

--- a/tests/unit-tests/test_sphinx_codeblock.py
+++ b/tests/unit-tests/test_sphinx_codeblock.py
@@ -23,7 +23,11 @@ class TestConfluenceSphinxCodeblock(ConfluenceTestCase):
         out_dir = self.build(self.dataset, filenames=['code-block-caption'])
 
         with parse('code-block-caption', out_dir) as data:
-            title_param = data.find('ac:parameter', {'ac:name': 'title'})
+            title_params = data.find_all('ac:parameter', {'ac:name': 'title'})
+            self.assertIsNotNone(title_params)
+            self.assertEqual(len(title_params), 2)
+
+            title_param = title_params.pop(0)
             self.assertIsNotNone(title_param)
             self.assertEqual(title_param.text, 'code caption test')
 


### PR DESCRIPTION
When tracking a caption value to apply to a code block, a check exists to exclude processing this for a parsed literal (since this is not supported). An issue with the initial implementation is that this sanity check used the caption node to sanity check if a node was a parsed literal block, instead of the sibling code block.

This commit corrects the implementation by checking for a parsed literal block type on the sibling.

---

This pull request includes a series of corrections to testing, where the quoted-value caption and encoding issues in unit tests.