### PR TITLE
support emoticon macro

### DIFF
--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -3,6 +3,28 @@ Roles
 
 The following outlines additional `roles`_ supported by this extension.
 
+.. index:: Macros; Emoticon Macro (role)
+.. index:: Emoticon Macro
+
+Emoticon Macro
+--------------
+
+The following role can be used to help include Confluence emoticon macro into
+generated Confluence documents.
+
+.. rst:role:: confluence_emoticon
+
+    .. versionadded:: 1.9
+
+    The ``confluence_emoticon`` role allows a user to build inlined emoticon
+    macros. For example:
+
+    .. code-block:: rst
+
+        :confluence_emoticon:`tick`: This is done.
+
+        :confluence_emoticon:`cross`: This is incomplete.
+
 .. index:: Macros; Jira Macro
 .. _jira-roles:
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -22,6 +22,7 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.nodes import jira
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
+from sphinxcontrib.confluencebuilder.roles import ConfluenceEmoticonRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceLatexRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceMentionRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceStatusRole
@@ -281,6 +282,7 @@ def confluence_builder_inited(app):
     app.add_directive('jira_issue', JiraIssueDirective)
 
     # register roles
+    app.add_role('confluence_emoticon', ConfluenceEmoticonRole)
     app.add_role('confluence_latex', ConfluenceLatexRole)
     app.add_role('confluence_mention', ConfluenceMentionRole)
     app.add_role('confluence_status', ConfluenceStatusRole)

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -28,6 +28,15 @@ class ConfluenceParams(nodes.Element):
         self.params = self.attributes.setdefault('confluence-params', {})
 
 
+class confluence_emoticon_inline(nodes.Inline, nodes.TextElement):
+    """
+    confluence emoticon inline node
+
+    A Confluence builder defined emoticon inline node, used to help manage
+    emoticon content designed for an inlined section of a paragraph.
+    """
+
+
 class confluence_expand(nodes.Body, nodes.Element):
     """
     confluence expand node

--- a/sphinxcontrib/confluencebuilder/roles.py
+++ b/sphinxcontrib/confluencebuilder/roles.py
@@ -8,10 +8,36 @@ See also docutils roles:
     https://docutils.sourceforge.io/docs/howto/rst-roles.html#define-the-role-function
 """
 
+from sphinxcontrib.confluencebuilder.nodes import confluence_emoticon_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_mention_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_status_inline
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
+
+
+def ConfluenceEmoticonRole(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """
+    a confluence emoticon role
+
+    Defines an inline Confluence emoticon role where users can inject inlined
+    emoticon macros.
+
+    Args:
+        name: local name of the interpreted text role
+        rawtext: the entire interpreted text construct
+        text: the interpreted text content
+        lineno: the line number where the interpreted text beings
+        inliner: inliner object that called the role function
+        options: dictionary of directive options for customization
+        content: list of strings, the directive content for customization
+
+    Returns:
+        returns a tuple include a list of nodes and a list of system messages
+    """
+
+    node = confluence_emoticon_inline(rawsource=text, text=text)
+
+    return [node], []
 
 
 def ConfluenceLatexRole(name, rawtext, text, lineno, inliner, options=None, content=None):

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1823,6 +1823,16 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         raise nodes.SkipNode
 
+    # ----------------------------------------------
+    # confluence-builder -- enhancements -- emoticon
+    # ----------------------------------------------
+
+    def visit_confluence_emoticon_inline(self, node):
+        self.body.append(self._start_tag(node, 'ac:emoticon', empty=True,
+            **{'ac:name': self.encode(node.rawsource)}))
+
+        raise nodes.SkipNode
+
     # -------------------------------------------
     # confluence-builder -- enhancements -- latex
     # -------------------------------------------

--- a/tests/unit-tests/datasets/emoticon/index.rst
+++ b/tests/unit-tests/datasets/emoticon/index.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+emoticon
+--------
+
+:confluence_emoticon:`tick`

--- a/tests/unit-tests/test_confluence_emoticon.py
+++ b/tests/unit-tests/test_confluence_emoticon.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+from tests.lib import parse
+import os
+
+
+class TestConfluenceEmoticon(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestConfluenceEmoticon, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'emoticon')
+
+    @setup_builder('html')
+    def test_html_confluence_emoticon_role_ignore(self):
+        # build attempt should not throw an exception/error
+        self.build(self.dataset, relax=True)
+
+    @setup_builder('confluence')
+    def test_storage_confluence_emoticon_role_default(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            emoticons = data.find_all('ac:emoticon')
+            self.assertEqual(len(emoticons), 1)
+
+            # ##########################################################
+            # default
+            # ##########################################################
+            macro = emoticons.pop(0)
+
+            self.assertTrue(macro.has_attr('ac:name'))
+            self.assertEqual(macro['ac:name'], 'tick')


### PR DESCRIPTION
Providing initial support for user's to add Confluence emoticons in their documentation.

For example:

```
:confluence_emoticon:`tick`: This is done.

:confluence_emoticon:`cross`: This is incomplete.
```