### PR TITLE
correct package management changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,6 @@ classifiers = [
     'Topic :: Documentation',
     'Topic :: Utilities',
 ]
-dependencies = [
-    'docutils<0.18;python_version<"3.0"', # legacy docutils for older sphinx
-    'jinja2<=3.0.3;python_version<"3.0"', # legacy jinja2 for older sphinx
-    'requests>=2.14.0',
-    'sphinx>=1.8',
-]
 dynamic = [
     'entry-points',
     'version',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'sphinxcontrib-confluencebuilder'
-description = '''\
-Sphinx extension to output Atlassian Confluence Storage \
-Markup documents and publish to Confluence instances.\
-'''
+description = 'Sphinx extension to build Atlassian Confluence Storage Markup'
 authors = [
     {name = 'Anthony Shaw', email = 'anthonyshaw@apache.org'},
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,11 @@ group = root
 [options]
 packages = find:
 test_suite = tests
+install_requires =
+    docutils<0.18;python_version<"3.0" # legacy docutils for older sphinx
+    jinja2<=3.0.3;python_version<"3.0" # legacy jinja2 for older sphinx
+    requests>=2.14.0
+    sphinx>=1.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
### move dependencies into setup.cfg

Moving dependencies for the project (originally hosted in `setup.py`) from `pyproject.toml` into `setup.cfg`. This is to ensure legacy interpreters can properly install dependencies in their environment when `pyproject.toml` processing is not supported.

### pyproject.toml: correct package description

Splitting the single line description over multiple lines is not actually used in a built package (the METAFILE will have a '\' description). To support a description to be packaged that does not span the column length too long in the file, we will just minimize the description value.
