### PR TITLE
support archiving pages

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -523,6 +523,128 @@ Publishing configuration
     - |confluence_remove_title|_
     - |confluence_title_overrides|_
 
+.. index:: Page removal; Automatically archiving pages
+
+.. |confluence_cleanup_archive| replace:: ``confluence_cleanup_archive``
+.. _confluence_cleanup_archive:
+
+.. confval:: confluence_cleanup_archive
+
+    .. warning::
+
+       Publishing individual/subset of documents with this option may lead to
+       unexpected results.
+
+    .. note::
+
+        This option cannot be used with |confluence_cleanup_purge|_.
+
+    .. warning::
+
+        Only Confluence Cloud identifies support for an archiving API.
+        Attempting to Confluence server with this feature will most
+        likely result in an "Unsupported Confluence API call" error (500).
+
+    .. attention::
+
+        Confluence's archiving API is marked as experimental at the time
+        of writing. This feature may experience issues over time until the
+        API is flagged as stable (if ever).
+
+    A boolean value to whether to archive legacy pages detected in a space or
+    parent page. By default, this value is set to ``False`` to indicate that no
+    pages will be archived. If this configuration is set to ``True``, detected
+    pages in Confluence that do not match the set of published documents will be
+    automatically archived. If the option |confluence_parent_page|_ is set, only
+    pages which are a descendant of the configured parent page can be removed;
+    otherwise, all flagged pages in the configured space could be archived.
+
+    .. code-block:: python
+
+        confluence_cleanup_archive = False
+
+    While this capability is useful for updating a series of pages, it may lead
+    to unexpected results when attempting to publish a single-page update. The
+    archive operation will archive all pages that are not publish in the
+    request. For example, if an original request publishes ten documents and
+    archives excess documents, a following publish attempt with only one of
+    the documents will archive the other nine pages.
+
+    See also:
+
+    - |confluence_cleanup_from_root|_
+    - |confluence_cleanup_purge|_
+    - |confluence_publish_dryrun|_
+
+.. |confluence_cleanup_from_root| replace:: ``confluence_cleanup_from_root``
+.. _confluence_cleanup_from_root:
+
+.. confval:: confluence_cleanup_from_root
+
+    .. versionadded:: 1.9
+
+    A boolean value to which indicates that any cleanup attempt should be done
+    from the root of a published root_doc_ page (instead of a configured parent
+    page; i.e. |confluence_parent_page|_). In specific publishing scenarios, a
+    user may wish to publish multiple documentation sets based off a single
+    parent/container page. To prevent any cleanup between multiple documentation
+    sets, this option can be set to ``True``. When generating legacy pages to be
+    removed, this extension will only attempt to populate legacy pages based off
+    the children of the root_doc_ page. This option requires either
+    |confluence_cleanup_archive|_ or |confluence_cleanup_purge|_ to be set
+    to ``True`` before taking effect. If |confluence_publish_root|_ is
+    set, this option is implicitly enabled.
+
+    .. code-block:: python
+
+        confluence_cleanup_from_root = False
+
+    See also:
+
+    - |confluence_cleanup_archive|_
+    - |confluence_cleanup_purge|_
+
+.. index:: Page removal; Automatically purging pages
+
+.. |confluence_cleanup_purge| replace:: ``confluence_cleanup_purge``
+.. _confluence_cleanup_purge:
+
+.. confval:: confluence_cleanup_purge
+
+    .. warning::
+
+       Publishing individual/subset of documents with this option may lead to
+       unexpected results.
+
+    .. note::
+
+        This option cannot be used with |confluence_cleanup_archive|_.
+
+    A boolean value to whether or not purge legacy pages detected in a space or
+    parent page. By default, this value is set to ``False`` to indicate that no
+    pages will be removed. If this configuration is set to ``True``, detected
+    pages in Confluence that do not match the set of published documents will be
+    automatically removed. If the option |confluence_parent_page|_ is set, only
+    pages which are a descendant of the configured parent page can be removed;
+    otherwise, all flagged pages in the configured space could be removed.
+
+    .. code-block:: python
+
+        confluence_cleanup_purge = False
+
+    While this capability is useful for updating a series of pages, it may lead
+    to unexpected results when attempting to publish a single-page update. The
+    purge operation will remove all pages that are not publish in the request.
+    For example, if an original request publishes ten documents and purges
+    excess documents, a following publish attempt with only one of the documents
+    will purge the other nine pages.
+
+    See also:
+
+    - |confluence_cleanup_archive|_
+    - |confluence_cleanup_from_root|_
+    - |confluence_publish_dryrun|_
+
 .. |confluence_disable_notifications| replace:: ``confluence_disable_notifications``
 .. _confluence_disable_notifications:
 
@@ -690,66 +812,6 @@ Publishing configuration
        confluence_publish_root = 123456
 
     See also |confluence_parent_page|_.
-
-.. index:: Page removal; Automatically purging pages
-
-.. |confluence_purge| replace:: ``confluence_purge``
-.. _confluence_purge:
-
-.. confval:: confluence_purge
-
-    .. warning::
-
-       Publishing individual/subset of documents with this option may lead to
-       unexpected results.
-
-    A boolean value to whether or not purge legacy pages detected in a space or
-    parent page. By default, this value is set to ``False`` to indicate that no
-    pages will be removed. If this configuration is set to ``True``, detected
-    pages in Confluence that do not match the set of published documents will be
-    automatically removed. If the option |confluence_parent_page|_ is set, only
-    pages which are a descendant of the configured parent page can be removed;
-    otherwise, all flagged pages in the configured space could be removed.
-
-    .. code-block:: python
-
-        confluence_purge = False
-
-    While this capability is useful for updating a series of pages, it may lead
-    to unexpected results when attempting to publish a single-page update. The
-    purge operation will remove all pages that are not publish in the request.
-    For example, if an original request publishes ten documents and purges
-    excess documents, a following publish attempt with only one of the documents
-    will purge the other nine pages.
-
-    See also:
-
-    - |confluence_publish_dryrun|_
-    - |confluence_purge_from_root|_
-
-.. |confluence_purge_from_root| replace:: ``confluence_purge_from_root``
-.. _confluence_purge_from_root:
-
-.. confval:: confluence_purge_from_root
-
-    .. versionadded:: 1.6
-
-    A boolean value to which indicates that any purging attempt should be done
-    from the root of a published root_doc_ page (instead of a configured parent
-    page; i.e. |confluence_parent_page|_). In specific publishing scenarios, a
-    user may wish to publish multiple documentation sets based off a single
-    parent/container page. To prevent any purging between multiple documentation
-    sets, this option can be set to ``True``. When generating legacy pages to be
-    removed, this extension will only attempt to populate legacy pages based off
-    the children of the root_doc_ page. This option requires |confluence_purge|_
-    to be set to ``True`` before taking effect. If |confluence_publish_root|_ is
-    set, this option is implicitly enabled.
-
-    .. code-block:: python
-
-        confluence_purge_from_root = False
-
-    See also |confluence_purge|_.
 
 .. confval:: confluence_sourcelink
 
@@ -1128,7 +1190,8 @@ Advanced publishing configuration
 
     .. note::
 
-        Using this option will disable the |confluence_purge|_ option.
+        Using this option will disable the |confluence_cleanup_archive|_
+        and |confluence_cleanup_purge|_ options.
 
     Defines a list of documents to be published to a Confluence instance. When a
     user invokes sphinx-build_, a user has the ability to process all documents
@@ -1209,7 +1272,8 @@ Advanced publishing configuration
 
     .. note::
 
-        Using this option will disable the |confluence_purge|_ option.
+        Using this option will disable the |confluence_cleanup_archive|_
+        and |confluence_cleanup_purge|_ options.
 
     Defines a list of documents to not be published to a Confluence instance.
     When a user invokes sphinx-build_, a user has the ability to process all
@@ -1695,7 +1759,14 @@ Deprecated options
 
     .. versionchanged:: 1.6
 
-    This option has been renamed to |confluence_purge_from_root|_.
+    This option has been renamed to ``confluence_purge_from_root``, and has
+    since been replaced with |confluence_cleanup_from_root|_.
+
+.. confval:: confluence_purge_from_root
+
+    .. versionchanged:: 1.9
+
+    This option has been renamed to |confluence_cleanup_from_root|_.
 
 .. confval:: confluence_space_name
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -113,6 +113,12 @@ def setup(app):
     cm.add_conf_bool('confluence_ask_password')
     # Request for publish username to come from interactive session.
     cm.add_conf_bool('confluence_ask_user')
+    # Enablement of archiving legacy child pages.
+    cm.add_conf_bool('confluence_cleanup_archive')
+    # Enablement of cleaning legacy child pages from a root page.
+    cm.add_conf_bool('confluence_cleanup_from_root')
+    # Enablement of purging legacy child pages.
+    cm.add_conf_bool('confluence_cleanup_purge')
     # Explicitly prevent auto-generation of titles for titleless documents.
     cm.add_conf_bool('confluence_disable_autogen_title')
     # Explicitly prevent page notifications on update.
@@ -133,10 +139,6 @@ def setup(app):
     cm.add_conf('confluence_publish_prefix', 'env')
     # Root page's identifier to publish documents into.
     cm.add_conf_int('confluence_publish_root')
-    # Enablement of purging legacy child pages from a parent page.
-    cm.add_conf_bool('confluence_purge')
-    # Enablement of purging legacy child pages from a root page.
-    cm.add_conf_bool('confluence_purge_from_root')
     # docname-2-title dictionary for title overrides.
     cm.add_conf('confluence_title_overrides', 'env')
     # Timeout for network-related calls (publishing).
@@ -213,8 +215,10 @@ def setup(app):
     cm.add_conf_bool('confluence_remove_title', 'env')
 
     # (configuration - undocumented)
-    # Enablement for aggressive descendents search (for purge).
+    # Enablement for aggressive descendents search (for cleanup).
     cm.add_conf_bool('confluence_adv_aggressive_search')
+    # Enablement for bulk archiving of packages (for premium environments).
+    cm.add_conf_bool('confluence_adv_bulk_archiving')
     # List of node types to ignore if no translator support exists.
     cm.add_conf('confluence_adv_ignore_nodes')
     # Unknown node handler dictionary for advanced integrations.
@@ -235,6 +239,8 @@ def setup(app):
     cm.add_conf('confluence_publish_subset')
     # replaced by confluence_purge_from_root
     cm.add_conf_bool('confluence_purge_from_master')
+    # replaced by confluence_cleanup_from_root
+    cm.add_conf_bool('confluence_purge_from_root')
     # replaced by confluence_space_key
     cm.add_conf('confluence_space_name')
 

--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -310,7 +310,7 @@ class ConfluenceAssetManager:
                 asset = self.hash2asset[hash_]
                 self.path2asset[path] = asset
         else:
-            assert(self.hash2asset[asset.hash] == asset)
+            assert (self.hash2asset[asset.hash] == asset)
 
         # track (if not already) that this document uses this asset
         asset.docnames.add(docname)

--- a/sphinxcontrib/confluencebuilder/config/__init__.py
+++ b/sphinxcontrib/confluencebuilder/config/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/config/__init__.py
+++ b/sphinxcontrib/confluencebuilder/config/__init__.py
@@ -22,15 +22,16 @@ def handle_config_inited(app, config):
         config: the configuration
     """
 
-    def handle_legacy(new, orig):
+    def legacy(new, orig):
         if getattr(config, new) is None and getattr(config, orig) is not None:
             config[new] = config[orig]
 
     # copy over deprecated configuration names to new names (if any)
-    handle_legacy('confluence_publish_allowlist', 'confluence_publish_subset')
-    handle_legacy('confluence_purge_from_root', 'confluence_purge_from_master')
-    handle_legacy('confluence_root_homepage', 'confluence_master_homepage')
-    handle_legacy('confluence_space_key', 'confluence_space_name')
+    legacy('confluence_publish_allowlist', 'confluence_publish_subset')
+    legacy('confluence_cleanup_from_root', 'confluence_purge_from_master')
+    legacy('confluence_cleanup_from_root', 'confluence_purge_from_root')
+    legacy('confluence_root_homepage', 'confluence_master_homepage')
+    legacy('confluence_space_key', 'confluence_space_name')
 
 
 def process_ask_configs(config):

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -56,6 +56,12 @@ def validate_configuration(builder):
 
     # ##################################################################
 
+    # confluence_adv_bulk_archiving
+    validator.conf('confluence_adv_bulk_archiving') \
+             .bool()
+
+    # ##################################################################
+
     # confluence_adv_permit_raw_html
     validator.conf('confluence_adv_permit_raw_html') \
              .bool()
@@ -106,6 +112,24 @@ def validate_configuration(builder):
 
     validator.conf('confluence_ca_cert') \
              .path()
+
+    # ##################################################################
+
+    # confluence_cleanup_archive
+    validator.conf('confluence_cleanup_archive') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_cleanup_from_root
+    validator.conf('confluence_cleanup_from_root') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_cleanup_purge
+    validator.conf('confluence_cleanup_purge') \
+             .bool()
 
     # ##################################################################
 
@@ -524,18 +548,6 @@ names are relative to the documentation's source directory.
 
     # ##################################################################
 
-    # confluence_purge
-    validator.conf('confluence_purge') \
-             .bool()
-
-    # ##################################################################
-
-    # confluence_purge_from_root
-    validator.conf('confluence_purge_from_root') \
-             .bool()
-
-    # ##################################################################
-
     # confluence_remove_title
     validator.conf('confluence_remove_title') \
              .bool()
@@ -761,6 +773,16 @@ conflicting publish point configurations
 When configuring for a publishing container, a user can configure for either
 'confluence_parent_page' or 'confluence_publish_root'; however, both cannot be
 configured at the same time.
+''')
+
+        if config.confluence_cleanup_purge:
+            if config.confluence_cleanup_archive:
+                raise ConfluenceConfigurationError('''\
+conflicting cleanup configurations
+
+When configuring for cleanup of legacy pages, a user can configure for either
+'confluence_cleanup_archive' or 'confluence_publish_root'; however, both
+cannot be configured at the same time.
 ''')
 
     # ##################################################################

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -20,7 +20,9 @@ DEPRECATED_CONFIGS = {
     'confluence_publish_subset':
         'use "confluence_publish_allowlist" instead',
     'confluence_purge_from_master':
-        'use "confluence_purge_from_root" instead',
+        'use "confluence_cleanup_from_root" instead',
+    'confluence_purge_from_root':
+        'use "confluence_cleanup_from_root" instead',
     'confluence_space_name':
         'use "confluence_space_key" instead',
 }

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -230,7 +230,7 @@ class Rest(object):
 
     @rate_limited_retries()
     @requests_exception_wrappers()
-    def get(self, key, params):
+    def get(self, key, params=None):
         rest_url = self.url + self.bind_path + '/' + key
 
         rsp = self.session.get(rest_url, params=params, timeout=self.timeout)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2018-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2018-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -87,7 +87,8 @@ class TestConfluenceValidation(unittest.TestCase):
             cls.config['confluence_root_homepage'] = False
         cls.config['confluence_publish_prefix'] = ''
         cls.config['confluence_publish_postfix'] = ''
-        cls.config['confluence_purge'] = False
+        cls.config['confluence_cleanup_archive'] = False
+        cls.config['confluence_cleanup_purge'] = False
         cls.config['confluence_sourcelink']['version'] = cls.test_version
         cls.config['rst_epilog'] = """
 .. |test_key| replace:: {}
@@ -118,8 +119,8 @@ class TestConfluenceValidation(unittest.TestCase):
 
         # finalize configuration for tests
         cls.config['confluence_parent_page'] = cls.test_key
-        cls.config['confluence_purge'] = True
-        cls.config['confluence_purge_from_root'] = True
+        cls.config['confluence_cleanup_purge'] = True
+        cls.config['confluence_cleanup_from_root'] = True
         cls.config['confluence_root_homepage'] = False
 
     def test_extended_autodocs(self):


### PR DESCRIPTION
The following attempts to support Confluence Cloud's experiment API of archiving pages. With these changes, users could flag legacy pages to be archived, instead of removed (purged). The new configuration option would be as follows:

```
confluence_cleanup_archive = True
```

This pull request also renames the configuration options as follows (but still supports legacy options for now):

- `confluence_purge` -> `confluence_cleanup_purge`
- `confluence_purge_from_root` -> `confluence_cleanup_from_root`
