### PR TITLE
report command improvements

### DIFF
--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -104,6 +104,7 @@ def report_main(args_parser):
                     except ConfluenceConfigurationError:
                         offline = True
                 # extract configuration information
+                cm = app.config_manager_
                 for k, v in app.config.values.items():
                     raw = getattr(app.config, k)
                     if raw is None:
@@ -114,11 +115,7 @@ def report_main(args_parser):
                     else:
                         value = raw
 
-                    prefixes = (
-                        'confluence_',
-                        'singleconfluence_',
-                    )
-                    if not args.full_config and not k.startswith(prefixes):
+                    if not args.full_config and k not in cm.options:
                         continue
 
                     # always extract some known builder configurations

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -98,11 +98,15 @@ def report_main(args_parser):
                 # apply environment-based configuration changes
                 apply_env_overrides(app.builder)
 
+                # if the configuration is enabled for publishing, check if
+                # we need to ask for authentication information (to perform
+                # the connection sanity checks)
                 if app.config.confluence_publish:
                     try:
                         process_ask_configs(app.config)
                     except ConfluenceConfigurationError:
                         offline = True
+
                 # extract configuration information
                 cm = app.config_manager_
                 for k, v in app.config.values.items():

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -108,7 +108,7 @@ def report_main(args_parser):
                         offline = True
 
                 # extract configuration information
-                cm = app.config_manager_
+                cm = app.config_manager_  # pylint: disable=no-member
                 for k, v in app.config.values.items():
                     raw = getattr(app.config, k)
                     if raw is None:

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -12,6 +12,7 @@ from sphinx.application import Sphinx
 from sphinx.util.docutils import docutils_namespace
 from sphinxcontrib.confluencebuilder import __version__ as scb_version
 from sphinxcontrib.confluencebuilder.config import process_ask_configs
+from sphinxcontrib.confluencebuilder.config.env import apply_env_overrides
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
@@ -93,6 +94,9 @@ def report_main(args_parser):
                     builder,             # builder to execute
                     status=sys.stdout,   # sphinx status output
                     warning=sys.stderr)  # sphinx warning output
+
+                # apply environment-based configuration changes
+                apply_env_overrides(app.builder)
 
                 if app.config.confluence_publish:
                     try:


### PR DESCRIPTION
### report: process environment configuration options

Adjust the report helper to take into consideration environment-based configuration options.

### report: explicitly check supported configuration options

Since this extension will track explicit configuration options registered by this extension, the report implementation does not need to filter based off a prefix string value. Instead, check if a configuration key exists in the configuration manager before filtering.