### PR TITLE
Provide Sphinx Development Check GitHub manual action

### DIFF
--- a/.github/workflows/sphinx-dev-check.yml
+++ b/.github/workflows/sphinx-dev-check.yml
@@ -1,0 +1,45 @@
+# Provides a manual action allowing developers to trigger a tox run
+# against a specific version of Sphinx directly from Sphinx's official
+# repository. This action can be used by this extension's maintainers
+# as well as sphinx-contrib owners (if needed).
+
+name: Sphinx Development Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      python:
+        description: 'Python interpreter'
+        required: true
+        default: '3.10'
+      sphinx:
+        description: 'Sphinx Revision'
+        required: true
+        default: 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ github.event.inputs.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ github.event.inputs.python }}
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: ubuntu-latest-${{ github.event.inputs.python }}-pip-
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade tox
+
+    - name: tox
+      env:
+        SPHINX_VER: ${{ github.event.inputs.sphinx }}
+      run: tox -e develop

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 
 [testenv:develop]
 deps =
-    git+https://github.com/sphinx-doc/sphinx.git@master
+    git+https://github.com/sphinx-doc/sphinx.git@{env:SPHINX_VER:master}
     -r{toxinidir}/requirements_dev.txt
 pip_pre = true
 


### PR DESCRIPTION
### tox: permit sphinx version overrides for develop environment

When running the `develop` environment in tox, the following change will allow developers to override the target revision of Sphinx desired by providing a new revision using the `SPHINX_VER` variable.

### workflows: add manual sphinx-check job

Providing a new manual job when can enable developers to run a tox run against a specific version of Sphinx. This is to help easily check this extensions capabilities against a specific version of Sphinx without having to locally setup a working environment.