### PR TITLE
new project version dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,32 +41,25 @@ jobs:
     strategy:
       matrix:
         include:
-            - { os:  ubuntu-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx18, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx43, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx45, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx51, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx18, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx43, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx45, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx51, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx18, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx43, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx45, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx51, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx18, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx44, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx45, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx50, cache: ~/.cache/pip }
-            - { os:   macos-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~/Library/Caches/pip }
             - { os:   macos-latest, python: "3.10", toxenv: py310-sphinx51, cache: ~/Library/Caches/pip }
-            - { os: windows-latest, python:  "2.7", toxenv:  py27-sphinx18, cache: ~\AppData\Local\pip\Cache }
             - { os: windows-latest, python: "3.10", toxenv: py310-sphinx51, cache: ~\AppData\Local\pip\Cache }
             - { os:  ubuntu-latest, python: "3.10", toxenv:         flake8, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv:         pylint, cache: ~/.cache/pip }

--- a/README.rst
+++ b/README.rst
@@ -26,9 +26,17 @@ optionally publish them to a Confluence instance.
 Requirements
 ============
 
+Active release (v1.9) requirements:
+
 * Python_ 2.7 or 3.7+
 * Requests_ 2.14.0+
 * Sphinx_ 1.8 or 4.1+
+
+Next release requirements:
+
+* Python_ 3.7+
+* Requests_ 2.14.0+
+* Sphinx_ 4.3+
 
 If publishing:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 maintainers = [
     {name = 'James Knight', email = 'james.d.knight@live.com'},
 ]
-requires-python = '>=2.7'
+requires-python = '>=3.7'
 readme = 'README.rst'
 license = {text = 'BSD-2-Clause'}
 classifiers = [
@@ -24,11 +24,8 @@ classifiers = [
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,2 @@
 beautifulsoup4
 requests>=2.14.0
-mock;python_version<"3.3"

--- a/requirements_validation.txt
+++ b/requirements_validation.txt
@@ -1,2 +1,2 @@
-breathe; python_version >= '3.5'
+breathe
 myst_parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,32 +1,24 @@
 [metadata]
 name = sphinxcontrib-confluencebuilder
-version = 1.10.0.dev0
-
-[bdist_wheel]
-# build a universal wheel (Python 2 and 3 supported)
-universal=1
+version = attr: sphinxcontrib.confluencebuilder.__version__
 
 [sdist]
 owner = root
 group = root
 
 [options]
-packages = find:
-namespace_packages = sphinxcontrib
+packages = find_namespace:
 test_suite = tests
 install_requires =
-    docutils<0.18;python_version<"3.0" # legacy docutils for older sphinx
-    jinja2<=3.0.3;python_version<"3.0" # legacy jinja2 for older sphinx
     requests>=2.14.0
-    sphinx>=1.8
+    sphinx>=4.3
 
 [options.entry_points]
 console_scripts =
     sphinx-build-confluence = sphinxcontrib.confluencebuilder.__main__:main
 
 [options.packages.find]
-exclude =
-    tests*
+include = sphinxcontrib*
 
 ########################################################################
 # Translation support (Babel)

--- a/sphinxcontrib/__init__.py
+++ b/sphinxcontrib/__init__.py
@@ -1,3 +1,0 @@
-# -*- coding: utf-8 -*-
-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -330,9 +330,7 @@ def confluence_builder_inited(app):
     #
     # If 'sphinx.ext.imgmath' is not already explicitly loaded, bind it into the
     # setup process to a configurer can use the same configuration options
-    # outlined in the sphinx.ext.imgmath in this extension. This applies for
-    # Sphinx 1.8 and higher which math support is embedded; for older versions,
-    # users will need to explicitly load 'sphinx.ext.mathbase'.
+    # outlined in the sphinx.ext.imgmath in this extension.
     if imgmath is not None:
         if 'sphinx.ext.imgmath' not in app.config.extensions:
             imgmath.setup(app)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -5,9 +5,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 from collections import defaultdict
 from docutils import nodes
 from docutils.io import StringOutput
@@ -46,11 +43,6 @@ from sphinxcontrib.confluencebuilder.util import first
 from sphinxcontrib.confluencebuilder.writer import ConfluenceWriter
 import io
 import os
-
-try:
-    basestring  # pylint: disable=E0601
-except NameError:
-    basestring = str
 
 
 class ConfluenceBuilder(Builder):
@@ -189,10 +181,10 @@ class ConfluenceBuilder(Builder):
                 return None
 
             # if provided via command line, treat as a list
-            if option in config['overrides'] and isinstance(value, basestring):
+            if option in config['overrides'] and isinstance(value, str):
                 value = value.split(',')
 
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 files = extract_strings_from_file(value)
             else:
                 files = value

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -4,7 +4,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from __future__ import print_function
 from collections import OrderedDict
 from requests import __version__ as requests_version
 from sphinx import __version__ as sphinx_version
@@ -19,16 +18,13 @@ from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
 from sphinxcontrib.confluencebuilder.util import temp_dir
+from urllib.parse import urlparse
 from xml.etree import ElementTree
 import os
 import platform
 import sys
 import traceback
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
 
 #: rest point to fetch instance manifest state
 MANIFEST_PATH = 'rest/applinks/1.0/manifest'

--- a/sphinxcontrib/confluencebuilder/cmd/wipe.py
+++ b/sphinxcontrib/confluencebuilder/cmd/wipe.py
@@ -4,11 +4,9 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from __future__ import print_function
 from sphinx.application import Sphinx
 from sphinx.locale import __
 from sphinx.util.docutils import docutils_namespace
-from sphinxcontrib.confluencebuilder.compat import compat_input
 from sphinxcontrib.confluencebuilder.config import process_ask_configs
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
@@ -202,7 +200,7 @@ def ask_question(question, default='no'):
         prompt = ' [y/N] '
 
     while True:
-        rsp = compat_input(question + prompt).strip().lower()
+        rsp = input(question + prompt).strip().lower()
         if default is not None and rsp == '':
             return default == 'yes'
         elif rsp in ('y', 'yes'):

--- a/sphinxcontrib/confluencebuilder/cmd/wipe.py
+++ b/sphinxcontrib/confluencebuilder/cmd/wipe.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/compat.py
+++ b/sphinxcontrib/confluencebuilder/compat.py
@@ -10,28 +10,9 @@ from docutils import nodes
 from sphinx import addnodes
 from sphinx import version_info as sphinx_version_info
 from sphinx.locale import __
-from sphinx.util.console import bold  # pylint: disable=no-name-in-module
 from sphinx.util.nodes import inline_all_toctrees as sphinx_inline_all_toctrees
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from typing import cast
-
-
-# load sphinx's progress_message or use a compatible instance
-try:
-    from sphinx.util import progress_message  # pylint: disable=W0611
-except ImportError:
-    class progress_message:
-        def __init__(self, msg):
-            self.msg = msg
-
-        def __enter__(self):
-            logger.info(bold(self.msg + '... '), nonl=True)
-
-        def __exit__(self, type_, value, traceback):
-            if type_:
-                logger.info(__('failed'))
-            else:
-                logger.info(__('done'))
 
 
 # use docutil's findall call over traverse (obsolete)

--- a/sphinxcontrib/confluencebuilder/compat.py
+++ b/sphinxcontrib/confluencebuilder/compat.py
@@ -5,7 +5,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from __future__ import absolute_import
 from docutils import __version_info__ as docutils_version_info
 from docutils import nodes
 from sphinx import addnodes
@@ -16,11 +15,6 @@ from sphinx.util.nodes import inline_all_toctrees as sphinx_inline_all_toctrees
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from typing import cast
 
-# input support with all supported python interpreters
-try:
-    compat_input = raw_input
-except NameError:
-    compat_input = input  # pylint: disable=W0127
 
 # load sphinx's progress_message or use a compatible instance
 try:

--- a/sphinxcontrib/confluencebuilder/config/__init__.py
+++ b/sphinxcontrib/confluencebuilder/config/__init__.py
@@ -4,7 +4,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from sphinxcontrib.confluencebuilder import compat
 from sphinxcontrib.confluencebuilder import util
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 import sys
@@ -56,8 +55,7 @@ def process_ask_configs(config):
         if default_user:
             u_str = ' [{}]'.format(default_user)
 
-        input_ = compat.compat_input
-        target_user = input_(' User{}: '.format(u_str)) or default_user
+        target_user = input(' User{}: '.format(u_str)) or default_user
         if not target_user:
             raise ConfluenceConfigurationError('no user provided')
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -11,11 +11,6 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationEr
 from requests.auth import AuthBase
 import os
 
-try:
-    basestring  # pylint: disable=E0601
-except NameError:
-    basestring = str
-
 
 def validate_configuration(builder):
     """
@@ -300,7 +295,7 @@ to a proper file path.
             issue = True
         else:
             for name, info in jira_servers.items():
-                if not isinstance(name, basestring):
+                if not isinstance(name, str):
                     issue = True
                     break
 
@@ -311,8 +306,8 @@ to a proper file path.
                 jira_id = info.get('id')
                 jira_name = info.get('name')
 
-                if not (isinstance(jira_id, basestring) and
-                        isinstance(jira_name, basestring)):
+                if not (isinstance(jira_id, str) and
+                        isinstance(jira_name, str)):
                     issue = True
                     break
 
@@ -478,7 +473,7 @@ navigational buttons onto generated pages. Accepted values include 'bottom',
 
         # if provided via command line, treat as a list
         def conf_translate(value):
-            if option in config['overrides'] and isinstance(value, basestring):
+            if option in config['overrides'] and isinstance(value, str):
                 value = value.split(',')
             return value
         value = conf_translate(value)
@@ -487,7 +482,7 @@ navigational buttons onto generated pages. Accepted values include 'bottom',
             validator.conf(option, conf_translate) \
                      .string_or_strings()
 
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 validator.docnames_from_file()
             else:
                 validator.docnames()

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -84,8 +84,3 @@ def apply_defaults(builder):
             conf.confluence_parent_page = int(conf.confluence_parent_page)
         except ValueError:
             pass
-
-    # if running an older version of Sphinx which does not define `root_doc`,
-    # copy it over now from the legacy configuration
-    if 'root_doc' not in conf:
-        conf.root_doc = conf.master_doc

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -9,11 +9,6 @@ from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import str2bool
 import os
 
-try:
-    basestring  # pylint: disable=E0601
-except NameError:
-    basestring = str
-
 
 class ConfigurationValidation:
     def __init__(self, builder):
@@ -60,7 +55,7 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 try:
                     str2bool(value)
                 except ValueError:
@@ -135,8 +130,8 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if not isinstance(value, dict) or not all(isinstance(k, basestring)
-                    and isinstance(v, basestring) for k, v in value.items()):
+            if not isinstance(value, dict) or not all(isinstance(k, str)
+                    and isinstance(v, str) for k, v in value.items()):
                 raise ConfluenceConfigurationError(
                     '%s is not a dictionary of strings' % self.key)
 
@@ -161,7 +156,7 @@ class ConfigurationValidation:
 
         if value is not None:
             if not (isinstance(value, (list, set, tuple)) or not all(
-                    isinstance(label, basestring) for label in value)):
+                    isinstance(label, str) for label in value)):
                 raise ConfluenceConfigurationError(
                     '%s is not a collection of filenames' % self.key)
 
@@ -194,7 +189,7 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if not isinstance(value, basestring) or not os.path.isfile(
+            if not isinstance(value, str) or not os.path.isfile(
                     os.path.join(self.env.srcdir, value)):
                 raise ConfluenceConfigurationError(
                     '%s is not a file' % self.key)
@@ -228,7 +223,7 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if not isinstance(value, basestring) or not os.path.isfile(
+            if not isinstance(value, str) or not os.path.isfile(
                     os.path.join(self.env.srcdir, value)):
                 raise ConfluenceConfigurationError(
                     '%s is not a file' % self.key)
@@ -257,7 +252,7 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 try:
                     value = float(value)
                 except ValueError:
@@ -298,7 +293,7 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 try:
                     value = int(value)
                 except ValueError:
@@ -359,7 +354,7 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if not isinstance(value, basestring) or not os.path.exists(
+            if not isinstance(value, str) or not os.path.exists(
                     os.path.join(self.env.srcdir, value)):
                 raise ConfluenceConfigurationError(
                     '%s is not a file' % self.key)
@@ -384,7 +379,7 @@ class ConfigurationValidation:
 
         value = self._value()
 
-        if value is not None and not isinstance(value, basestring):
+        if value is not None and not isinstance(value, str):
             raise ConfluenceConfigurationError(
                 '%s is not a string' % self.key)
 
@@ -409,10 +404,10 @@ class ConfigurationValidation:
 
         if value is not None:
             if isinstance(value, (list, set, tuple)):
-                if not all(isinstance(entry, basestring) for entry in value):
+                if not all(isinstance(entry, str) for entry in value):
                     raise ConfluenceConfigurationError(
                         '%s is not a collection of strings' % self.key)
-            elif not isinstance(value, basestring):
+            elif not isinstance(value, str):
                 raise ConfluenceConfigurationError(
                     '%s is not a string or collection of strings' % self.key)
 
@@ -441,7 +436,7 @@ class ConfigurationValidation:
 
         if value is not None:
             if not (isinstance(value, (list, set, tuple)) and all(
-                    isinstance(entry, basestring) for entry in value)):
+                    isinstance(entry, str) for entry in value)):
                 raise ConfluenceConfigurationError(
                     '%s is not a collection of strings' % self.key)
 
@@ -472,7 +467,7 @@ class ConfigurationValidation:
         # If an empty string, treat that this value is actually a `None` value.
         # This permits callers from passing "empty"/unset configuration entries
         # via the command line to "clear" a configuration value.
-        if isinstance(value, basestring) and not value:
+        if isinstance(value, str) and not value:
             value = None
 
         return value

--- a/sphinxcontrib/confluencebuilder/intersphinx.py
+++ b/sphinxcontrib/confluencebuilder/intersphinx.py
@@ -5,7 +5,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from __future__ import unicode_literals
 from os import path
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 import re

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -6,11 +6,11 @@
 """
 
 from docutils import nodes
+from sphinx.util import progress_message
 from sphinx.util.console import darkgreen  # pylint: disable=no-name-in-module
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.compat import inline_all_toctrees
-from sphinxcontrib.confluencebuilder.compat import progress_message
 from sphinxcontrib.confluencebuilder.locale import C
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 

--- a/sphinxcontrib/confluencebuilder/std/sphinx.py
+++ b/sphinxcontrib/confluencebuilder/std/sphinx.py
@@ -4,15 +4,9 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from sphinx import version_info as sphinx_version_info
-
-# sphinx's default highlight style\
+# sphinx's default highlight style
 #  http://www.sphinx-doc.org/en/stable/config.html#confval-highlight_language
 DEFAULT_HIGHLIGHT_STYLE = 'default'
 
 # sphinx's default alignment
-#  https://github.com/sphinx-doc/sphinx/issues/4550
-if sphinx_version_info >= (2, 0):
-    DEFAULT_ALIGNMENT = 'center'
-else:
-    DEFAULT_ALIGNMENT = None  # 'left'
+DEFAULT_ALIGNMENT = 'center'

--- a/sphinxcontrib/confluencebuilder/std/sphinx.py
+++ b/sphinxcontrib/confluencebuilder/std/sphinx.py
@@ -4,7 +4,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from __future__ import absolute_import
 from sphinx import version_info as sphinx_version_info
 
 # sphinx's default highlight style\

--- a/sphinxcontrib/confluencebuilder/std/sphinx.py
+++ b/sphinxcontrib/confluencebuilder/std/sphinx.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2018-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2018-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/storage/__init__.py
+++ b/sphinxcontrib/confluencebuilder/storage/__init__.py
@@ -6,11 +6,6 @@
 
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 
-try:
-    unicode  # pylint: disable=E0601
-except NameError:
-    unicode = str
-
 
 def encode_storage_format(data):
     """
@@ -34,7 +29,7 @@ def encode_storage_format(data):
     }
 
     # first pass needs to handle ampersand
-    data = unicode(data).replace('&', '&amp;')
+    data = str(data).replace('&', '&amp;')
 
     for find, encoded in STORAGE_FORMAT_REPLACEMENTS:
         data = data.replace(find, encoded)

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -5,7 +5,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from __future__ import unicode_literals
 from docutils import nodes
 from os import path
 from sphinx import addnodes

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -17,6 +17,7 @@ from sphinxcontrib.confluencebuilder.transmute.ext_sphinx_diagrams import replac
 from sphinxcontrib.confluencebuilder.transmute.ext_sphinx_gallery import replace_sphinx_gallery_nodes
 from sphinxcontrib.confluencebuilder.transmute.ext_sphinx_toolbox import replace_sphinx_toolbox_nodes
 from sphinxcontrib.confluencebuilder.transmute.ext_sphinxcontrib_mermaid import replace_sphinxcontrib_mermaid_nodes
+import itertools
 
 # load graphviz extension if available to handle node pre-processing
 try:
@@ -29,7 +30,6 @@ except ImportError:
 # load imgmath extension if available to handle math node pre-processing
 try:
     from sphinx.ext import imgmath
-    import itertools
 except ImportError:
     imgmath = None
 

--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
@@ -10,11 +10,8 @@ from sphinx import addnodes
 from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.nodes import confluence_expand
 from sphinxcontrib.confluencebuilder.util import first
+import itertools
 
-try:
-    import itertools
-except ImportError:
-    pass
 
 # ##############################################################################
 # disable import/except warnings for third-party modules

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2018-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2018-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -5,7 +5,6 @@
 """
 
 from contextlib import contextmanager
-from sphinxcontrib.confluencebuilder import compat
 from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_SIZE
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_X_HEIGHT
@@ -282,8 +281,7 @@ def getpass2(prompt='Password: '):
             'CONFLUENCEBUILDER_NO_GETPASS_HOOK' not in os.environ):
         subprocess.check_call(['stty', '-echo'])
         try:
-            input_ = compat.compat_input
-            value = input_(prompt)
+            value = input(prompt)
         finally:
             subprocess.check_call(['stty', 'echo'])
         print('')

--- a/sphinxcontrib/confluencebuilder/writer.py
+++ b/sphinxcontrib/confluencebuilder/writer.py
@@ -4,9 +4,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
 from docutils import writers
 
 

--- a/sphinxcontrib/confluencebuilder/writer.py
+++ b/sphinxcontrib/confluencebuilder/writer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2021 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -13,28 +13,20 @@ from sphinx.application import Sphinx
 from sphinx.util.console import color_terminal
 from sphinx.util.console import nocolor
 from sphinx.util.docutils import docutils_namespace
-from sphinxcontrib.confluencebuilder import compat
 from sphinxcontrib.confluencebuilder import util
 from threading import Event
 from threading import Lock
 from threading import Thread
+import builtins
+import http.server as http_server
 import inspect
 import io
 import json
 import os
 import shutil
+import socketserver as server_socket
 import sys
 import time
-
-try:
-    import http.server as http_server
-except ImportError:
-    import SimpleHTTPServer as http_server
-
-try:
-    import socketserver as server_socket
-except ImportError:
-    import SocketServer as server_socket
 
 
 # full extension name
@@ -433,12 +425,12 @@ def mock_input(mock):
         return mock
 
     try:
-        original = compat.compat_input
+        original = builtins.input
         try:
-            compat.compat_input = _
+            builtins.input = _
             yield
         finally:
-            compat.compat_input = original
+            builtins.input = original
     finally:
         pass
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -7,8 +7,6 @@
 from bs4 import BeautifulSoup
 from contextlib import contextmanager
 from copy import deepcopy
-from pkg_resources import parse_version
-from sphinx.__init__ import __version__ as sphinx_version
 from sphinx.application import Sphinx
 from sphinx.util.console import color_terminal
 from sphinx.util.console import nocolor
@@ -481,10 +479,6 @@ def prepare_conf():
     ]
     config['confluence_publish'] = False
 
-    # support pre-Sphinx v2.0 installations which default to 'contents'
-    if parse_version(sphinx_version) < parse_version('2.0'):
-        config['master_doc'] = 'index'
-
     return config
 
 
@@ -598,13 +592,6 @@ def prepare_sphinx(src_dir, config=None, out_dir=None, extra_config=None,
         out_dir = prepare_dirs(f_back_count=3)
 
     doctrees_dir = os.path.join(out_dir, '.doctrees')
-
-    # support pre-Sphinx v4.0 installations which do not have `root_doc` by
-    # swapping to the obsolete configuration name
-    if parse_version(sphinx_version) < parse_version('4.0'):
-        if 'root_doc' in conf:
-            conf['master_doc'] = conf['root_doc']
-            del conf['root_doc']
 
     with docutils_namespace():
         app = Sphinx(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,8 +4,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from pkg_resources import parse_version
-from sphinx.__init__ import __version__ as sphinx_version
 from tests.lib import build_sphinx
 from tests.lib import enable_sphinx_info
 from tests.lib import prepare_conf
@@ -124,9 +122,6 @@ class TestConfluenceValidation(unittest.TestCase):
         cls.config['confluence_root_homepage'] = False
 
     def test_extended_autodocs(self):
-        if parse_version(sphinx_version) < parse_version('2.3.1'):
-            raise unittest.SkipTest('breathe requires sphinx>=2.3.1')
-
         config = self.config.clone()
         config['confluence_sourcelink']['container'] += 'extended-autodocs/'
         config['extensions'].append('breathe')

--- a/tests/unit-tests/test_sphinx_alignment.py
+++ b/tests/unit-tests/test_sphinx_alignment.py
@@ -4,23 +4,16 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from pkg_resources import parse_version
-from sphinx.__init__ import __version__ as sphinx_version
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 from tests.lib import parse
 import os
-import unittest
 
 
 class TestConfluenceSphinxAlignment(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestConfluenceSphinxAlignment, cls).setUpClass()
-
-        # skip alignment tests pre-sphinx 2.1 as 'default' hints do not exist
-        if parse_version(sphinx_version) < parse_version('2.1'):
-            raise unittest.SkipTest('default hints not supported in sphinx')
 
         cls.dataset = os.path.join(cls.datasets, 'alignment')
 

--- a/tests/unit-tests/test_sphinx_codeblock_highlight.py
+++ b/tests/unit-tests/test_sphinx_codeblock_highlight.py
@@ -4,13 +4,10 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from pkg_resources import parse_version
-from sphinx.__init__ import __version__ as sphinx_version
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 from tests.lib import parse
 import os
-import unittest
 
 
 class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
@@ -40,11 +37,6 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_codeblock_highlight_linenothreshold(self):
-        # skip code-block tests in Sphinx v1.8.x due to regression
-        #  https://github.com/sphinx-contrib/confluencebuilder/issues/148
-        if parse_version(sphinx_version) < parse_version('2.0'):
-            raise unittest.SkipTest('not supported in sphinx-1.8.x')
-
         out_dir = self.build(self.dataset,
             filenames=['code-block-linenothreshold'])
 

--- a/tests/unit-tests/test_sphinx_domains.py
+++ b/tests/unit-tests/test_sphinx_domains.py
@@ -4,8 +4,6 @@
 :license: BSD-2-Clause (LICENSE)
 """
 
-from pkg_resources import parse_version
-from sphinx.__init__ import __version__ as sphinx_version
 from sphinx.locale import _
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
@@ -36,10 +34,8 @@ class TestConfluenceSphinxDomains(ConfluenceTestCase):
             self.assertIsNotNone(stronged_term)
             self.assertEqual(stronged_term.text, 'my_func')
 
-            # ignore pre-v3.0 as it embeds asterisk in variable
-            if parse_version(sphinx_version) >= parse_version('3.0'):
-                param_context = term.find('em', text='context')
-                self.assertIsNotNone(param_context)
+            param_context = term.find('em', text='context')
+            self.assertIsNotNone(param_context)
 
             # description
             desc = definition.find('dd', recursive=False)
@@ -99,12 +95,6 @@ class TestConfluenceSphinxDomains(ConfluenceTestCase):
                 'param2',
                 _('Throws') + ':',
             ]
-
-            # in sphinx v4.1+, exception are no longer strong styled
-            if parse_version(sphinx_version) < parse_version('4.1'):
-                expected_stronged.extend([
-                    'SomeError',
-                ])
 
             expected_stronged.extend([
                 _('Returns') + ':',

--- a/tox.ini
+++ b/tox.ini
@@ -2,16 +2,12 @@
 envlist =
     flake8
     pylint
-    py{27,37,38,39,310}-sphinx{18}
     py{37,38,39}-sphinx{43,44,50,51}
     py{310}-sphinx{43,44,45,50,51}
 
 [testenv]
 deps =
     -r{toxinidir}/requirements_dev.txt
-    sphinx18: docutils<0.18
-    sphinx18: jinja2<=3.0.3
-    sphinx18: sphinx>=1.8,<2.0
     sphinx43: sphinx>=4.3,<4.4
     sphinx44: sphinx>=4.4,<4.5
     sphinx45: sphinx>=4.5,<4.6
@@ -60,21 +56,21 @@ commands =
 [testenv:pylint]
 deps =
     {[testenv]deps}
-    pylint: pylint<2.7.3
+    pylint
 commands =
     pylint \
     sphinxcontrib.confluencebuilder \
     tests \
     setup.py
 
-[testenv:{,py27-,py37-,py38-,py39-,py310-,py311-}sandbox]
+[testenv:{,py37-,py38-,py39-,py310-,py311-}sandbox]
 deps =
     -r{toxinidir}/sandbox/requirements.txt
 commands =
     {envpython} -m tests.test_sandbox {posargs}
 passenv = *
 
-[testenv:{,py27-,py37-,py38-,py39-,py310-,py311-}validation]
+[testenv:{,py37-,py38-,py39-,py310-,py311-}validation]
 deps = 
     {[testenv]deps}
     -r{toxinidir}/requirements_validation.txt


### PR DESCRIPTION
With this extension focusing support for only Python 3.7+ and Sphinx 4.3+ versions, adjusting a series of implementation to remove the legacy implementation (to reduce maintenance and efforts needed for compatibility).
