### PR TITLE
switch to main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ name: Build
 on:
   push:
     branches:
-    - master
+    - main
     paths:
       - '.github/workflows/build.yml'
       - 'sphinxcontrib/**'
@@ -17,7 +17,7 @@ on:
       - 'tox.ini'
   pull_request:
     branches:
-    - master
+    - main
     paths:
       - '.github/workflows/build.yml'
       - 'sphinxcontrib/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,14 +5,14 @@ name: Documentation
 on:
   push:
     branches:
-    - master
+    - main
     paths:
       - '.github/workflows/docs.yml'
       - 'doc/**'
       - 'CHANGES.rst'
   pull_request:
     branches:
-    - master
+    - main
     paths:
       - '.github/workflows/docs.yml'
       - 'doc/**'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,7 @@ on:
         default: 'test state'
       test_version:
         description: 'Test Version'
-        default: 'master'
+        default: 'main'
 
 jobs:
   build:

--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -126,4 +126,4 @@ reference, ensure the following post-release tasks are performed:
       config_version = '<tag>'
 
 .. _Atlassian Support End of Life Policy: https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html
-.. _CONTRIBUTING.rst: https://github.com/sphinx-contrib/confluencebuilder/blob/master/CONTRIBUTING.rst
+.. _CONTRIBUTING.rst: https://github.com/sphinx-contrib/confluencebuilder/blob/main/CONTRIBUTING.rst

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Atlassian Confluence Builder for Sphinx
    :target: https://pypi.python.org/pypi/sphinxcontrib-confluencebuilder
    :alt: pip Version
 
-.. image:: https://github.com/sphinx-contrib/confluencebuilder/workflows/build/badge.svg?branch=master
+.. image:: https://github.com/sphinx-contrib/confluencebuilder/workflows/build/badge.svg?branch=main
     :target: https://github.com/sphinx-contrib/confluencebuilder/actions?query=workflow%3Abuild
     :alt: Build Status
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -896,7 +896,7 @@ Publishing configuration
             'owner': 'sphinx-contrib',
             'repo': 'confluencebuilder',
             'container': 'doc/',
-            'version': 'master',
+            'version': 'main',
             'view': 'edit',
         }
 


### PR DESCRIPTION
- .github: switch workflows to use main branch
- doc: update confluencebuilder branch sourcelink example
- MAINTAINERS.rst: updating contributing link
- README.rst: updating build badge to new branch