### PR TITLE
cleanup configuration document

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,14 +6,14 @@ on:
     - master
     paths:
       - '.github/workflows/docs.yml'
-      - 'docs/**'
+      - 'doc/**'
       - 'CHANGES.rst'
   pull_request:
     branches:
     - master
     paths:
       - '.github/workflows/docs.yml'
-      - 'docs/**'
+      - 'doc/**'
       - 'CHANGES.rst'
 
 jobs:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -252,6 +252,9 @@ Generic configuration
     - |confluence_footer_file|_ 
     - |confluence_header_data|_
 
+.. |confluence_header_data| replace:: ``confluence_header_data``
+.. _confluence_header_data:
+
 .. confval:: confluence_header_data
 
     .. versionadded:: 1.9
@@ -281,6 +284,9 @@ Generic configuration
     
     - |confluence_header_file|_ 
     - |confluence_footer_data|_
+
+.. |confluence_footer_data| replace:: ``confluence_footer_data``
+.. _confluence_footer_data:
 
 .. confval:: confluence_footer_data
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -248,8 +248,8 @@ Generic configuration
         confluence_header_file = 'assets/header.tpl'
 
     See also:
-    
-    - |confluence_footer_file|_ 
+
+    - |confluence_footer_file|_
     - |confluence_header_data|_
 
 .. |confluence_header_data| replace:: ``confluence_header_data``
@@ -281,8 +281,8 @@ Generic configuration
         confluence_footer_file = 'assets/footer.tpl'
 
     See also:
-    
-    - |confluence_header_file|_ 
+
+    - |confluence_header_file|_
     - |confluence_footer_data|_
 
 .. |confluence_footer_data| replace:: ``confluence_footer_data``
@@ -291,7 +291,7 @@ Generic configuration
 .. confval:: confluence_footer_data
 
     .. versionadded:: 1.9
-    
+
     Takes an optional dictionary. If this value is set then
     ``confluence_footer_file`` is interpreted as a jinja2 template with these
     values passed in. If this value is not set then ``confluence_footer_file``


### PR DESCRIPTION
### doc: add missing substitutions

Recent header/footer configuration documentation entries did not include substitutions for the respective configuration keys; correcting.

### doc: cleanup whitespaces