### PR TITLE
support confluence toc macro

### DIFF
--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -84,6 +84,133 @@ Common
 
         .. confluence_newline::
 
+.. rst:directive:: confluence_toc
+
+    .. versionadded:: 1.9
+
+    The ``confluence_toc`` directive allows a user to define a Confluence
+    `Table of Contents Macro`_. Users are typically recommended to use
+    `reStructuredText's Table of Contents`_ directive when generating local
+    table of contents; and Confluence's Table of Contents macro is typically
+    not a replacement of `Sphinx's toctree directive`_. However, if a user
+    wishes to take advantage of Confluence's TOC-specific macro capabilities,
+    the following can be used:
+
+    .. code-block:: rst
+
+        .. confluence_toc::
+
+    This directive supports the following options:
+
+    .. rst:directive:option:: absolute-url: flag
+        :type: boolean
+
+        Whether the macro should generate full URLs for TOC entry links.
+        Valid values are ``true`` or ``false`` (default).
+
+        .. code-block:: rst
+
+            .. confluence_toc::
+                :absolute-url: true
+
+    .. rst:directive:option:: exclude: value
+        :type: string
+
+        Filter heading to exclude entries matching the provided value. The
+        value should support a regular expressions string.
+
+    .. rst:directive:option:: include: value
+        :type: string
+
+        Filter heading to include entries matching the provided value. The
+        value should support a regular expressions string.
+
+    .. rst:directive:option:: indent: value
+        :type: string
+
+        The indent to apply for header entries.
+
+        .. code-block:: rst
+
+            .. confluence_toc::
+                :indent: 15px
+
+    .. rst:directive:option:: max-level: count
+        :type: number
+
+        Defines the lowest heading level to include in the table of contents.
+
+        .. code-block:: rst
+
+            .. confluence_toc::
+                :max-level: 10
+
+    .. rst:directive:option:: min-level: count
+        :type: number
+
+        Defines the highest heading level to include in the table of contents.
+
+        .. code-block:: rst
+
+            .. confluence_toc::
+                :min-level: 1
+
+    .. rst:directive:option:: outline: flag
+        :type: boolean
+
+        Whether the macro should include outline numbering for entries.
+        Valid values are ``true`` or ``false`` (default).
+
+        .. code-block:: rst
+
+            .. confluence_toc::
+                :outline: true
+
+    .. rst:directive:option:: printable: flag
+        :type: boolean
+
+        Whether the macro should render when a user prints a Confluence page.
+        Valid values are ``true`` (default) or ``false``.
+
+        .. code-block:: rst
+
+            .. confluence_toc::
+                :printable: true
+
+    .. rst:directive:option:: separator: separator style type of the toc
+        :type: brackets, braces, parens, <user-defined>
+
+        When the ``type`` option is configured to ``flat``, this option can
+        configure the separator type applied between header entries. By
+        default, the separator type is set to ``brackets``.
+
+        .. code-block:: rst
+
+            .. confluence_toc::
+                :separator: braces
+
+    .. rst:directive:option:: style: list style type of the toc
+        :type: default, none, disc, circle, square, decimal, lower-alpha,
+               lower-roman, upper-roman
+
+        Configures how the table of contents will be style its list type. By
+        default, the style type is set to ``default``.
+
+        .. code-block:: rst
+
+            .. confluence_toc::
+                :style: square
+
+    .. rst:directive:option:: type: outline type of the toc
+        :type: flat or list
+
+        Configures how the table of contents will be style its structure.
+        Valid values are ``flat`` or ``list`` (default).
+
+        .. code-block:: rst
+
+            .. confluence_toc::
+                :type: flat
 
 .. index:: Macros; Jira Macro
 .. _jira-directives:
@@ -286,5 +413,8 @@ See also :ref:`LaTeX roles <latex-roles>`.
 .. references ------------------------------------------------------------------
 
 .. _Expand Macro: https://confluence.atlassian.com/doc/expand-macro-223222352.html
+.. _Sphinx's toctree directive: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#table-of-contents
+.. _Table of Contents Macro: https://support.atlassian.com/confluence-cloud/docs/insert-the-table-of-contents-macro/
 .. _directives: https://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html
+.. _reStructuredText's Table of Contents: https://docutils.sourceforge.io/docs/ref/rst/directives.html#table-of-contents
 .. _only: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-only

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -12,6 +12,7 @@ from sphinxcontrib.confluencebuilder.directives import ConfluenceExpandDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceLatexDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceMetadataDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceNewline
+from sphinxcontrib.confluencebuilder.directives import ConfluenceToc
 from sphinxcontrib.confluencebuilder.directives import JiraDirective
 from sphinxcontrib.confluencebuilder.directives import JiraIssueDirective
 from sphinxcontrib.confluencebuilder.locale import MESSAGE_CATALOG_NAME
@@ -267,6 +268,7 @@ def confluence_builder_inited(app):
     app.add_directive('confluence_latex', ConfluenceLatexDirective)
     app.add_directive('confluence_metadata', ConfluenceMetadataDirective)
     app.add_directive('confluence_newline', ConfluenceNewline)
+    app.add_directive('confluence_toc', ConfluenceToc)
     app.add_directive('jira', JiraDirective)
     app.add_directive('jira_issue', JiraIssueDirective)
 

--- a/sphinxcontrib/confluencebuilder/directives.py
+++ b/sphinxcontrib/confluencebuilder/directives.py
@@ -10,6 +10,7 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_expand
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_block
 from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.nodes import confluence_newline
+from sphinxcontrib.confluencebuilder.nodes import confluence_toc
 from sphinxcontrib.confluencebuilder.nodes import jira
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
 from uuid import UUID
@@ -94,6 +95,32 @@ class ConfluenceNewline(Directive):
 
     def run(self):
         node = confluence_newline()
+
+        return [node]
+
+
+class ConfluenceToc(Directive):
+    has_content = False
+    option_spec = {
+        'absolute-url': lambda x: directives.choice(x, ('true', 'false')),
+        'exclude': directives.unchanged,
+        'include': directives.unchanged,
+        'indent': directives.unchanged,
+        'max-level': directives.positive_int,
+        'min-level': directives.positive_int,
+        'outline': lambda x: directives.choice(x, ('true', 'false')),
+        'printable': lambda x: directives.choice(x, ('true', 'false')),
+        'separator': directives.unchanged,
+        'style': directives.unchanged,
+        'type': lambda x: directives.choice(x, ('flat', 'list')),
+    }
+    final_argument_whitespace = True
+
+    def run(self):
+        node = confluence_toc()
+
+        for k, v in self.options.items():
+            node.params[kebab_case_to_camel_case(k)] = v
 
         return [node]
 

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -132,6 +132,15 @@ class confluence_source_link(nodes.Structural, ConfluenceParams):
     """
 
 
+class confluence_toc(nodes.Structural, ConfluenceParams):
+    """
+    confluence toc node
+
+    Provides a Confluence's TOC macro; an alternative to Sphinx's TOC and
+    reStructuredText's contents directive.
+    """
+
+
 class jira(nodes.Inline, ConfluenceParams):
     """
     jira (query) node

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1935,6 +1935,18 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         raise nodes.SkipNode
 
+    # -----------------------------------------
+    # confluence-builder -- enhancements -- toc
+    # -----------------------------------------
+
+    def visit_confluence_toc(self, node):
+        self.body.append(self._start_ac_macro(node, 'toc'))
+        for k, v in sorted(node.params.items()):
+            self.body.append(self._build_ac_param(node, k, str(v)))
+        self.body.append(self._end_ac_macro(node))
+
+        raise nodes.SkipNode
+
     # ---------------------------------------------------
     # sphinx -- extension (third party) -- sphinx-toolbox
     # ---------------------------------------------------

--- a/tests/unit-tests/datasets/confluence-toc/index.rst
+++ b/tests/unit-tests/datasets/confluence-toc/index.rst
@@ -1,0 +1,15 @@
+:orphan:
+
+confluence toc
+--------------
+
+.. basic
+
+.. confluence_toc::
+
+.. options
+
+.. confluence_toc::
+    :type: flat
+    :absolute-url: true
+    :printable: false

--- a/tests/unit-tests/test_confluence_toc.py
+++ b/tests/unit-tests/test_confluence_toc.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+from tests.lib import parse
+import os
+
+
+class TestConfluenceToc(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestConfluenceToc, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'confluence-toc')
+
+    @setup_builder('html')
+    def test_html_confluence_toc_directive_ignore(self):
+        # build attempt should not throw an exception/error
+        self.build(self.dataset, relax=True)
+
+    @setup_builder('confluence')
+    def test_storage_confluence_toc_directive_default(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            tocs = data.find_all(
+                'ac:structured-macro', {'ac:name': 'toc'})
+            self.assertEqual(len(tocs), 2)
+
+            # ##########################################################
+            # basic
+            # ##########################################################
+            macro = tocs.pop(0)
+
+            any_param = macro.find('ac:parameter')
+            self.assertIsNone(any_param)
+
+            # ##########################################################
+            # options
+            # ##########################################################
+            macro = tocs.pop(0)
+
+            type_ = macro.find('ac:parameter', {'ac:name': 'type'})
+            self.assertIsNotNone(type_)
+            self.assertEqual(type_.text, 'flat')
+
+            absurl = macro.find('ac:parameter', {'ac:name': 'absoluteUrl'})
+            self.assertIsNotNone(absurl)
+            self.assertEqual(absurl.text, 'true')
+
+            printable = macro.find('ac:parameter', {'ac:name': 'printable'})
+            self.assertIsNotNone(printable)
+            self.assertEqual(printable.text, 'false')


### PR DESCRIPTION
Providing initial support for user's to add Confluence table of contents macros in their documentation.