### PR TITLE
Recognize confluence_publish as a boolean config

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -75,6 +75,7 @@ def apply_defaults(conf):
         'confluence_master_homepage',
         'confluence_page_generation_notice',
         'confluence_page_hierarchy',
+        'confluence_publish',
         'confluence_publish_debug',
         'confluence_publish_dryrun',
         'confluence_publish_onlynew',


### PR DESCRIPTION
This corrects the behavior of `-D confluence_publish=false`.