### PR TITLE
dropping max-doc-depth

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -365,24 +365,6 @@ Generic configuration
 
         confluence_include_search = True
 
-.. confval:: confluence_max_doc_depth
-
-    .. important::
-
-        This feature is deprecated. If there is a desire to generate a single
-        document page instead, consider using the ``singleconfluence``
-        :doc:`builder <builders>` instead.
-
-    A positive integer value, if provided, to indicate the maximum depth
-    permitted for a nested child page before its contents is inlined with a
-    parent. The root of all pages is typically the configured root_doc_. The
-    root page is considered to be at a depth of zero. By default, the maximum
-    document depth is disabled with a value of ``None``.
-
-    .. code-block:: python
-
-        confluence_max_doc_depth = 2
-
 .. confval:: confluence_page_generation_notice
 
     .. versionadded:: 1.7

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -93,8 +93,6 @@ def setup(app):
     cm.add_conf('confluence_footer_data', 'env')
     # Enablement of a generated search documents
     cm.add_conf_bool('confluence_include_search')
-    # Enablement of the maximum document depth (before inlining).
-    cm.add_conf_int('confluence_max_doc_depth', 'env')
     # Enablement of a "page generated" notice.
     cm.add_conf_bool('confluence_page_generation_notice', 'env')
     # Enablement of publishing pages into a hierarchy from a root toctree.
@@ -251,6 +249,8 @@ def setup(app):
     cm.add_conf_bool('confluence_purge_from_root')
     # replaced by confluence_space_key
     cm.add_conf('confluence_space_name')
+    # dropped
+    cm.add_conf_int('confluence_max_doc_depth')
 
     # ##########################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -417,23 +417,6 @@ The following keys are required:
 
     # ##################################################################
 
-    # confluence_max_doc_depth
-    try:
-        validator.conf('confluence_max_doc_depth') \
-                 .int_()
-    except ConfluenceConfigurationError as e:
-        raise ConfluenceConfigurationError('''\
-{msg}
-
-When limiting the document depth permitted for a building/publishing event, the
-defined maximum document depth must be defined as a non-negative integer value.
-
-If planning to use a depth of zero, it is recommended to use the
-'singleconfluence' builder instead.
-'''.format(msg=e))
-
-    # ##################################################################
-
     # confluence_navdocs_transform
     validator.conf('confluence_navdocs_transform') \
              .callable_()

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -16,6 +16,8 @@ DEPRECATED_CONFIGS = {
         'to be removed in a future version',
     'confluence_master_homepage':
         'use "confluence_root_homepage" instead',
+    'confluence_max_doc_depth':
+        'option does nothing',
     'confluence_parent_page_id_check':
         '"confluence_parent_page" now accepts a page id',
     'confluence_publish_subset':
@@ -47,14 +49,6 @@ def deprecated(validator):
     for key, msg in DEPRECATED_CONFIGS.items():
         if config[key] is not None:
             logger.warn('%s deprecated; %s' % (key, msg))
-
-    # promote singleconfluence over confluence_max_doc_depth=0
-    if config.confluence_max_doc_depth == 0:
-        logger.warn('confluence_max_doc_depth with a value of zero '
-            "is deprecated; use the 'singleconfluence' builder instead")
-    elif config.confluence_max_doc_depth:
-        logger.warn('confluence_max_doc_depth is deprecated and will '
-            "be removed; consider using the 'singleconfluence' builder instead")
 
 
 def warnings(validator):

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -486,31 +486,6 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
-    def test_config_check_max_doc_depth(self):
-        self.config['confluence_max_doc_depth'] = 2
-        with self.assertRaises(SphinxWarning):
-            self._try_config()
-
-        self.config['confluence_max_doc_depth'] = '2'
-        with self.assertRaises(SphinxWarning):
-            self._try_config()
-
-        self.config['confluence_max_doc_depth'] = -1
-        with self.assertRaises(ConfluenceConfigurationError):
-            self._try_config()
-
-        self.config['confluence_max_doc_depth'] = 0
-        with self.assertRaises(SphinxWarning):
-            self._try_config()
-
-        del self.config['confluence_max_doc_depth']
-
-        defines = {
-            'confluence_max_doc_depth': '1',
-        }
-        with self.assertRaises(SphinxWarning):
-            self._try_config(edefs=defines)
-
     def test_config_check_mentions(self):
         self.config['confluence_mentions'] = {}
         self._try_config()

--- a/tests/unit-tests/test_config_hierarchy.py
+++ b/tests/unit-tests/test_config_hierarchy.py
@@ -6,42 +6,17 @@
 
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from tests.lib.testcase import ConfluenceTestCase
-from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
-import re
 
 
-class TestConfluenceConfigPrevNext(ConfluenceTestCase):
+class TestConfluenceHierarchy(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceConfigPrevNext, cls).setUpClass()
-
-        cls.config['confluence_max_doc_depth'] = 1
-        cls.config['confluence_page_hierarchy'] = True
+        super(TestConfluenceHierarchy, cls).setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'hierarchy')
 
-    def test_config_hierarchy_max_depth(self):
-        out_dir = self.build(self.dataset, relax=True)
-
-        index = os.path.join(out_dir, 'index.conf')
-        self.assertTrue(os.path.exists(index),
-            'expected file was not generated: {}'.format(index))
-
-        # ensure no documents are created beyond the maximum depth
-        test_paths = [
-            os.path.join(out_dir, 'toctree-doc2a.conf'),
-            os.path.join(out_dir, 'toctree-doc2aa.conf'),
-            os.path.join(out_dir, 'toctree-doc2aaa.conf'),
-            os.path.join(out_dir, 'toctree-doc2b.conf'),
-            os.path.join(out_dir, 'toctree-doc2c.conf')
-        ]
-        for test_path in test_paths:
-            self.assertFalse(os.path.exists(test_path),
-                'unexpected file was generated: {}'.format(test_path))
-
-    def test_config_hierarchy_parent_registration(self):
+    def test_config_hierarchy_parent_registration_default(self):
         ConfluenceState.reset()
         self.build(self.dataset, relax=True)
 
@@ -61,108 +36,3 @@ class TestConfluenceConfigPrevNext(ConfluenceTestCase):
 
         parent_doc = ConfluenceState.parent_docname('toctree-doc2a')
         self.assertEqual(parent_doc, 'toctree-doc2')
-
-    @setup_builder('confluence')
-    def test_storage_config_hierarchy_max_depth(self):
-        out_dir = self.build(self.dataset, relax=True)
-
-        # ensure data is merged in when capping the depth
-        doc2_expected_headers = [
-            'treedoc2a',
-            'hyperlink references (part a)',
-            'treedoc2aa',
-            'treedoc2aaa',
-            'treedoc2b',
-            'treedoc2c',
-            'check citations',
-            'hyperlink references (part b)',
-        ]
-
-        with parse('toctree-doc1', out_dir) as data:
-            # sanity check anchor creation
-            anchor_tag = data.find('ac:structured-macro')
-            self.assertIsNotNone(anchor_tag)
-            self.assertTrue(anchor_tag.has_attr('ac:name'))
-            self.assertEqual(anchor_tag['ac:name'], 'anchor')
-
-            anchor_param = anchor_tag.find('ac:parameter', recursive=False)
-            self.assertIsNotNone(anchor_param)
-            self.assertEqual(anchor_param.text, 'example-doc1-label')
-
-            # ensure link back to combined doc2 page
-            link_tag = data.find('ac:link')
-            self.assertIsNotNone(link_tag)
-
-            self.assertTrue(link_tag.has_attr('ac:anchor'))
-            self.assertEqual(link_tag['ac:anchor'], 'checkcitations')
-
-            page_ref = link_tag.find('ri:page')
-            self.assertIsNotNone(page_ref)
-            self.assertEqual(page_ref['ri:content-title'], 'treedoc2')
-
-            link_body = link_tag.find('ac:link-body', recursive=False)
-            self.assertIsNotNone(link_body)
-            self.assertEqual(link_body.text, 'doc2c')
-
-        with parse('toctree-doc2', out_dir) as data:
-            # ensure headers in the "two" group have all been merged in
-            headers = data.find_all(re.compile('^h[1-6]$'))
-            self.assertEqual(len(headers), len(doc2_expected_headers))
-
-            for header, expected in zip(headers, doc2_expected_headers):
-                self.assertEqual(header.text, expected)
-
-            # check if links are pointing to other documents
-            link_tags = data.find_all('ac:link')
-            self.assertIsNotNone(link_tags)
-
-            doc1_link_tag = link_tags.pop(0)
-            self.assertTrue(doc1_link_tag.has_attr('ac:anchor'))
-            self.assertEqual(doc1_link_tag['ac:anchor'], 'example-doc1-label')
-
-            doc1_page_ref = doc1_link_tag.find('ri:page')
-            self.assertIsNotNone(doc1_page_ref)
-            self.assertEqual(doc1_page_ref['ri:content-title'], 'treedoc1')
-
-            doc1_link_body = doc1_link_tag.find('ac:link-body', recursive=False)
-            self.assertIsNotNone(doc1_link_body)
-            self.assertEqual(doc1_link_body.text, 'doc1')
-
-            doc2_link_tag = link_tags.pop(0)
-            self.assertTrue(doc2_link_tag.has_attr('ac:anchor'))
-            self.assertEqual(doc2_link_tag['ac:anchor'], 'example-doc3-label')
-
-            doc2_page_ref = doc2_link_tag.find('ri:page')
-            self.assertIsNotNone(doc2_page_ref)
-            self.assertEqual(doc2_page_ref['ri:content-title'], 'treedoc3')
-
-            doc2_link_body = doc2_link_tag.find('ac:link-body', recursive=False)
-            self.assertIsNotNone(doc2_link_body)
-            self.assertEqual(doc2_link_body.text, 'doc2')
-
-        with parse('toctree-doc3', out_dir) as data:
-            # sanity check anchor creation
-            anchor_tag = data.find('ac:structured-macro')
-            self.assertIsNotNone(anchor_tag)
-            self.assertTrue(anchor_tag.has_attr('ac:name'))
-            self.assertEqual(anchor_tag['ac:name'], 'anchor')
-
-            anchor_param = anchor_tag.find('ac:parameter', recursive=False)
-            self.assertIsNotNone(anchor_param)
-            self.assertEqual(anchor_param.text, 'example-doc3-label')
-
-            # ensure link back to combined doc2 page
-            link_tag = data.find('ac:link')
-            self.assertIsNotNone(link_tag)
-
-            self.assertTrue(link_tag.has_attr('ac:anchor'))
-            self.assertEqual(link_tag['ac:anchor'],
-                'hyperlinkreferences(parta)')
-
-            page_ref = link_tag.find('ri:page')
-            self.assertIsNotNone(page_ref)
-            self.assertEqual(page_ref['ri:content-title'], 'treedoc2')
-
-            link_body = link_tag.find('ac:link-body', recursive=False)
-            self.assertIsNotNone(link_body)
-            self.assertEqual(link_body.text, 'doc2a')


### PR DESCRIPTION
The `confluence_max_doc_depth` option has been deprecated for some time. With the development branch planned to be used for a next v2.0 release, this feature is now being removed (as mentioned in previous noticed over the past several releases).