### PR TITLE
adjust for new sphinx versions (v5.0.x)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,30 +32,31 @@ jobs:
         include:
             - { os:  ubuntu-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx42, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx43, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx45, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx42, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx43, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx45, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx41, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx42, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx43, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx45, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx18, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx45, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx50, cache: ~/.cache/pip }
             - { os:   macos-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~/Library/Caches/pip }
-            - { os:   macos-latest, python: "3.10", toxenv: py310-sphinx45, cache: ~/Library/Caches/pip }
+            - { os:   macos-latest, python: "3.10", toxenv: py310-sphinx50, cache: ~/Library/Caches/pip }
             - { os: windows-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~\AppData\Local\pip\Cache }
-            - { os: windows-latest, python: "3.10", toxenv: py310-sphinx45, cache: ~\AppData\Local\pip\Cache }
+            - { os: windows-latest, python: "3.10", toxenv: py310-sphinx50, cache: ~\AppData\Local\pip\Cache }
             - { os:  ubuntu-latest, python: "3.10", toxenv:         flake8, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv:         pylint, cache: ~/.cache/pip }
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist =
     flake8
     pylint
     py{27,37,38,39,310}-sphinx{18}
-    py{37,38,39}-sphinx{41,42,43,44}
-    py{310}-sphinx{42,43,44,45}
+    py{37,38,39}-sphinx{42,43,44,50}
+    py{310}-sphinx{42,43,44,45,50}
 
 [testenv]
 deps =
@@ -12,11 +12,11 @@ deps =
     sphinx18: docutils<0.18
     sphinx18: jinja2<=3.0.3
     sphinx18: sphinx>=1.8,<2.0
-    sphinx41: sphinx>=4.1,<4.2
     sphinx42: sphinx>=4.2,<4.3
     sphinx43: sphinx>=4.3,<4.4
     sphinx44: sphinx>=4.4,<4.5
     sphinx45: sphinx>=4.5,<4.6
+    sphinx50: sphinx>=5.0,<5.1
 commands =
     {envpython} -m tests {posargs}
 setenv =


### PR DESCRIPTION
### tox: adjust for new sphinx versions (v5.0.x)

Sphinx provides a stable v5.0.x series; adjusting the tox configuration to support the new revision. Following maintenance guidelines, this allows a series of legacy Sphinx revisions to be dropped as well.

See CONTRIBUTING.rst for additional information.

### workflows: adjust for new sphinx versions (v5.0.x)

The tox configuration has been adjusted with a new version of Sphinx versions to test against. Adjusting the automated building to invoke these accordingly.