### PR TITLE
cleanup publisher tests

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -269,6 +269,9 @@ class ConfluenceInstanceRequestHandler(http_server.SimpleHTTPRequestHandler):
                 code = 500
                 data = None
 
+        length = int(self.headers.get('content-length'))
+        self.rfile.read(length)
+
         self.send_response(code)
         self.end_headers()
         if data:

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -307,6 +307,29 @@ class MockedConfig(dict):
         return cloned
 
 
+@contextmanager
+def autocleanup_publisher(ptype):
+    """
+    creates a confluence publisher that cleanups after a context
+
+    The following create a provided publisher instance and yeild it to the
+    running context. The publisher can be used to connect to an instance
+    and perform other capabilities provided by the class. When the context
+    is left, the publisher will be cleaned up to ensure any pending
+    session state can been disconnected.
+
+    Yields:
+        the publisher
+    """
+
+    try:
+        publisher = ptype()
+        yield publisher
+
+    finally:
+        publisher.disconnect()
+
+
 def enable_sphinx_info(verbosity=None):
     """
     enable verbosity for features handled by this utility class

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -489,6 +489,30 @@ def prepare_conf():
     return config
 
 
+def prepare_conf_publisher():
+    """
+    prepare minimal sphinx configuration for sphinx application (publisher)
+
+    Prepares a minimum number of required configuration values into a
+    dictionary for unit tests to extend. This dictionary can be passed into
+    a Sphinx application instance. This call focuses on configuration options
+    for publisher-specific tests.
+
+    Returns:
+        the configuration
+    """
+
+    config = prepare_conf()
+
+    # always enable debug prints from urllib
+    config.confluence_publish_debug = True
+
+    # define a timeout to ensure publishing tests do not block
+    config.confluence_timeout = 5
+
+    return config
+
+
 def prepare_dirs(container=None, f_back_count=1, postfix=None):
     """
     return the output directory base for all unit tests

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -12,7 +12,7 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluenceTimeoutError
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from tests.lib import autocleanup_publisher
 from tests.lib import mock_confluence_instance
-from tests.lib import prepare_conf
+from tests.lib import prepare_conf_publisher
 import os
 import time
 import unittest
@@ -21,9 +21,7 @@ import unittest
 class TestConfluencePublisherConnect(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        cls.config.confluence_publish_debug = True
-        cls.config.confluence_timeout = 5
+        cls.config = prepare_conf_publisher()
 
     def test_publisher_connect_bad_response_code(self):
         """validate publisher can handle bad response code"""

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -5,6 +5,7 @@
 """
 
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
+from tests.lib import autocleanup_publisher
 from tests.lib import mock_confluence_instance
 from tests.lib import prepare_conf
 import unittest
@@ -35,10 +36,10 @@ class TestConfluencePublisherPage(unittest.TestCase):
         config = self.config.clone()
         config.confluence_watch = True
 
-        with mock_confluence_instance(config) as daemon:
+        with mock_confluence_instance(config) as daemon, \
+                autocleanup_publisher(ConfluencePublisher) as publisher:
             daemon.register_get_rsp(200, self.std_space_connect_rsp)
 
-            publisher = ConfluencePublisher()
             publisher.init(config)
             publisher.connect()
 
@@ -95,10 +96,10 @@ class TestConfluencePublisherPage(unittest.TestCase):
         # identifier value. By default, the update request will ensure
         # the user configures to not watch the page.
 
-        with mock_confluence_instance(self.config) as daemon:
+        with mock_confluence_instance(self.config) as daemon, \
+                autocleanup_publisher(ConfluencePublisher) as publisher:
             daemon.register_get_rsp(200, self.std_space_connect_rsp)
 
-            publisher = ConfluencePublisher()
             publisher.init(self.config)
             publisher.connect()
 
@@ -167,10 +168,10 @@ class TestConfluencePublisherPage(unittest.TestCase):
         config = self.config.clone()
         config.confluence_publish_dryrun = True
 
-        with mock_confluence_instance(config) as daemon:
+        with mock_confluence_instance(config) as daemon, \
+                autocleanup_publisher(ConfluencePublisher) as publisher:
             daemon.register_get_rsp(200, self.std_space_connect_rsp)
 
-            publisher = ConfluencePublisher()
             publisher.init(config)
             publisher.connect()
 

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -7,16 +7,14 @@
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from tests.lib import autocleanup_publisher
 from tests.lib import mock_confluence_instance
-from tests.lib import prepare_conf
+from tests.lib import prepare_conf_publisher
 import unittest
 
 
 class TestConfluencePublisherPage(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.config = prepare_conf()
-        cls.config.confluence_publish_debug = True
-        cls.config.confluence_timeout = 5
+        cls.config = prepare_conf_publisher()
 
         cls.std_space_connect_rsp = {
             'size': 1,


### PR DESCRIPTION
The following cleans up a series of publisher-related tests. The main goal is to address the random socket failures observed from CI tests (e.g. [build 6557547345](https://github.com/sphinx-contrib/confluencebuilder/runs/6557547345)).