### PR TITLE
support labels on new pages on confluence server

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -114,14 +114,6 @@ class ConfluenceBuilder(Builder):
         if self.config.confluence_publish:
             process_ask_configs(self.config)
 
-        self.assets = ConfluenceAssetManager(config, self.env, self.outdir)
-        self.writer = ConfluenceWriter(self)
-        self.config.sphinx_verbosity = self._verbose
-        self.publisher.init(self.config)
-
-        self.create_template_bridge()
-        self.templates.init(self)
-
         old_url = self.config.confluence_server_url
         new_url = ConfluenceUtil.normalize_base_url(old_url)
         if old_url != new_url:
@@ -132,6 +124,14 @@ class ConfluenceBuilder(Builder):
         # detect if Confluence Cloud if using the Atlassian domain
         if new_url:
             self.cloud = new_url.endswith('.atlassian.net/wiki/')
+
+        self.assets = ConfluenceAssetManager(config, self.env, self.outdir)
+        self.writer = ConfluenceWriter(self)
+        self.config.sphinx_verbosity = self._verbose
+        self.publisher.init(self.config, self.cloud)
+
+        self.create_template_bridge()
+        self.templates.init(self)
 
         if self.config.confluence_file_suffix is not None:
             self.file_suffix = self.config.confluence_file_suffix

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -48,7 +48,7 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             builder = ConfluenceBuilder(app)
 
             class MockedPublisher:
-                def init(self, config):
+                def init(self, config, cloud=None):
                     pass
 
                 def connect(self):


### PR DESCRIPTION
Initial label support for new pages would include metadata in a "Create content" request. However, only Confluence Cloud's REST API supports providing metadata information in this request type. To support initial label creation on non-Cloud instances, labels will be created for new pages uses a `content/{id}/label` request.