### PR TITLE
sanitize only non-space unicode control characters

### DIFF
--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -305,7 +305,7 @@ def remove_nonspace_control_chars(text):
     """
 
     return ''.join(c for c in text if c.isspace()
-        or unicodedata.category(c)[0] != 'C')
+        or unicodedata.category(c) != 'Cc')
 
 
 def str2bool(value):


### PR DESCRIPTION
The character sanitizer's primary goal is to strip out control characters to prevent issues where Confluence will reject a page update for unsupported characters. The implementation ignored all Unicode characters which had a category leading with `C`. However, this includes format characters which certain users/documents need to properly format text (for example, the Zero-width non-joiner \[1\]).

Adjusting the utility method to only sanitize out control characters found in the `Cc` group.

\[1\]: https://en.wikipedia.org/wiki/Zero-width_non-joiner