### PR TITLE
Fix for going over CONFLUENCE_MAX_TITLE_LEN while handling title conflict

### DIFF
--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -107,9 +107,8 @@ class ConfluenceState:
                         ConfluenceState.title2doc[title.lower()], docname))
 
             tail = ' ({}){}'.format(offset, base_tail)
-            try_max = CONFLUENCE_MAX_TITLE_LEN + len(tail)
-            if len(base_title) > try_max:
-                base_title = base_title[0:try_max]
+            if len(base_title) + len(tail) > try_max:
+                base_title = base_title[0:(try_max - len(tail))]
 
             title = base_title + tail
             offset += 1

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -88,12 +88,13 @@ class ConfluenceState:
 
         if postfix:
             base_tail += postfix
-            try_max += len(postfix)
 
-        if len(title) > try_max:
-            title = title[0:try_max]
-            logger.warn('document title has been trimmed due to '
-                'length: %s' % docname)
+        if len(title) + len(base_tail) > try_max:
+            warning = 'document title has been trimmed due to length: %s' % title
+            if len(base_tail) > 0:
+                warning += '; With postfix: %s' % base_tail
+            logger.warn(warning)
+            title = title[0:try_max - len(base_tail)]
 
         base_title = title
         title += base_tail

--- a/tests/unit-tests/test_titles.py
+++ b/tests/unit-tests/test_titles.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_TITLE_LEN
+from sphinxcontrib.confluencebuilder.state import ConfluenceState
+from tests.lib import MockedConfig
+import unittest
+
+
+class TestTitles(unittest.TestCase):
+    def setUp(self):
+        ConfluenceState.reset()
+        self.config = MockedConfig()
+
+    def _register_title(self, title):
+        return ConfluenceState.register_title('mock', title, self.config)
+
+    def test_titles_maximum_checks_default(self):
+        t0 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 1))
+        t1 = self._register_title('S' * CONFLUENCE_MAX_TITLE_LEN)
+        t2 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN + 1))
+
+        self.assertEqual(len(t0), CONFLUENCE_MAX_TITLE_LEN - 1)
+        self.assertEqual(len(t1), CONFLUENCE_MAX_TITLE_LEN)
+        self.assertEqual(len(t2), CONFLUENCE_MAX_TITLE_LEN)
+
+    def test_titles_maximum_checks_duplicate_capped(self):
+        t0 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 1))
+        t1 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 1))
+
+        self.assertEqual(len(t0), CONFLUENCE_MAX_TITLE_LEN - 1)
+        self.assertEqual(len(t1), CONFLUENCE_MAX_TITLE_LEN)
+
+    def test_titles_maximum_checks_postfix(self):
+        self.config.confluence_publish_postfix = 'Z'
+
+        t0 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 2))
+        t1 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 1))
+        t2 = self._register_title('S' * CONFLUENCE_MAX_TITLE_LEN)
+        t3 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN + 1))
+
+        self.assertEqual(len(t0), CONFLUENCE_MAX_TITLE_LEN - 1)
+        self.assertEqual(len(t1), CONFLUENCE_MAX_TITLE_LEN)
+        self.assertEqual(len(t2), CONFLUENCE_MAX_TITLE_LEN)
+        self.assertEqual(len(t3), CONFLUENCE_MAX_TITLE_LEN)
+
+    def test_titles_maximum_checks_prefix(self):
+        self.config.confluence_publish_prefix = 'A'
+
+        t0 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 2))
+        t1 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 1))
+        t2 = self._register_title('S' * CONFLUENCE_MAX_TITLE_LEN)
+        t3 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN + 1))
+
+        self.assertEqual(len(t0), CONFLUENCE_MAX_TITLE_LEN - 1)
+        self.assertEqual(len(t1), CONFLUENCE_MAX_TITLE_LEN)
+        self.assertEqual(len(t2), CONFLUENCE_MAX_TITLE_LEN)
+        self.assertEqual(len(t3), CONFLUENCE_MAX_TITLE_LEN)
+
+    def test_titles_maximum_checks_prefix_and_postfix(self):
+        self.config.confluence_publish_postfix = 'Z'
+        self.config.confluence_publish_prefix = 'A'
+
+        t0 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 3))
+        t1 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 2))
+        t2 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 1))
+        t3 = self._register_title('S' * CONFLUENCE_MAX_TITLE_LEN)
+        t4 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN + 1))
+
+        self.assertEqual(len(t0), CONFLUENCE_MAX_TITLE_LEN - 1)
+        self.assertEqual(len(t1), CONFLUENCE_MAX_TITLE_LEN)
+        self.assertEqual(len(t2), CONFLUENCE_MAX_TITLE_LEN)
+        self.assertEqual(len(t3), CONFLUENCE_MAX_TITLE_LEN)
+        self.assertEqual(len(t4), CONFLUENCE_MAX_TITLE_LEN)
+
+    def test_titles_prefix_and_postfix_not_truncated(self):
+        self.config.confluence_publish_postfix = 'Z'
+        self.config.confluence_publish_prefix = 'A'
+
+        title = self._register_title('S' * CONFLUENCE_MAX_TITLE_LEN)
+
+        self.assertEqual(len(title), CONFLUENCE_MAX_TITLE_LEN)
+        self.assertEqual(title[0], 'A')
+        self.assertEqual(title[-1], 'Z')
+
+    def tearDown(self):
+        ConfluenceState.reset()

--- a/tests/unit-tests/test_titles.py
+++ b/tests/unit-tests/test_titles.py
@@ -4,6 +4,7 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
+from sphinx.util.logging import skip_warningiserror
 from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_TITLE_LEN
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from tests.lib import MockedConfig
@@ -16,7 +17,8 @@ class TestTitles(unittest.TestCase):
         self.config = MockedConfig()
 
     def _register_title(self, title):
-        return ConfluenceState.register_title('mock', title, self.config)
+        with skip_warningiserror():
+            return ConfluenceState.register_title('mock', title, self.config)
 
     def test_titles_maximum_checks_default(self):
         t0 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 1))


### PR DESCRIPTION
Increasing trimming length over CONFLUENCE_MAX_TITLE_LEN results in failed publishing attempt. Instead, trimming using tail length so that the title won't go over the limit. Signed-off-by: Anton Mihalkov <box4android@gmail.com>