### PR TITLE
support a confluence instance using a non-standard url endpoint

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1208,6 +1208,17 @@ Advanced publishing configuration
 
     See also |confluence_publish_allowlist|_.
 
+.. confval:: confluence_publish_disable_api_prefix
+
+    A boolean value which explicitly disables the use of the ``rest/api`` in
+    the Confluence publish URL. This can be useful for environments where the
+    API endpoint for a Confluence instance is proxied through a non-standard
+    location. By default, API prefixes are enabled with a value of ``False``.
+
+    .. code-block:: python
+
+        confluence_publish_disable_api_prefix = True
+
 .. |confluence_publish_dryrun| replace:: ``confluence_publish_dryrun``
 .. _confluence_publish_dryrun:
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -167,6 +167,8 @@ def setup(app):
     app.add_config_value('confluence_publish_delay', None, '')
     # Subset of documents which are denied to be published.
     app.add_config_value('confluence_publish_denylist', None, '')
+    # Disable adding `rest/api` to REST requests.
+    app.add_config_value('confluence_publish_disable_api_prefix', None, '')
     # Header(s) to use for Confluence REST interaction.
     app.add_config_value('confluence_publish_headers', None, '')
     # Manipulate a requests instance.

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -153,6 +153,7 @@ class Rest(object):
     CONFLUENCE_DEFAULT_ENCODING = 'utf-8'
 
     def __init__(self, config):
+        self.bind_path = API_REST_BIND_PATH
         self.config = config
         self.last_retry = 1
         self.next_delay = None
@@ -161,6 +162,9 @@ class Rest(object):
         self.timeout = config.confluence_timeout
         self.verbosity = config.sphinx_verbosity
         self._reported_large_delay = False
+
+        if config.confluence_publish_disable_api_prefix:
+            self.bind_path = ''
 
     def __del__(self):
         self.session.close()
@@ -230,7 +234,7 @@ class Rest(object):
     @rate_limited_retries()
     @requests_exception_wrappers()
     def get(self, key, params):
-        rest_url = self.url + API_REST_BIND_PATH + '/' + key
+        rest_url = self.url + self.bind_path + '/' + key
 
         rsp = self.session.get(rest_url, params=params, timeout=self.timeout)
         self._handle_common_request(rsp)
@@ -253,7 +257,7 @@ class Rest(object):
     @rate_limited_retries()
     @requests_exception_wrappers()
     def post(self, key, data, files=None):
-        rest_url = self.url + API_REST_BIND_PATH + '/' + key
+        rest_url = self.url + self.bind_path + '/' + key
 
         rsp = self.session.post(
             rest_url, json=data, files=files, timeout=self.timeout)
@@ -280,7 +284,7 @@ class Rest(object):
     @rate_limited_retries()
     @requests_exception_wrappers()
     def put(self, key, value, data):
-        rest_url = self.url + API_REST_BIND_PATH + '/' + key + '/' + str(value)
+        rest_url = self.url + self.bind_path + '/' + key + '/' + str(value)
 
         rsp = self.session.put(rest_url, json=data, timeout=self.timeout)
         self._handle_common_request(rsp)
@@ -306,7 +310,7 @@ class Rest(object):
     @rate_limited_retries()
     @requests_exception_wrappers()
     def delete(self, key, value):
-        rest_url = self.url + API_REST_BIND_PATH + '/' + key + '/' + str(value)
+        rest_url = self.url + self.bind_path + '/' + key + '/' + str(value)
 
         rsp = self.session.delete(rest_url, timeout=self.timeout)
         self._handle_common_request(rsp)
@@ -322,7 +326,7 @@ class Rest(object):
         err = ""
         err += "REQ: {0}\n".format(rsp.request.method)
         err += "RSP: " + str(rsp.status_code) + "\n"
-        err += "URL: " + self.url + API_REST_BIND_PATH + "\n"
+        err += "URL: " + self.url + self.bind_path + "\n"
         err += "API: " + key + "\n"
         try:
             err += 'DATA: {}'.format(json.dumps(rsp.json(), indent=2))

--- a/tests/unit-tests/test_publisher_api_bind_path.py
+++ b/tests/unit-tests/test_publisher_api_bind_path.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
+from tests.lib import autocleanup_publisher
+from tests.lib import mock_confluence_instance
+from tests.lib import prepare_conf_publisher
+import unittest
+
+
+class TestConfluencePublisherApiBindPath(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config = prepare_conf_publisher()
+
+        cls.std_space_connect_rsp = {
+            'size': 1,
+            'results': [{
+                'name': 'Mock Space',
+                'type': 'global',
+            }],
+        }
+
+    def test_publisher_api_bind_path_default(self):
+        """validate publisher includes api bind path"""
+        #
+        # Verify that a publisher will perform requests which target the
+        # `/rest/api` endpoint.
+
+        with mock_confluence_instance(self.config) as daemon, \
+                autocleanup_publisher(ConfluencePublisher) as publisher:
+            daemon.register_get_rsp(200, self.std_space_connect_rsp)
+
+            publisher.init(self.config)
+            publisher.connect()
+
+            # connect request
+            connect_req = daemon.pop_get_request()
+            self.assertIsNotNone(connect_req)
+            req_path, _ = connect_req
+            self.assertTrue('/rest/api/' in req_path)
+
+    def test_publisher_api_bind_path_disabled(self):
+        """validate publisher can disable api bind path"""
+        #
+        # Verify that a publisher can perform requests disables the use of
+        # the `/rest/api` endpoint.
+
+        config = self.config.clone()
+        config.confluence_publish_disable_api_prefix = True
+
+        with mock_confluence_instance(config) as daemon, \
+                autocleanup_publisher(ConfluencePublisher) as publisher:
+            daemon.register_get_rsp(200, self.std_space_connect_rsp)
+
+            publisher.init(config)
+            publisher.connect()
+
+            # connect request
+            connect_req = daemon.pop_get_request()
+            self.assertIsNotNone(connect_req)
+            req_path, _ = connect_req
+            self.assertTrue('/rest/api/' not in req_path)


### PR DESCRIPTION
In some corporate environments, a Confluence instance's API endpoint may target a URL which does not include the `rest/api` path. This extension always injected these parts in the path to support common installations; however, this would always break these unique endpoints. This commit introduces a `confluence_publish_disable_api_prefix` option to disable adding the `rest/api` parts in the publish URL.