### PR TITLE
improve paragraph indentation/offsets with v2 editor

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2527,16 +2527,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         style = ''
 
         if self.v2:
-            # see "visit_paragraph"
-            style += 'margin-left: {}px;'.format(INDENT * self._indent_level)
+            tag = 'p'
         else:
-            # indent this line-block if its not the first element in the parent
-            # (excluding titles for a new section), or if the parent is
-            # also a line-block
-            if (node.parent[0] != node and
-                    not isinstance(node.parent[0], nodes.title)) or \
-                    isinstance(node.parent, nodes.line_block):
-                style += 'margin-left: {}px;'.format(INDENT)
+            tag = 'div'
 
             # if this line-block is not the first element in the parent and the
             # parent is not a line-block, add some separation from a previous
@@ -2544,10 +2537,29 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if node.parent[0] != node and not isinstance(node.parent, nodes.line_block):
                 style += 'padding-top: {}px;'.format(FCMMO)
 
+        # indent this line-block if its not the first element in the parent
+        # (excluding titles for a new section), or if the parent is
+        # also a line-block
+        if (node.parent[0] != node and
+                not isinstance(node.parent[0], nodes.title)) or \
+                isinstance(node.parent, nodes.line_block):
+
+            indent = INDENT
+
+            # if v2, apply additional indentation (if needed)
+            # (see "visit_paragraph")
+            if self.v2:
+                indent = INDENT * (self._indent_level + 1)
+
+            style += 'margin-left: {}px;'.format(indent)
+        elif self.v2:
+            # (see "visit_paragraph")
+            style += 'margin-left: {}px;'.format(INDENT * self._indent_level)
+
         if style:
             attribs['style'] = style
 
-        self.body.append(self._start_tag(node, 'div', **attribs))
+        self.body.append(self._start_tag(node, tag, **attribs))
         self.context.append(self._end_tag(node))
 
     def depart_line_block(self, node):


### PR DESCRIPTION
An inconsistency has been reported when comparing indentations/offsets between the original (v1) editor and new editor. First, when using a v2 editor, line block types stacked against a paragraph would not have the same spacing compared to the older editor. The use of the div tag does not gracefully work in a v2 editor, and will be switched to a p tag. This should help ensure expected spacing.

Next, for line blocks, the Confluence output should be indented these configured blocks if detected that this are new line blocks inside, for example, a paragraph. While this logic was applied on the v1 editor, the same logic was not used on the v2 editor. We now apply a line-block indentation if the condition is detected.
