### PR TITLE
support confluence status macro

### DIFF
--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -18,6 +18,8 @@ used to restrict these directives to supported builders by using the
 Common
 ------
 
+.. index:: Macros; Expand Macro
+
 .. rst:directive:: confluence_expand
 
     .. versionadded:: 1.3
@@ -83,6 +85,7 @@ Common
         .. confluence_newline::
 
 
+.. index:: Macros; Jira Macro
 .. _jira-directives:
 
 Jira
@@ -233,6 +236,7 @@ Confluence documents.
 
 See also :ref:`Jira roles <jira-roles>`.
 
+.. index:: Macros; LaTeX Macro
 .. _latex-directives:
 
 LaTeX

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -3,6 +3,7 @@ Roles
 
 The following outlines additional `roles`_ supported by this extension.
 
+.. index:: Macros; Jira Macro
 .. _jira-roles:
 
 Jira
@@ -26,6 +27,7 @@ Confluence documents.
 
 See also :ref:`Jira directives <jira-directives>`.
 
+.. index:: Macros; LaTeX Macro
 .. _latex-roles:
 
 LaTeX
@@ -54,6 +56,7 @@ Confluence documents.
 
 See also :ref:`LaTeX directives <latex-directives>`.
 
+.. index:: Macros; Mentions Macro
 .. _mention-roles:
 
 Mentions

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -94,8 +94,43 @@ generated Confluence documents.
     A user mapping table can also be configured using the
     ``confluence_mentions`` (:ref:`ref<confluence_mentions>`) option.
 
+.. index:: Macros; Status Macro
+
+Status Macro
+------------
+
+The following role can be used to help include `Confluence status macro`_ into
+generated Confluence documents.
+
+.. rst:role:: confluence_status
+
+    .. versionadded:: 1.9
+
+    The ``confluence_status`` role allows a user to build inlined status
+    macros. For example:
+
+    .. code-block:: rst
+
+        :confluence_status:`My Status`
+
+    The color of a status macro can be configured to a value supported by
+    Confluence's status macro. For example, to adjust the status value to
+    a yellow color, the following can be used:
+
+    .. code-block:: rst
+
+        :confluence_status:`WARNING <yellow>`
+
+    To tweak the style of a status macro to an outlined variant, adjust the
+    color enclosure to square brackets:
+
+    .. code-block:: rst
+
+        :confluence_status:`PASSED <green>`
+
 
 .. references ------------------------------------------------------------------
 
 .. _Confluence mentions: https://support.atlassian.com/confluence-cloud/docs/mention-a-person-or-team/
+.. _Confluence status macro: https://support.atlassian.com/confluence-cloud/docs/insert-the-status-macro/
 .. _roles: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -22,6 +22,7 @@ from sphinxcontrib.confluencebuilder.nodes import jira_issue
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
 from sphinxcontrib.confluencebuilder.roles import ConfluenceLatexRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceMentionRole
+from sphinxcontrib.confluencebuilder.roles import ConfluenceStatusRole
 from sphinxcontrib.confluencebuilder.roles import JiraRole
 from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
 
@@ -272,6 +273,7 @@ def confluence_builder_inited(app):
     # register roles
     app.add_role('confluence_latex', ConfluenceLatexRole)
     app.add_role('confluence_mention', ConfluenceMentionRole)
+    app.add_role('confluence_status', ConfluenceStatusRole)
     app.add_role('jira', JiraRole)
 
     # inject compatible autosummary nodes if the extension is available/loaded

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -103,6 +103,15 @@ class confluence_mention_inline(nodes.Inline, nodes.TextElement):
     """
 
 
+class confluence_status_inline(nodes.Inline, ConfluenceParams):
+    """
+    confluence status inline node
+
+    A Confluence builder defined status inline node, used to help add
+    Confluence status macros for an inlined section of a paragraph.
+    """
+
+
 class confluence_page_generation_notice(nodes.TextElement):
     """
     confluence page generation notice node

--- a/sphinxcontrib/confluencebuilder/roles.py
+++ b/sphinxcontrib/confluencebuilder/roles.py
@@ -10,6 +10,7 @@ See also docutils roles:
 
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_mention_inline
+from sphinxcontrib.confluencebuilder.nodes import confluence_status_inline
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
 
 
@@ -59,6 +60,54 @@ def ConfluenceMentionRole(name, rawtext, text, lineno, inliner, options=None, co
     """
 
     node = confluence_mention_inline(rawsource=text, text=text)
+
+    return [node], []
+
+
+def ConfluenceStatusRole(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """
+    a confluence status role
+
+    Defines an inline Confluence status role where users can inject inlined
+    status macros.
+
+    Args:
+        name: local name of the interpreted text role
+        rawtext: the entire interpreted text construct
+        text: the interpreted text content
+        lineno: the line number where the interpreted text beings
+        inliner: inliner object that called the role function
+        options: dictionary of directive options for customization
+        content: list of strings, the directive content for customization
+
+    Returns:
+        returns a tuple include a list of nodes and a list of system messages
+    """
+
+    color = ''
+    outlined = False
+
+    try:
+        leading_txt, opts = text.rsplit(' ', 1)
+
+        parse_opts = False
+        if opts.startswith('<') and opts.endswith('>'):
+            parse_opts = True
+        elif opts.startswith('[') and opts.endswith(']'):
+            parse_opts = True
+            outlined = True
+
+        if parse_opts:
+            text = leading_txt
+            color = opts[1:-1]
+    except ValueError:
+        pass
+
+    node = confluence_status_inline(rawsource=text, text=text)
+    node.params['color'] = color
+    node.params['title'] = text
+    if outlined:
+        node.params['subtle'] = 'true'
 
     return [node], []
 

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1923,6 +1923,18 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     visit_jira = _visit_jira_node
     visit_jira_issue = _visit_jira_node
 
+    # --------------------------------------------
+    # confluence-builder -- enhancements -- status
+    # --------------------------------------------
+
+    def visit_confluence_status_inline(self, node):
+        self.body.append(self._start_ac_macro(node, 'status'))
+        for k, v in sorted(node.params.items()):
+            self.body.append(self._build_ac_param(node, k, str(v)))
+        self.body.append(self._end_ac_macro(node))
+
+        raise nodes.SkipNode
+
     # ---------------------------------------------------
     # sphinx -- extension (third party) -- sphinx-toolbox
     # ---------------------------------------------------

--- a/tests/unit-tests/datasets/status/index.rst
+++ b/tests/unit-tests/datasets/status/index.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+status
+------
+
+.. default
+
+:confluence_status:`status a`
+
+.. color
+
+:confluence_status:`status b <yellow>`
+
+.. outlined
+
+:confluence_status:`status c []`
+
+.. outlined, color
+
+:confluence_status:`status d [green]`

--- a/tests/unit-tests/test_confluence_status.py
+++ b/tests/unit-tests/test_confluence_status.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+from tests.lib import parse
+import os
+
+
+class TestConfluenceStatus(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestConfluenceStatus, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'status')
+
+    @setup_builder('html')
+    def test_html_confluence_status_role_ignore(self):
+        # build attempt should not throw an exception/error
+        self.build(self.dataset, relax=True)
+
+    @setup_builder('confluence')
+    def test_storage_confluence_status_role_default(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            statuses = data.find_all(
+                'ac:structured-macro', {'ac:name': 'status'})
+            self.assertEqual(len(statuses), 4)
+
+            # ##########################################################
+            # default
+            # ##########################################################
+            macro = statuses.pop(0)
+
+            color = macro.find('ac:parameter', {'ac:name': 'color'})
+            self.assertIsNotNone(color)
+            self.assertEqual(color.text, '')
+
+            title = macro.find('ac:parameter', {'ac:name': 'title'})
+            self.assertIsNotNone(title)
+            self.assertEqual(title.text, 'status a')
+
+            subtle = macro.find('ac:parameter', {'ac:name': 'subtle'})
+            self.assertIsNone(subtle)
+
+            # ##########################################################
+            # color
+            # ##########################################################
+            macro = statuses.pop(0)
+
+            color = macro.find('ac:parameter', {'ac:name': 'color'})
+            self.assertIsNotNone(color)
+            self.assertEqual(color.text, 'yellow')
+
+            title = macro.find('ac:parameter', {'ac:name': 'title'})
+            self.assertIsNotNone(title)
+            self.assertEqual(title.text, 'status b')
+
+            subtle = macro.find('ac:parameter', {'ac:name': 'subtle'})
+            self.assertIsNone(subtle)
+
+            # ##########################################################
+            # outlined
+            # ##########################################################
+            macro = statuses.pop(0)
+
+            color = macro.find('ac:parameter', {'ac:name': 'color'})
+            self.assertIsNotNone(color)
+            self.assertEqual(color.text, '')
+
+            title = macro.find('ac:parameter', {'ac:name': 'title'})
+            self.assertIsNotNone(title)
+            self.assertEqual(title.text, 'status c')
+
+            subtle = macro.find('ac:parameter', {'ac:name': 'subtle'})
+            self.assertIsNotNone(subtle)
+            self.assertEqual(subtle.text, 'true')
+
+            # ##########################################################
+            # outlined, color
+            # ##########################################################
+            macro = statuses.pop(0)
+
+            color = macro.find('ac:parameter', {'ac:name': 'color'})
+            self.assertIsNotNone(color)
+            self.assertEqual(color.text, 'green')
+
+            title = macro.find('ac:parameter', {'ac:name': 'title'})
+            self.assertIsNotNone(title)
+            self.assertEqual(title.text, 'status d')
+
+            subtle = macro.find('ac:parameter', {'ac:name': 'subtle'})
+            self.assertIsNotNone(subtle)
+            self.assertEqual(subtle.text, 'true')


### PR DESCRIPTION
Providing initial support for user's to add Confluence status macros in their documentation.