### PR TITLE
tests: register threading-mix-in on server implementation

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -41,7 +41,8 @@ except ImportError:
 EXT_NAME = 'sphinxcontrib.confluencebuilder'
 
 
-class ConfluenceInstanceServer(server_socket.TCPServer):
+class ConfluenceInstanceServer(server_socket.ThreadingMixIn,
+        server_socket.TCPServer):
 
     def __init__(self):
         """
@@ -200,8 +201,7 @@ class ConfluenceInstanceServer(server_socket.TCPServer):
             self.put_rsp.append((code, data))
 
 
-class ConfluenceInstanceRequestHandler(server_socket.ThreadingMixIn,
-        http_server.SimpleHTTPRequestHandler):
+class ConfluenceInstanceRequestHandler(http_server.SimpleHTTPRequestHandler):
     """
     confluence instance request handler
 


### PR DESCRIPTION
Asynchronous tweaks were attempted to be added into unit testing \[1\]. However, the `ThreadingMixIn` implementation was added to the request handler instead of the server instance; correcting.

\[1\]: c9c1ff3fa3d65192d74c66c359ed2d152f192959