### PR TITLE
use docutils node's findall call when available

### DIFF
--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -8,6 +8,7 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx.util.osutil import canon_path
 from sphinx.util.images import guess_mimetype
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.std.confluence import INVALID_CHARS
 from sphinxcontrib.confluencebuilder.std.confluence import SUPPORTED_IMAGE_TYPES
@@ -194,11 +195,11 @@ class ConfluenceAssetManager:
             docname: the document's name
             standalone (optional): ignore hash mappings (defaults to False)
         """
-        image_nodes = doctree.traverse(nodes.image)
+        image_nodes = findall(doctree, nodes.image)
         for node in image_nodes:
             self.process_image_node(node, docname, standalone)
 
-        file_nodes = doctree.traverse(addnodes.download_reference)
+        file_nodes = findall(doctree, addnodes.download_reference)
         for node in file_nodes:
             self.process_file_node(node, docname, standalone)
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -21,6 +21,7 @@ from sphinx.util import status_iterator
 from sphinx.util.osutil import ensuredir
 from sphinxcontrib.confluencebuilder.assets import ConfluenceAssetManager
 from sphinxcontrib.confluencebuilder.assets import ConfluenceSupportedImages
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.config import process_ask_configs
 from sphinxcontrib.confluencebuilder.config.checks import validate_configuration
 from sphinxcontrib.confluencebuilder.config.defaults import apply_defaults
@@ -303,7 +304,7 @@ class ConfluenceBuilder(Builder):
 
             # track the toctree depth for a document, which a translator can
             # use as a hint when dealing with max-depth capabilities
-            toctree = first(doctree.traverse(addnodes.toctree))
+            toctree = first(findall(doctree, addnodes.toctree))
             if toctree and toctree.get('maxdepth') > 0:
                 self.state.register_toctree_depth(
                     docname, toctree.get('maxdepth'))
@@ -408,7 +409,7 @@ class ConfluenceBuilder(Builder):
 
         modified = False
         doctree = self.env.get_doctree(docname)
-        for toctreenode in doctree.traverse(addnodes.toctree):
+        for toctreenode in findall(doctree, addnodes.toctree):
             if not omit and max_depth is not None:
                 if (toctreenode['maxdepth'] == -1 or
                         depth + toctreenode['maxdepth'] > max_depth):
@@ -467,7 +468,7 @@ class ConfluenceBuilder(Builder):
                     ids.extend(parent['ids'])
 
                 if ids:
-                    for node in doctree.traverse(nodes.reference):
+                    for node in findall(doctree, nodes.reference):
                         if 'refid' in node and node['refid']:
                             top_ref = node['refid'] in ids
 
@@ -811,7 +812,7 @@ class ConfluenceBuilder(Builder):
         """
         metadata = self.metadata.setdefault(docname, {})
 
-        for node in doctree.traverse(confluence_metadata):
+        for node in findall(doctree, confluence_metadata):
             labels = metadata.setdefault('labels', [])
             labels.extend(node.params['labels'])
             node.parent.remove(node)
@@ -1120,7 +1121,7 @@ class ConfluenceBuilder(Builder):
         doc_used_names = {}
         secnumbers = self.env.toc_secnumbers.get(docname, {})
 
-        for node in doctree.traverse(nodes.title):
+        for node in findall(doctree, nodes.title):
             if isinstance(node.parent, nodes.section):
                 section_node = node.parent
                 if 'ids' in section_node:

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -8,6 +8,7 @@
 from docutils import nodes
 from sphinx.util.console import darkgreen  # pylint: disable=no-name-in-module
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.compat import inline_all_toctrees
 from sphinxcontrib.confluencebuilder.compat import progress_message
 from sphinxcontrib.confluencebuilder.locale import C
@@ -130,7 +131,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         """
         root_docuri = self.config.root_doc + self.file_suffix
 
-        for refnode in doctree.traverse(nodes.reference):
+        for refnode in findall(doctree, nodes.reference):
             if 'refuri' not in refnode:
                 continue
 
@@ -208,7 +209,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         if title_node:
             root_section = title_node.parent
 
-        for node in doctree.traverse(nodes.title):
+        for node in findall(doctree, nodes.title):
             if isinstance(node.parent, nodes.section):
                 section_node = node.parent
                 if 'ids' in section_node:

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -11,6 +11,7 @@ from os import path
 from sphinx import addnodes
 from sphinx.locale import _ as SL
 from sphinx.locale import admonitionlabels
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceError
 from sphinxcontrib.confluencebuilder.locale import L
 from sphinxcontrib.confluencebuilder.std.confluence import FALLBACK_HIGHLIGHT_STYLE
@@ -636,7 +637,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     # -----------------------------
 
     def visit_block_quote(self, node):
-        if node.traverse(nodes.attribution):
+        if first(findall(node, nodes.attribution)):
             self.body.append(self._start_tag(node, 'blockquote'))
             self.context.append(self._end_tag(node))
         else:
@@ -677,7 +678,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             # for now.
             firstchild_margin = True
 
-            next_child = first(node.traverse(include_self=False))
+            next_child = first(findall(node, include_self=False))
             if isinstance(next_child, nodes.block_quote):
                 firstchild_margin = False
 
@@ -739,7 +740,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self._visit_admonition(node, 'warning')
 
     def visit_admonition(self, node):
-        title_node = first(node.traverse(nodes.title))
+        title_node = first(findall(node, nodes.title))
         if title_node:
             title = title_node.astext()
             self._visit_admonition(node, 'info', title, logo=False)
@@ -773,7 +774,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     # ------
 
     def visit_table(self, node):
-        title_node = first(node.traverse(nodes.title))
+        title_node = first(findall(node, nodes.title))
         if title_node:
             self.body.append(self._start_tag(node, 'p'))
             self.body.append(self._start_tag(node, 'strong'))
@@ -824,7 +825,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         if apply_colwidths:
             has_colspec = False
-            for colspec in node.traverse(nodes.colspec):
+            for colspec in findall(node, nodes.colspec):
                 if not has_colspec:
                     self.body.append(self._start_tag(node, 'colgroup'))
                     has_colspec = True
@@ -1154,7 +1155,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self.context.pop())  # tr
 
         # if next entry is not another footnote or citation, close off the table
-        next_sibling = first(node.traverse(
+        next_sibling = first(findall(node,
             include_self=False, descend=False, siblings=True))
         if not isinstance(next_sibling, (nodes.citation, nodes.footnote)):
             self.body.append(self.context.pop())  # tbody
@@ -1270,7 +1271,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     def visit_caption(self, node):
         # if a caption for a literal block, pass the caption data to it can be
         # rendered in the macro's title field
-        next_sibling = first(node.traverse(
+        next_sibling = first(findall(node,
             include_self=False, descend=False, siblings=True))
         if isinstance(next_sibling, nodes.literal_block):
             # anything that is not a parsed literals
@@ -2048,7 +2049,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self.context.pop())  # div
 
     def depart_line(self, node):
-        next_sibling = first(node.traverse(
+        next_sibling = first(findall(node,
             include_self=False, descend=False, siblings=True))
         if isinstance(next_sibling, nodes.line):
             self.body.append('<br />')

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -7,6 +7,7 @@
 from docutils import nodes
 from os import path
 from sphinx.util.math import wrap_displaymath
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_block
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
@@ -102,7 +103,7 @@ def prepare_svgs(builder, doctree):
 
     svg_initialize()
 
-    for node in doctree.traverse(nodes.image):
+    for node in findall(doctree, nodes.image):
         confluence_supported_svg(builder, node)
 
 
@@ -140,7 +141,7 @@ def replace_graphviz_nodes(builder, doctree):
             self.builder = builder
     mock_translator = MockTranslator(builder)
 
-    for node in doctree.traverse(graphviz):
+    for node in findall(doctree, graphviz):
         try:
             _, out_filename = render_dot(mock_translator, node['code'],
                 node['options'], builder.graphviz_output_format, 'graphviz')
@@ -194,7 +195,7 @@ def replace_inheritance_diagram(builder, doctree):
             self.builder = builder
     mock_translator = MockTranslator(builder)
 
-    for node in doctree.traverse(inheritance_diagram.inheritance_diagram):
+    for node in findall(doctree, inheritance_diagram.inheritance_diagram):
         graph = node['graph']
 
         graph_hash = inheritance_diagram.get_graph_hash(node)
@@ -238,8 +239,8 @@ def replace_math_blocks(builder, doctree):
         return
 
     # phase 1 -- convert math blocks into Confluence LaTeX blocks
-    for node in itertools.chain(doctree.traverse(nodes.math),
-            doctree.traverse(nodes.math_block)):
+    for node in itertools.chain(findall(doctree, nodes.math),
+            findall(doctree, nodes.math_block)):
         if not isinstance(node, nodes.math):
             if node['nowrap']:
                 latex = node.astext()
@@ -275,8 +276,8 @@ def replace_math_blocks(builder, doctree):
             self.builder = builder
     mock_translator = MockTranslator(builder)
 
-    for node in itertools.chain(doctree.traverse(confluence_latex_inline),
-            doctree.traverse(confluence_latex_block)):
+    for node in itertools.chain(findall(doctree, confluence_latex_inline),
+            findall(doctree, confluence_latex_block)):
         try:
             mf, depth = imgmath.render_math(mock_translator, node.astext())
             if not mf:

--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_diagrams.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_diagrams.py
@@ -5,6 +5,7 @@
 """
 
 from docutils import nodes
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 
 # ##############################################################################
@@ -52,7 +53,7 @@ def replace_sphinx_diagrams_nodes(builder, doctree):
             self.builder = builder
     mock_translator = MockTranslator(builder)
 
-    for node in doctree.traverse(sphinx_diagrams_diagrams):
+    for node in findall(doctree, sphinx_diagrams_diagrams):
         try:
             fname, _ = sphinx_diagrams_render(mock_translator,
                 node['code'], node['options'], 'diagrams')

--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_gallery.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_gallery.py
@@ -5,6 +5,7 @@
 """
 
 from docutils import nodes
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 
 # ##############################################################################
 # disable import/except warnings for third-party modules
@@ -42,7 +43,7 @@ def replace_sphinx_gallery_nodes(builder, doctree):
     if not sphinx_gallery:
         return
 
-    for node in doctree.traverse(sphinx_gallery_imgsgnode):
+    for node in findall(doctree, sphinx_gallery_imgsgnode):
         new_node = nodes.image(candidates={'?'}, **node.attributes)
         if 'align' in node:
             new_node['align'] = node['align']

--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
@@ -7,6 +7,7 @@
 from docutils import nodes
 from os import path
 from sphinx import addnodes
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.nodes import confluence_expand
 from sphinxcontrib.confluencebuilder.util import first
 
@@ -68,7 +69,7 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
         return
 
     if sphinx_toolbox_assets:
-        for node in doctree.traverse(sphinx_toolbox_AssetNode):
+        for node in findall(doctree, sphinx_toolbox_AssetNode):
             # mock a docname based off the configured sphinx_toolbox's asset
             # directory; which the processing of a download_reference will
             # strip and use the asset directory has the container folder to find
@@ -84,7 +85,7 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
             node.replace_self(new_node)
 
     if sphinx_toolbox_collapse:
-        for node in doctree.traverse(sphinx_toolbox_CollapseNode):
+        for node in findall(doctree, sphinx_toolbox_CollapseNode):
             new_node = confluence_expand(node.rawsource, title=node.label,
                 *node.children, **node.attributes)
             node.replace_self(new_node)
@@ -94,8 +95,8 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
         #  cause an exception while docutils is processing a doctree
         while True:
             node = first(itertools.chain(
-                doctree.traverse(sphinx_toolbox_IssueNode),
-                doctree.traverse(sphinx_toolbox_IssueNodeWithName)))
+                findall(doctree, sphinx_toolbox_IssueNode),
+                findall(doctree, sphinx_toolbox_IssueNodeWithName)))
             if not node:
                 break
 
@@ -108,6 +109,6 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
             node.replace_self(new_node)
 
     if sphinx_toolbox_github_repos_and_users:
-        for node in doctree.traverse(sphinx_toolbox_GitHubObjectLinkNode):
+        for node in findall(doctree, sphinx_toolbox_GitHubObjectLinkNode):
             new_node = nodes.reference(node.name, node.name, refuri=node.url)
             node.replace_self(new_node)

--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinxcontrib_mermaid.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinxcontrib_mermaid.py
@@ -5,6 +5,7 @@
 """
 
 from docutils import nodes
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
 
 # ##############################################################################
@@ -52,7 +53,7 @@ def replace_sphinxcontrib_mermaid_nodes(builder, doctree):
             self.builder = builder
     mock_translator = MockTranslator(builder)
 
-    for node in doctree.traverse(mermaid):
+    for node in findall(doctree, mermaid):
         try:
             format_ = builder.config.mermaid_output_format
             if format_ == 'raw':


### PR DESCRIPTION
As of docutils v0.18.1, a node now has a `findall` method (iterator) over a now obsolete `traverse` method (list). This causes users using the more recent docutils to have several deprecated warnings. To help deal with users on newer and older versions, provide a helper call to call `findall` if it is available.