### PR TITLE
builder: skip restrict ancestors check on dry-run without existing root

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -519,9 +519,10 @@ class ConfluenceBuilder(Builder):
             self.root_doc_page_id = uploaded_id
 
             # populate ancestors to be used to pre-check ancestors assignments
-            # on new pages
-            root_ancestors = self.publisher.get_ancestors(uploaded_id)
-            self.publisher.restrict_ancestors(root_ancestors)
+            # on new pages (`uploaded_id` may not be set if dry run)
+            if uploaded_id:
+                root_ancestors = self.publisher.get_ancestors(uploaded_id)
+                self.publisher.restrict_ancestors(root_ancestors)
 
         # if purging is enabled and we have yet to populate a list of legacy
         # pages to cache, populate pages in our target scope now

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -148,6 +148,7 @@ class ConfluencePublisher:
             the ancestors
         """
 
+        assert page_id
         ancestors = set()
 
         _, page = self.get_page_by_id(page_id, 'ancestors')


### PR DESCRIPTION
When configured for a dry-run state and a restrict ancestors check is performed, if the root page did not already exist (to be updated), no root page will exist to compiler a list of ancestors on. This causes the extension to issue an invalid API request with a `None` page ID call. Tweaking the restrict ancestors check to be skipped if no root page is detected.