### PR TITLE
maintenance (pre-release cleanup 02)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,9 @@
 Anthony Shaw <anthony.p.shaw@gmail.com>
+Anton <box4android@gmail.com>
 Chugunov Denis <chugunov_official@mail.ru>
 Colin Starner <colin.starner@gmail.com>
 Daniel Gray <dg.dan.b@gmail.com>
+Dave Finke <dave.finke@artisancells.com>
 Felix Sherrington-Kendall <sherrinj@tcd.ie>
 Fernando Gargiulo <fernando.gargiulo@enel.com>
 Freek Dijkstra <software@macfreek.nl>
@@ -19,6 +21,7 @@ Michael Kunzmann <michael.kunzmann@gmx.net>
 Michał Sochoń <kaszpir@gmail.com>
 Paul D.Smith <paul@pauldsmith.org.uk>
 Pawel Limanowka <plimanowka@gmail.com>
+Richard Vodden <richard@humanisingautonomy.com>
 Thomas Malcher <malcher@student.tugraz.at>
 Toni Ruža <toni.ruza@gmail.com>
 Tsvi Mostovicz <ttmost@gmail.com>

--- a/MAINTAINERS.rst
+++ b/MAINTAINERS.rst
@@ -66,7 +66,7 @@ following steps are performed:
 - Ensure version values in the implementation are incremented and tagged
   appropriately. The tagged commit should have a "clean" version string.
 - Ensure the release tag is signed.
-- After invoking ``bdist_wheel``, ensure a universal wheel has been created
+- After invoking a build, ensure a universal wheel has been created
   (i.e. inspect that the generated package inside ``dist/``  properly reflects
   ``py2.py3`` support).
 
@@ -75,8 +75,7 @@ A release can be made with the following commands:
 .. code-block:: shell-session
 
     $ python -m build
-    running sdist
-    running egg_info
+    * Creating virtualenv isolated environment...
     ...
 
     (note: verify packages can be published)

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -19,7 +19,7 @@
 {%trans%}Atlassian® Confluence® Builder for <a href="{{url_sphinx}}">Sphinx</a>
 is a community provided extension to help build
 <a href="{{url_confluence}}">Confluence</a> supported format files (e.g. storage
-format) and optionally publish them to a Confluence instance.{%endtrans%}
+format) and publish them to a Confluence instance.{%endtrans%}
 </p>
 
 <ul>

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -4,12 +4,16 @@ Advanced
 Publishing permissions
 ----------------------
 
-An account used for authentication requires the following permissions_ when
-attempting to publish to a configured space:
+An account used for authentication will have the best experience with the
+following permissions_ when attempting to publish to a configured space:
 
 - Space -- View
 - Page -- Add, Delete
 - Attachments -- Add, Delete
+
+Delete permissions are only required for environments using the
+``confluence_cleanup_purge`` (:ref:`ref<confluence_cleanup_purge>`)
+capabilitity.
 
 For environments using an OAuth connector, the following scopes are required:
 

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -28,4 +28,4 @@ For environments using an OAuth connector, the following scopes are required:
 
 .. references ------------------------------------------------------------------
 
-.. _Permissions: https://confluence.atlassian.com/x/_AozKw
+.. _Permissions: https://support.atlassian.com/confluence-cloud/docs/what-are-confluence-cloud-permissions-and-restrictions/

--- a/doc/install-virtualenv.rst
+++ b/doc/install-virtualenv.rst
@@ -125,4 +125,4 @@ following:
 
 .. _Python: https://www.python.org/
 .. _pip: https://pip.pypa.io/
-.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+.. _virtualenv: https://virtualenv.pypa.io/


### PR DESCRIPTION
- AUTHORS: adding new authors
- doc: remove optional hint in home description
- doc: indicate deletion permissions are for purging only
- doc: cleanup links
- MAINTAINERS.rst: cleanup to better reflect new build command

