### PR TITLE
documentation cleanup

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1565,7 +1565,7 @@ Advanced processing configuration
     get_relative_uri_ method. The default translation will be the combination of
     "``docname`` + |confluence_link_suffix|_".
 
-.. index:: Mentions
+.. index:: Mentions; Configuration
 
 .. _confluence_mentions:
 

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -18,7 +18,8 @@ used to restrict these directives to supported builders by using the
 Common
 ------
 
-.. index:: Macros; Expand Macro
+.. index:: Macros; Expand Macro (directive)
+.. index:: Expand Macro
 
 .. rst:directive:: confluence_expand
 
@@ -212,7 +213,7 @@ Common
             .. confluence_toc::
                 :type: flat
 
-.. index:: Macros; Jira Macro
+.. index:: Macros; Jira Macro (directive)
 .. _jira-directives:
 
 Jira
@@ -363,7 +364,8 @@ Confluence documents.
 
 See also :ref:`Jira roles <jira-roles>`.
 
-.. index:: Macros; LaTeX Macro
+.. index:: Macros; LaTeX Macro (directive)
+.. index:: LaTeX Macro; Adding a LaTeX block (directive)
 .. _latex-directives:
 
 LaTeX

--- a/doc/guide-math.rst
+++ b/doc/guide-math.rst
@@ -1,3 +1,5 @@
+.. index:: Math; Math support
+
 Math support
 ============
 
@@ -35,6 +37,8 @@ The former case will generate math content in an inlined fashion, where the
 latter will generate a math block. Math defined in this way is supported on
 Sphinx's standard builders with the help of other Sphinx-provided math
 extensions.
+
+.. index:: Math; Recommended options
 
 Recommended options for math
 ----------------------------
@@ -76,6 +80,8 @@ This configures the generated font size commonly observed on Confluence
 instances, hints that images are generated into SVG images (for ideal image
 scaling) and attempt to process the "depth" of an image to better align content
 alongside text.
+
+.. index:: Math; LaTeX macros
 
 Support for LaTeX macros for math
 ---------------------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -26,9 +26,9 @@ To verify the package has been installed, the following command can be used:
 
     <hr />
 
-For new users, following provides a series of steps to assist in preparing a new
-environment to use this package. For users wishing to use virtualenv, please
-consult the instructions in :doc:`install-virtualenv`.
+For new users, the following provides a series of steps to assist in preparing
+a new environment to use this package. For users wishing to use virtualenv,
+please see the instructions in :doc:`install-virtualenv`.
 
 .. note::
 

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -25,7 +25,7 @@ generated Confluence documents.
 
         :confluence_emoticon:`cross`: This is incomplete.
 
-.. index:: Macros; Jira Macro
+.. index:: Macros; Jira Macro (role)
 .. _jira-roles:
 
 Jira
@@ -49,7 +49,8 @@ Confluence documents.
 
 See also :ref:`Jira directives <jira-directives>`.
 
-.. index:: Macros; LaTeX Macro
+.. index:: Macros; LaTeX Macro (role)
+.. index:: LaTeX Macro; Adding inlined LaTeX (role)
 .. _latex-roles:
 
 LaTeX
@@ -78,7 +79,8 @@ Confluence documents.
 
 See also :ref:`LaTeX directives <latex-directives>`.
 
-.. index:: Macros; Mentions Macro
+.. index:: Macros; Mentions Macro (role)
+.. index:: Mentions; Macro (role)
 .. _mention-roles:
 
 Mentions
@@ -119,7 +121,8 @@ generated Confluence documents.
     A user mapping table can also be configured using the
     ``confluence_mentions`` (:ref:`ref<confluence_mentions>`) option.
 
-.. index:: Macros; Status Macro
+.. index:: Macros; Status Macro (role)
+.. index:: Status Macro
 
 Status Macro
 ------------

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -9,7 +9,7 @@ The following outlines additional `roles`_ supported by this extension.
 Emoticon Macro
 --------------
 
-The following role can be used to help include Confluence emoticon macro into
+The following role can be used to help include Confluence emoticon macros into
 generated Confluence documents.
 
 .. rst:role:: confluence_emoticon

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -70,8 +70,6 @@ content can use the ``confluence_publish_prefix``
 See also the :ref:`dry run capability <confluence_publish_dryrun>` and the
 :ref:`title overrides capability <confluence_title_overrides>`.
 
-.. index:: Math (recommended options)
-
 Setting a publishing timeout
 ----------------------------
 


### PR DESCRIPTION
Maintenance work on the documentation:

- Cleanup some grammar.
- Corrects an invalid math-related index entry and add/improve a series of other index entries for the documentation.