### PR TITLE
support providing configuration options from environment

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -21,6 +21,15 @@ All configurations introduced by this extension are listed below. This
 extension may take advantage of a subset of `Sphinx configurations`_ as well
 when preparing documents.
 
+.. versionadded:: 1.9
+
+    All options provided by this extension may be set from the running
+    environment. For example, if ``confluence_publish`` is not explicitly set
+    inside ``conf.py`` or provided via `Sphinx's command line`_, this extension
+    may check the ``CONFLUENCE_PUBLISH`` environment option as a fallback. Note
+    that this only applies options provided below and will not work for other
+    configuration options provided by Sphinx or other Sphinx extensions.
+
 .. only:: latex
 
     .. contents::
@@ -1677,6 +1686,7 @@ Deprecated options
 .. _Requests SSL Cert Verification: https://requests.readthedocs.io/en/stable/user/advanced/#ssl-cert-verification
 .. _Requests: https://pypi.python.org/pypi/requests
 .. _Sphinx configurations: https://www.sphinx-doc.org/en/master/usage/configuration.html
+.. _Sphinx's command line: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D
 .. _TLS/SSL wrapper for socket object: https://docs.python.org/3/library/ssl.html#ssl.create_default_context
 .. _Using Personal Access Tokens: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
 .. _api_tokens: https://confluence.atlassian.com/cloud/api-tokens-938839638.html

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -8,6 +8,7 @@ from os import path
 from sphinx.util import docutils
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.config import handle_config_inited
+from sphinxcontrib.confluencebuilder.config.manager import ConfigManager
 from sphinxcontrib.confluencebuilder.directives import ConfluenceExpandDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceLatexDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceMetadataDirective
@@ -44,6 +45,7 @@ __version__ = '1.9.0.dev0'
 
 def setup(app):
     ConfluenceLogger.initialize()
+    cm = app.config_manager_ = ConfigManager(app)
 
     app.require_sphinx('1.8')
     app.add_builder(ConfluenceBuilder)
@@ -59,179 +61,179 @@ def setup(app):
 
     # (configuration - essential)
     # Enablement of publishing.
-    app.add_config_value('confluence_publish', None, '')
+    cm.add_conf_bool('confluence_publish')
     # PAT to authenticate to Confluence API with.
-    app.add_config_value('confluence_publish_token', None, '')
+    cm.add_conf('confluence_publish_token')
     # API key/password to login to Confluence API with.
-    app.add_config_value('confluence_server_pass', None, '')
+    cm.add_conf('confluence_server_pass')
     # URL of the Confluence instance to publish to.
-    app.add_config_value('confluence_server_url', None, '')
+    cm.add_conf('confluence_server_url')
     # Username to login to Confluence API with.
-    app.add_config_value('confluence_server_user', None, '')
+    cm.add_conf('confluence_server_user')
     # Confluence Space to publish to.
-    app.add_config_value('confluence_space_key', None, '')
+    cm.add_conf('confluence_space_key')
 
     # (configuration - generic)
     # Add page and section numbers if doctree has :numbered: option
-    app.add_config_value('confluence_add_secnumbers', None, 'env')
+    cm.add_conf_bool('confluence_add_secnumbers', 'env')
     # Default alignment for tables, figures, etc.
-    app.add_config_value('confluence_default_alignment', None, 'env')
+    cm.add_conf('confluence_default_alignment', 'env')
     # Enablement of a generated domain index documents
-    app.add_config_value('confluence_domain_indices', None, '')
+    cm.add_conf('confluence_domain_indices')
     # File to get page header information from.
-    app.add_config_value('confluence_header_file', None, 'env')
+    cm.add_conf('confluence_header_file', 'env')
     # Dictionary to pass to header when rendering template
-    app.add_config_value('confluence_header_data', None, 'env')
+    cm.add_conf('confluence_header_data', 'env')
     # File to get page footer information from.
-    app.add_config_value('confluence_footer_file', None, 'env')
+    cm.add_conf('confluence_footer_file', 'env')
     # Dictionary to pass to footer when rendering template.
-    app.add_config_value('confluence_footer_data', None, 'env')
+    cm.add_conf('confluence_footer_data', 'env')
     # Enablement of a generated search documents
-    app.add_config_value('confluence_include_search', None, '')
+    cm.add_conf_bool('confluence_include_search')
     # Enablement of the maximum document depth (before inlining).
-    app.add_config_value('confluence_max_doc_depth', None, 'env')
+    cm.add_conf_int('confluence_max_doc_depth', 'env')
     # Enablement of a "page generated" notice.
-    app.add_config_value('confluence_page_generation_notice', None, 'env')
+    cm.add_conf_bool('confluence_page_generation_notice', 'env')
     # Enablement of publishing pages into a hierarchy from a root toctree.
-    app.add_config_value('confluence_page_hierarchy', None, False)
+    cm.add_conf_bool('confluence_page_hierarchy')
     # Show previous/next buttons (bottom, top, both, None).
-    app.add_config_value('confluence_prev_next_buttons_location', None, 'env')
+    cm.add_conf('confluence_prev_next_buttons_location', 'env')
     # Suffix to put after section numbers, before section name
-    app.add_config_value('confluence_secnumber_suffix', None, 'env')
+    cm.add_conf('confluence_secnumber_suffix', 'env')
     # Enablement of a "Edit/Show Source" reference on each document
-    app.add_config_value('confluence_sourcelink', None, 'env')
+    cm.add_conf('confluence_sourcelink', 'env')
     # Enablement of a generated index document
-    app.add_config_value('confluence_use_index', None, '')
+    cm.add_conf_bool('confluence_use_index')
     # Enablement for toctrees for singleconfluence documents.
-    app.add_config_value('singleconfluence_toctree', None, 'singleconfluence')
+    cm.add_conf_bool('singleconfluence_toctree', 'singleconfluence')
 
     # (configuration - publishing)
     # Request for publish password to come from interactive session.
-    app.add_config_value('confluence_ask_password', None, '')
+    cm.add_conf_bool('confluence_ask_password')
     # Request for publish username to come from interactive session.
-    app.add_config_value('confluence_ask_user', None, '')
+    cm.add_conf_bool('confluence_ask_user')
     # Explicitly prevent auto-generation of titles for titleless documents.
-    app.add_config_value('confluence_disable_autogen_title', None, '')
+    cm.add_conf_bool('confluence_disable_autogen_title')
     # Explicitly prevent page notifications on update.
-    app.add_config_value('confluence_disable_notifications', None, '')
+    cm.add_conf_bool('confluence_disable_notifications')
     # Define a series of labels to apply to all published pages.
-    app.add_config_value('confluence_global_labels', None, '')
+    cm.add_conf('confluence_global_labels')
     # Enablement of configuring root as space's homepage.
-    app.add_config_value('confluence_root_homepage', None, '')
+    cm.add_conf_bool('confluence_root_homepage')
     # Parent page's name or identifier to publish documents under.
-    app.add_config_value('confluence_parent_page', None, '')
+    cm.add_conf('confluence_parent_page')
     # Perform a dry run of publishing to inspect what publishing will do.
-    app.add_config_value('confluence_publish_dryrun', None, '')
+    cm.add_conf_bool('confluence_publish_dryrun')
     # Publish only new content (no page updates, etc.).
-    app.add_config_value('confluence_publish_onlynew', None, '')
+    cm.add_conf_bool('confluence_publish_onlynew')
     # Postfix to apply to title of published pages.
-    app.add_config_value('confluence_publish_postfix', None, 'env')
+    cm.add_conf('confluence_publish_postfix', 'env')
     # Prefix to apply to published pages.
-    app.add_config_value('confluence_publish_prefix', None, 'env')
+    cm.add_conf('confluence_publish_prefix', 'env')
     # Root page's identifier to publish documents into.
-    app.add_config_value('confluence_publish_root', None, '')
+    cm.add_conf_int('confluence_publish_root')
     # Enablement of purging legacy child pages from a parent page.
-    app.add_config_value('confluence_purge', None, '')
+    cm.add_conf_bool('confluence_purge')
     # Enablement of purging legacy child pages from a root page.
-    app.add_config_value('confluence_purge_from_root', None, '')
+    cm.add_conf_bool('confluence_purge_from_root')
     # docname-2-title dictionary for title overrides.
-    app.add_config_value('confluence_title_overrides', None, 'env')
+    cm.add_conf('confluence_title_overrides', 'env')
     # Timeout for network-related calls (publishing).
-    app.add_config_value('confluence_timeout', None, '')
+    cm.add_conf_int('confluence_timeout')
     # Whether or not new content should be watched.
-    app.add_config_value('confluence_watch', None, '')
+    cm.add_conf_bool('confluence_watch')
 
     # (configuration - advanced publishing)
     # Register additional mime types to be selected for image candidates.
-    app.add_config_value('confluence_additional_mime_types', None, 'env')
+    cm.add_conf('confluence_additional_mime_types', 'env')
     # Whether or not labels will be appended instead of overwriting them.
-    app.add_config_value('confluence_append_labels', None, '')
+    cm.add_conf_bool('confluence_append_labels')
     # Forcing all assets to be standalone.
-    app.add_config_value('confluence_asset_force_standalone', None, 'env')
+    cm.add_conf_bool('confluence_asset_force_standalone', 'env')
     # Tri-state asset handling (auto, force push or disable).
-    app.add_config_value('confluence_asset_override', None, '')
+    cm.add_conf_bool('confluence_asset_override')
     # File/path to Certificate Authority
-    app.add_config_value('confluence_ca_cert', None, '')
+    cm.add_conf('confluence_ca_cert')
     # Path to client certificate to use for publishing
-    app.add_config_value('confluence_client_cert', None, '')
+    cm.add_conf('confluence_client_cert')
     # Password for client certificate to use for publishing
-    app.add_config_value('confluence_client_cert_pass', None, '')
+    cm.add_conf('confluence_client_cert_pass')
     # Disable SSL validation with Confluence server.
-    app.add_config_value('confluence_disable_ssl_validation', None, '')
+    cm.add_conf_bool('confluence_disable_ssl_validation')
     # Ignore adding a titlefix on the index document.
-    app.add_config_value('confluence_ignore_titlefix_on_index', None, 'env')
+    cm.add_conf_bool('confluence_ignore_titlefix_on_index', 'env')
     # Parent page's identifier to publish documents under.
-    app.add_config_value('confluence_parent_page_id_check', None, '')
+    cm.add_conf_int('confluence_parent_page_id_check')
     # Proxy server needed to communicate with Confluence server.
-    app.add_config_value('confluence_proxy', None, '')
+    cm.add_conf('confluence_proxy')
     # Subset of documents which are allowed to be published.
-    app.add_config_value('confluence_publish_allowlist', None, '')
+    cm.add_conf('confluence_publish_allowlist')
     # Enable debugging for publish requests.
-    app.add_config_value('confluence_publish_debug', None, '')
+    cm.add_conf_bool('confluence_publish_debug')
     # Duration (in seconds) to delay each API request.
-    app.add_config_value('confluence_publish_delay', None, '')
+    cm.add_conf('confluence_publish_delay')
     # Subset of documents which are denied to be published.
-    app.add_config_value('confluence_publish_denylist', None, '')
+    cm.add_conf('confluence_publish_denylist')
     # Disable adding `rest/api` to REST requests.
-    app.add_config_value('confluence_publish_disable_api_prefix', None, '')
+    cm.add_conf_bool('confluence_publish_disable_api_prefix')
     # Header(s) to use for Confluence REST interaction.
-    app.add_config_value('confluence_publish_headers', None, '')
+    cm.add_conf('confluence_publish_headers')
     # Manipulate a requests instance.
-    app.add_config_value('confluence_request_session_override', None, '')
+    cm.add_conf('confluence_request_session_override')
     # Authentication passthrough for Confluence REST interaction.
-    app.add_config_value('confluence_server_auth', None, '')
+    cm.add_conf('confluence_server_auth')
     # Cookie(s) to use for Confluence REST interaction.
-    app.add_config_value('confluence_server_cookies', None, '')
+    cm.add_conf('confluence_server_cookies')
     # Comment added to confluence version history.
-    app.add_config_value('confluence_version_comment', None, '')
+    cm.add_conf('confluence_version_comment')
 
     # (configuration - advanced processing)
     # Filename suffix for generated files.
-    app.add_config_value('confluence_file_suffix', None, 'env')
+    cm.add_conf('confluence_file_suffix', 'env')
     # Translation of docname to a filename.
-    app.add_config_value('confluence_file_transform', None, 'env')
+    cm.add_conf('confluence_file_transform', 'env')
     # Configuration for named JIRA Servers
-    app.add_config_value('confluence_jira_servers', None, 'env')
+    cm.add_conf('confluence_jira_servers', 'env')
     # Translation of a raw language to code block macro language.
-    app.add_config_value('confluence_lang_transform', None, 'env')
+    cm.add_conf('confluence_lang_transform', 'env')
     # Macro configuration for Confluence-managed LaTeX content.
-    app.add_config_value('confluence_latex_macro', None, 'env')
+    cm.add_conf('confluence_latex_macro', 'env')
     # Link suffix for generated files.
-    app.add_config_value('confluence_link_suffix', None, 'env')
+    cm.add_conf('confluence_link_suffix', 'env')
     # Translation of docname to a (partial) URI.
-    app.add_config_value('confluence_link_transform', None, 'env')
+    cm.add_conf('confluence_link_transform', 'env')
     # Mappings for documentation mentions to Confluence keys.
-    app.add_config_value('confluence_mentions', None, 'env')
+    cm.add_conf('confluence_mentions', 'env')
     # Inject navigational hints into the documentation.
-    app.add_config_value('confluence_navdocs_transform', None, '')
+    cm.add_conf('confluence_navdocs_transform')
     # Remove a detected title from generated documents.
-    app.add_config_value('confluence_remove_title', None, 'env')
+    cm.add_conf_bool('confluence_remove_title', 'env')
 
     # (configuration - undocumented)
     # Enablement for aggressive descendents search (for purge).
-    app.add_config_value('confluence_adv_aggressive_search', None, '')
+    cm.add_conf_bool('confluence_adv_aggressive_search')
     # List of node types to ignore if no translator support exists.
-    app.add_config_value('confluence_adv_ignore_nodes', None, '')
+    cm.add_conf('confluence_adv_ignore_nodes')
     # Unknown node handler dictionary for advanced integrations.
-    app.add_config_value('confluence_adv_node_handler', None, '')
+    cm.add_conf('confluence_adv_node_handler')
     # Enablement of permitting raw html blocks to be used in storage format.
-    app.add_config_value('confluence_adv_permit_raw_html', None, 'env')
+    cm.add_conf_bool('confluence_adv_permit_raw_html', 'env')
     # List of optional features/macros/etc. restricted for use.
-    app.add_config_value('confluence_adv_restricted', None, 'env')
+    cm.add_conf('confluence_adv_restricted', 'env')
     # Enablement of tracing processed data.
-    app.add_config_value('confluence_adv_trace_data', None, '')
+    cm.add_conf_bool('confluence_adv_trace_data')
     # Do not cap sections to a maximum of six (6) levels.
-    app.add_config_value('confluence_adv_writer_no_section_cap', None, 'env')
+    cm.add_conf_bool('confluence_adv_writer_no_section_cap', 'env')
 
     # (configuration - deprecated)
     # replaced by confluence_root_homepage
-    app.add_config_value('confluence_master_homepage', None, '')
+    cm.add_conf('confluence_master_homepage')
     # replaced by confluence_publish_allowlist
-    app.add_config_value('confluence_publish_subset', None, '')
+    cm.add_conf('confluence_publish_subset')
     # replaced by confluence_purge_from_root
-    app.add_config_value('confluence_purge_from_master', None, '')
+    cm.add_conf_bool('confluence_purge_from_master')
     # replaced by confluence_space_key
-    app.add_config_value('confluence_space_name', None, '')
+    cm.add_conf('confluence_space_name')
 
     # ##########################################################################
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -92,7 +92,7 @@ class ConfluenceBuilder(Builder):
 
     def init(self):
         validate_configuration(self)
-        apply_defaults(self.config)
+        apply_defaults(self)
         config = self.config
 
         self.add_secnumbers = self.config.confluence_add_secnumbers

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -23,6 +23,7 @@ from sphinxcontrib.confluencebuilder.assets import ConfluenceSupportedImages
 from sphinxcontrib.confluencebuilder.config import process_ask_configs
 from sphinxcontrib.confluencebuilder.config.checks import validate_configuration
 from sphinxcontrib.confluencebuilder.config.defaults import apply_defaults
+from sphinxcontrib.confluencebuilder.config.env import apply_env_overrides
 from sphinxcontrib.confluencebuilder.intersphinx import build_intersphinx
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 from sphinxcontrib.confluencebuilder.nodes import confluence_footer
@@ -91,6 +92,7 @@ class ConfluenceBuilder(Builder):
         self.state.reset()
 
     def init(self):
+        apply_env_overrides(self)
         validate_configuration(self)
         apply_defaults(self)
         config = self.config

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -7,7 +7,7 @@
 from sphinxcontrib.confluencebuilder.util import str2bool
 
 
-def apply_defaults(conf):
+def apply_defaults(builder):
     """
     applies default values for select configurations
 
@@ -17,8 +17,11 @@ def apply_defaults(conf):
     a more controlled time.
 
     Args:
-        conf: the configuration to modify
+        builder: the builder which configuration defaults should be applied on
     """
+
+    conf = builder.config
+    config_manager = builder.app.config_manager_
 
     if conf.confluence_add_secnumbers is None:
         conf.confluence_add_secnumbers = True
@@ -59,45 +62,14 @@ def apply_defaults(conf):
     if conf.confluence_sourcelink is None:
         conf.confluence_sourcelink = {}
 
-    config2bool = [
-        'confluence_add_secnumbers',
-        'confluence_adv_aggressive_search',
-        'confluence_adv_permit_raw_html',
-        'confluence_adv_trace_data',
-        'confluence_adv_writer_no_section_cap',
-        'confluence_ask_password',
-        'confluence_ask_user',
-        'confluence_asset_force_standalone',
-        'confluence_disable_autogen_title',
-        'confluence_disable_notifications',
-        'confluence_disable_ssl_validation',
-        'confluence_ignore_titlefix_on_index',
-        'confluence_master_homepage',
-        'confluence_page_generation_notice',
-        'confluence_page_hierarchy',
-        'confluence_publish_debug',
-        'confluence_publish_dryrun',
-        'confluence_publish_onlynew',
-        'confluence_purge',
-        'confluence_purge_from_master',
-        'confluence_purge_from_root',
-        'confluence_remove_title',
-        'confluence_root_homepage',
-        'confluence_watch',
-        'singleconfluence_toctree',
-    ]
-    for key in config2bool:
+    # ensure all boolean-based options are converted to boolean types
+    for key in sorted(config_manager.options_bool):
         if getattr(conf, key) is not None:
             if not isinstance(getattr(conf, key), bool) and conf[key]:
                 conf[key] = str2bool(conf[key])
 
-    config2int = [
-        'confluence_max_doc_depth',
-        'confluence_parent_page_id_check',
-        'confluence_publish_root',
-        'confluence_timeout',
-    ]
-    for key in config2int:
+    # ensure all integer-based options are converted to integer types
+    for key in sorted(config_manager.options_int):
         if getattr(conf, key) is not None:
             if not isinstance(getattr(conf, key), int) and conf[key]:
                 conf[key] = int(conf[key])

--- a/sphinxcontrib/confluencebuilder/config/env.py
+++ b/sphinxcontrib/confluencebuilder/config/env.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
+from sphinxcontrib.confluencebuilder.util import str2bool
+import os
+
+
+def apply_env_overrides(builder):
+    """
+    applies configuration options from the environment into the extension
+
+    The Confluence builder extension will accept configuration options
+    provided from the running environment. For each configuration option
+    registered by this extension, the environment will be checked to see if
+    a matching environment key (capitalized) exists.
+
+    Args:
+        builder: the builder which configuration defaults should be applied on
+    """
+
+    conf = builder.config
+    config_manager = builder.app.config_manager_
+
+    for key in sorted(config_manager.options):
+        # skip over options that have been already set
+        if getattr(conf, key) is not None:
+            continue
+
+        env_key = key.upper()
+        env_val = os.getenv(env_key)
+        if env_val:
+            logger.verbose('accepting configuration from env: %s' % env_val)
+
+            if key in config_manager.options_bool:
+                conf[key] = str2bool(env_val)
+            elif key in config_manager.options_int:
+                conf[key] = int(env_val)
+            else:
+                conf[key] = env_val

--- a/sphinxcontrib/confluencebuilder/config/manager.py
+++ b/sphinxcontrib/confluencebuilder/config/manager.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+
+class ConfigManager:
+    def __init__(self, app):
+        """
+        configuration manager
+
+        The goal of a configuration manager is to track Confluence-specific
+        configuration options for late stage referencing. Configuration
+        options in this extension may be adjusted at a later stage beyond
+        the extension's setup stage. The manager can be used to track
+        what configuration options exist, even for specific types, which
+        can allow configuration tweaks to processing against tracked
+        options instead of having to explicitly reference groups of
+        configuration options outside the setup implementation.
+
+        Args:
+            app: the sphinx application instance
+
+        Attributes:
+            app: the sphinx application instance
+            options: set of registered extension options
+            options_bool: set of registered extension options (bool-specific)
+            options_int: set of registered extension options (integer-specific)
+        """
+        self.app = app
+        self.options = set()
+        self.options_bool = set()
+        self.options_int = set()
+
+    def add_conf(self, name, rebuild=''):
+        """
+        register a configuration option
+
+        Registers a provided configuration option into the Sphinx application.
+        Provides a simplified call over `add_config_value`, which always
+        specifics a `None` default type (required for the Confluence
+        extension's configuration processing) and defaults to a no rebuild
+        condition.
+
+        Args:
+            name: the name of the configuration value
+            rebuild (optional): the condition of rebuild based on Sphinx's
+                                 `add_config_value` option (defaults to `''`
+                                 for no rebuild)
+        """
+        self.options.add(name)
+        self.app.add_config_value(name, None, rebuild=rebuild)
+
+    def add_conf_bool(self, name, rebuild=''):
+        """
+        register a boolean-typed configuration option
+
+        Register a configuration option as outlined in `add_conf`. This call
+        is specific for registering options which values will be of a boolean
+        type, to help track all boolean-typed options for future processing.
+
+        Args:
+            name: the name of the configuration value
+            rebuild (optional): the condition of rebuild based on Sphinx's
+                                 `add_config_value` option (defaults to `''`
+                                 for no rebuild)
+        """
+        self.options_bool.add(name)
+        self.add_conf(name, rebuild=rebuild)
+
+    def add_conf_int(self, name, rebuild=''):
+        """
+        register a integer-typed configuration option
+
+        Register a configuration option as outlined in `add_conf`. This call
+        is specific for registering options which values will be of a integer
+        type, to help track all integer-typed options for future processing.
+
+        Args:
+            name: the name of the configuration value
+            rebuild (optional): the condition of rebuild based on Sphinx's
+                                 `add_config_value` option (defaults to `''`
+                                 for no rebuild)
+        """
+        self.options_int.add(name)
+        self.add_conf(name, rebuild=rebuild)

--- a/tests/unit-tests/test_config_env.py
+++ b/tests/unit-tests/test_config_env.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib import prepare_conf
+from tests.lib import prepare_sphinx
+import os
+import unittest
+
+
+class TestConfluenceConfigEnvironment(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+
+    def run(self, result=None):
+        # unique configuration each run to avoid copying it in each test
+        self.config = prepare_conf()
+
+        # ensure environment overrides do not leak between tests
+        old_env = dict(os.environ)
+        try:
+            super(TestConfluenceConfigEnvironment, self).run(result)
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+
+    def test_config_env_bool(self):
+        # default unset
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertIsNone(app.config.confluence_publish_debug)
+
+        # configure option from environment
+        os.environ['CONFLUENCE_PUBLISH_DEBUG'] = '0'
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertFalse(app.config.confluence_publish_debug)
+
+        os.environ['CONFLUENCE_PUBLISH_DEBUG'] = '1'
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertTrue(app.config.confluence_publish_debug)
+
+        # override the option (taking precedence over environment)
+        self.config['confluence_publish_debug'] = False
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertFalse(app.config.confluence_publish_debug)
+        self.assertTrue('CONFLUENCE_PUBLISH_DEBUG' in os.environ)
+        self.assertEqual(os.environ['CONFLUENCE_PUBLISH_DEBUG'], '1')
+
+    def test_config_env_int(self):
+        # default unset
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertIsNone(app.config.confluence_timeout)
+
+        # configure option from environment
+        os.environ['CONFLUENCE_TIMEOUT'] = '5'
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertEqual(app.config.confluence_timeout, 5)
+
+        # override the option (taking precedence over environment)
+        self.config['confluence_timeout'] = 10
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertEqual(app.config.confluence_timeout, 10)
+        self.assertTrue('CONFLUENCE_TIMEOUT' in os.environ)
+        self.assertEqual(os.environ['CONFLUENCE_TIMEOUT'], '5')
+
+    def test_config_env_str(self):
+        # default unset
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertIsNone(app.config.confluence_space_key)
+
+        # configure option from environment
+        os.environ['CONFLUENCE_SPACE_KEY'] = 'FIRSTSPACE'
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertEqual(app.config.confluence_space_key, 'FIRSTSPACE')
+
+        # override the option (taking precedence over environment)
+        self.config['confluence_space_key'] = 'SECONDSPACE'
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertEqual(app.config.confluence_space_key, 'SECONDSPACE')
+        self.assertTrue('CONFLUENCE_SPACE_KEY' in os.environ)
+        self.assertEqual(os.environ['CONFLUENCE_SPACE_KEY'], 'FIRSTSPACE')


### PR DESCRIPTION
Provides a series of changed to help support accepting configuration options from the environment.

### track configuration options for configuration type conversions

A subset of options to be used as a boolean or integer type can be accepted as a string (typically, from command line) and converted after post-processing configuration options. The original implementation defined a list of, for example, boolean configuration options and cycled through these keys to ensured all string-assigned values are converted to boolean types.

A maintenance issue observed is that as boolean options are defined for the extension, development may miss adding these new options into the respective type conversion lists in the "defaults" implementation. To prevent this from happening, rework this extension's configuration processing to help easily track the expected types for individual configurations. With this change, the "defaults" implementation can apply type conversions based off tracked configuration entries registered in the manager.

### accept configuration options from environment

If a Confluence supported configuration option is not configured, allow accepting an option from the running environment. Provides flexibility for users wishing to configure a subset of options using environment variables, instead of passing options via the command line or trying to manipulate a project's `conf.py` file to read options from the environment.

### tests: sanity check support for configuration from environment

Adding a series of tests verifying the ability to accept configuration options from the environment.

### doc: document options from environment

Providing information on how users can provide configuration options using the system environment.