### PR TITLE
rest: default disable embedded certificates from requests

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -219,6 +219,8 @@ def setup(app):
     cm.add_conf_bool('confluence_adv_aggressive_search')
     # Enablement for bulk archiving of packages (for premium environments).
     cm.add_conf_bool('confluence_adv_bulk_archiving')
+    # Flag to permit the use of embedded certificates from requests.
+    cm.add_conf_bool('confluence_adv_embedded_certs')
     # List of node types to ignore if no translator support exists.
     cm.add_conf('confluence_adv_ignore_nodes')
     # Unknown node handler dictionary for advanced integrations.

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -65,6 +65,14 @@ class SslAdapter(HTTPAdapter):
         kwargs['ssl_context'] = context
         return super(SslAdapter, self).init_poolmanager(*args, **kwargs)
 
+    def cert_verify(self, conn, url, verify, *args, **kwargs):
+        super(SslAdapter, self).cert_verify(conn, url, verify, *args, **kwargs)
+
+        # prevent requests from injected an embedded certificates to instead
+        # rely on the default certificate stores loaded by the context
+        if verify is True and not self._config.confluence_adv_embedded_certs:
+            conn.ca_certs = None
+
 
 def rate_limited_retries():
     """


### PR DESCRIPTION
Embedded root certificates provided by requests can cause users more issues when interacting with https-based sites. It should be more common for users environments to have the needed trusted CAs configured in their respective environments. Therefore, we will rely on the SSL module to properly load these stores. Users can still utilize the `confluence_ca_cert` option for explicitly trusting certificates.

In the rare case where users may need to rely on requests-provided certificates, the `confluence_adv_embedded_certs` fallback option can be used to prevent disabling requests certificates (ideally, this should never need to be used).
