### PR TITLE
allow parent page to accept page identifiers

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -541,15 +541,22 @@ Publishing configuration
 
     The root page found inside the configured space (|confluence_space_key|_)
     where published pages will be a descendant of. The parent page value is used
-    to match with the title of an existing page. If this option is not provided,
-    new pages will be published to the root of the configured space. If the
-    parent page cannot be found, the publish attempt will stop with an error
-    message. For example, the following will publish documentation under the
-    ``MyAwesomeDocs`` page:
+    to match either the title or page identifier of an existing page. If this
+    option is not provided, new pages will be published to the root of the
+    configured space. If the parent page cannot be found, the publish attempt
+    will stop with an error message. For example, the following will publish
+    documentation under the ``MyAwesomeDocs`` page:
 
     .. code-block:: python
 
         confluence_parent_page = 'MyAwesomeDocs'
+
+    Users wishing to publish against a parent page's identifier value can do
+    so by using an integer value instead. For example:
+
+    .. code-block:: python
+
+        confluence_parent_page = 123456
 
     If a parent page is not set, consider using the
     |confluence_root_homepage|_ option as well. Note that the page's name can
@@ -1050,19 +1057,6 @@ Advanced publishing configuration
 
     - |confluence_publish_postfix|_
     - |confluence_publish_prefix|_
-
-.. confval:: confluence_parent_page_id_check
-
-    The page identifier check for |confluence_parent_page|_. By providing an
-    identifier of the parent page, both the parent page's name and identifier
-    must match before this extension will publish any content to a Confluence
-    instance. This serves as a sanity-check configuration for the cautious.
-
-    .. code-block:: python
-
-        confluence_parent_page_id_check = 123456
-
-    See also |confluence_parent_page|_.
 
 .. confval:: confluence_proxy
 
@@ -1606,6 +1600,24 @@ Deprecated options
     .. versionchanged:: 1.6
 
     This option has been renamed to |confluence_root_homepage|_.
+
+.. confval:: confluence_parent_page_id_check
+
+    .. versionchanged:: 1.9
+
+        The |confluence_parent_page|_ option now accepts both a page name and
+        identifier.
+
+    The page identifier check for |confluence_parent_page|_. By providing an
+    identifier of the parent page, both the parent page's name and identifier
+    must match before this extension will publish any content to a Confluence
+    instance. This serves as a sanity-check configuration for the cautious.
+
+    .. code-block:: python
+
+        confluence_parent_page_id_check = 123456
+
+    See also |confluence_parent_page|_.
 
 .. confval:: confluence_publish_subset
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -114,7 +114,7 @@ def setup(app):
     app.add_config_value('confluence_global_labels', None, '')
     # Enablement of configuring root as space's homepage.
     app.add_config_value('confluence_root_homepage', None, '')
-    # Parent page's name to publish documents under.
+    # Parent page's name or identifier to publish documents under.
     app.add_config_value('confluence_parent_page', None, '')
     # Perform a dry run of publishing to inspect what publishing will do.
     app.add_config_value('confluence_publish_dryrun', None, '')

--- a/sphinxcontrib/confluencebuilder/cmd/wipe.py
+++ b/sphinxcontrib/confluencebuilder/cmd/wipe.py
@@ -81,7 +81,7 @@ To use this action, the argument '--danger' must be set.
                 dryrun = app.config.confluence_publish_dryrun
                 server_url = app.config.confluence_server_url
                 space_key = app.config.confluence_space_key
-                parent_name = app.config.confluence_parent_page
+                parent_ref = app.config.confluence_parent_page
 
                 # initialize the publisher (if permitted)
                 if app.config.confluence_publish:
@@ -103,7 +103,7 @@ To use this action, the argument '--danger' must be set.
         logger.error('publishing not configured in sphinx configuration')
         return 1
 
-    if args.parent and not parent_name:
+    if args.parent and not parent_ref:
         logger.error('parent option provided but no parent page is configured')
         return 1
 
@@ -141,7 +141,7 @@ pages. Only use this action if you know what you are doing.
     print('         URL:', server_url)
     print('       Space:', space_key)
     if base_page_id:
-        logger.note('       Pages: Child pages of ' + parent_name)
+        logger.note('       Pages: Child pages of ' + parent_ref)
     else:
         logger.note('       Pages: All Pages')
     print(' Total pages:', len(legacy_pages))

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -391,8 +391,14 @@ If planning to use a depth of zero, it is recommended to use the
 
     # ##################################################################
 
-    validator.conf('confluence_parent_page') \
-             .string()
+    try:
+        validator.conf('confluence_parent_page').string()
+    except ConfluenceConfigurationError:
+        try:
+            validator.conf('confluence_parent_page').int_(positive=True)
+        except ConfluenceConfigurationError:
+            raise ConfluenceConfigurationError('''\
+confluence_parent_page is not a string or a positive integer''')
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -102,6 +102,14 @@ def apply_defaults(conf):
             if not isinstance(getattr(conf, key), int) and conf[key]:
                 conf[key] = int(conf[key])
 
+    # if the parent page is an integer value in a string type, cast it to an
+    # integer; otherwise, assume it is a page name (string)
+    if conf.confluence_parent_page:
+        try:
+            conf.confluence_parent_page = int(conf.confluence_parent_page)
+        except ValueError:
+            pass
+
     # if running an older version of Sphinx which does not define `root_doc`,
     # copy it over now from the legacy configuration
     if 'root_doc' not in conf:

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -15,6 +15,8 @@ DEPRECATED_CONFIGS = {
         'to be removed in a future version',
     'confluence_master_homepage':
         'use "confluence_root_homepage" instead',
+    'confluence_parent_page_id_check':
+        '"confluence_parent_page" now accepts a page id',
     'confluence_publish_subset':
         'use "confluence_publish_allowlist" instead',
     'confluence_purge_from_master':

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -514,6 +514,20 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_parent_page'] = 'dummy'
         self._try_config()
 
+        self.config['confluence_parent_page'] = '123456'
+        self._try_config()
+
+        self.config['confluence_parent_page'] = 456789
+        self._try_config()
+
+        self.config['confluence_parent_page'] = 0
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_parent_page'] = -123456
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
     def test_config_check_parent_page_id_check(self):
         # enable publishing enabled checks
         self._prepare_valid_publish()
@@ -524,10 +538,12 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
         self.config['confluence_parent_page'] = 'dummy'
-        self._try_config()
+        with self.assertRaises(SphinxWarning):
+            self._try_config()
 
         self.config['confluence_parent_page_id_check'] = '123456'
-        self._try_config()
+        with self.assertRaises(SphinxWarning):
+            self._try_config()
 
         self.config['confluence_parent_page_id_check'] = 0
         with self.assertRaises(ConfluenceConfigurationError):

--- a/tests/unit-tests/test_publisher_base_id.py
+++ b/tests/unit-tests/test_publisher_base_id.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
+from tests.lib import autocleanup_publisher
+from tests.lib import mock_confluence_instance
+from tests.lib import prepare_conf_publisher
+import unittest
+
+
+class TestConfluencePublisherBaseId(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config = prepare_conf_publisher()
+
+        cls.std_space_connect_rsp = {
+            'size': 1,
+            'results': [{
+                'name': 'Mock Space',
+                'type': 'global',
+            }],
+        }
+
+    def test_publisher_page_base_id_parent_id(self):
+        """validate publisher will search for parent page by id"""
+        #
+        # Verify that a publisher will find a base (pages) identifier, based
+        # off a configured parent page id.
+
+        expected_page_id = 4568436
+
+        config = self.config.clone()
+        config.confluence_parent_page = expected_page_id
+
+        with mock_confluence_instance(config) as daemon, \
+                autocleanup_publisher(ConfluencePublisher) as publisher:
+            daemon.register_get_rsp(200, self.std_space_connect_rsp)
+
+            publisher.init(config)
+            publisher.connect()
+
+            # consume connect request
+            self.assertIsNotNone(daemon.pop_get_request())
+
+            # prepare response for a page fetch
+            page_fetch_rsp = {
+                'id': expected_page_id,
+                'title': 'mock page',
+                'type': 'page',
+            }
+            daemon.register_get_rsp(200, page_fetch_rsp)
+
+            # perform base page id fetch request
+            base_id = publisher.get_base_page_id()
+
+            # check expected page id returned
+            self.assertEqual(base_id, expected_page_id)
+
+            # check that the provided page id is set in the request
+            fetch_req = daemon.pop_get_request()
+            self.assertIsNotNone(fetch_req)
+            req_path, _ = fetch_req
+
+            expected_request = '/rest/api/content/{}'.format(expected_page_id)
+            self.assertTrue(req_path.startswith(expected_request))
+
+            # verify that no other request was made
+            self.assertFalse(daemon.check_unhandled_requests())
+
+    def test_publisher_page_base_id_parent_name(self):
+        """validate publisher will search for parent page by name"""
+        #
+        # Verify that a publisher will find a base (pages) identifier, based
+        # off a configured parent page name.
+
+        expected_page_name = 'refname-31421'
+
+        config = self.config.clone()
+        config.confluence_parent_page = expected_page_name
+
+        with mock_confluence_instance(config) as daemon, \
+                autocleanup_publisher(ConfluencePublisher) as publisher:
+            daemon.register_get_rsp(200, self.std_space_connect_rsp)
+
+            publisher.init(config)
+            publisher.connect()
+
+            # consume connect request
+            self.assertIsNotNone(daemon.pop_get_request())
+
+            # prepare response for a page fetch
+            expected_page_id = '245'
+
+            page_search_fetch_rsp = {
+                'size': 1,
+                'results': [{
+                    'id': expected_page_id,
+                    'title': 'mock page',
+                    'type': 'page',
+                }],
+            }
+            daemon.register_get_rsp(200, page_search_fetch_rsp)
+
+            # perform base page id fetch request
+            base_id = publisher.get_base_page_id()
+
+            # check expected page id returned
+            self.assertEqual(base_id, expected_page_id)
+
+            # check that the provided page id is set in the request
+            fetch_req = daemon.pop_get_request()
+            self.assertIsNotNone(fetch_req)
+            req_path, _ = fetch_req
+
+            expected_opt = 'title={}'.format(expected_page_name)
+            self.assertTrue(req_path.startswith('/rest/api/content'))
+            self.assertTrue(expected_opt in expected_opt)
+
+            # verify that no other request was made
+            self.assertFalse(daemon.check_unhandled_requests())
+
+    def test_publisher_page_base_id_parent_none(self):
+        """validate publisher will search for parent page by name"""
+        #
+        # Verify that a publisher will find a base (pages) identifier, based
+        # off a configured parent page name.
+
+        with mock_confluence_instance(self.config) as daemon, \
+                autocleanup_publisher(ConfluencePublisher) as publisher:
+            daemon.register_get_rsp(200, self.std_space_connect_rsp)
+
+            publisher.init(self.config)
+            publisher.connect()
+
+            # consume connect request
+            self.assertIsNotNone(daemon.pop_get_request())
+
+            # prepare response for a page fetch
+            expected_page_id = '416'
+
+            page_fetch_rsp = {
+                'size': 1,
+                'results': [{
+                    'id': expected_page_id,
+                    'title': 'mock page',
+                    'type': 'page',
+                }],
+            }
+            daemon.register_get_rsp(200, page_fetch_rsp)
+
+            # request base id which should return nothing, with no request
+            base_id = publisher.get_base_page_id()
+            self.assertIsNone(base_id)
+
+            # verify that no other request was made
+            self.assertFalse(daemon.check_unhandled_requests())


### PR DESCRIPTION
This commit tweaks the `confluence_parent_page` option to accept both a page's title value (original) or a page identifier (added).