### PR TITLE
third-party nbsphinx/jupyter support

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -25,6 +25,7 @@ from sphinxcontrib.confluencebuilder.translator import ConfluenceBaseTranslator
 from sphinxcontrib.confluencebuilder.util import convert_length
 from sphinxcontrib.confluencebuilder.util import first
 import posixpath
+import re
 import sys
 
 
@@ -2425,6 +2426,37 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self._end_ac_macro(node))
 
         raise nodes.SkipNode
+
+    # ---------------------------------------------
+    # sphinx -- extension (third party) -- nbsphinx
+    # ---------------------------------------------
+
+    def visit_AdmonitionNode(self, node):
+        if 'warning' in node.get('classes', []):
+            self._visit_warning(node)
+        else:
+            self._visit_info(node)
+
+    depart_AdmonitionNode = _depart_admonition
+
+    def visit_CodeAreaNode(self, node):
+        # if nbsphinx provides a prompt for a code block, use it for the title
+        # values (since we cannot gracefully inject it on the side of the
+        # block)
+        prompt = node.get('prompt', None)
+        if prompt:
+            next_child = first(findall(node, include_self=False))
+            if isinstance(next_child, nodes.literal_block):
+                next_child['scb-caption'] = re.escape(prompt)
+
+    def depart_CodeAreaNode(self, node):
+        pass
+
+    def visit_FancyOutputNode(self, node):
+        pass
+
+    def depart_FancyOutputNode(self, node):
+        pass
 
     # ---------------------------------------------------
     # sphinx -- extension (third party) -- sphinx-toolbox

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2427,6 +2427,50 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         raise nodes.SkipNode
 
+    # ---------------------------------------------------
+    # sphinx -- extension (third party) -- jupyter-sphinx
+    # ---------------------------------------------------
+
+    def visit_CellInputNode(self, node):
+        pass
+
+    def depart_CellInputNode(self, node):
+        pass
+
+    def visit_CellOutputNode(self, node):
+        pass
+
+    def depart_CellOutputNode(self, node):
+        pass
+
+    def visit_JupyterCellNode(self, node):
+        pass
+
+    def depart_JupyterCellNode(self, node):
+        pass
+
+    def visit_MimeBundleNode(self, node):
+        # note: do not promote svgs first in v2, since the v2 editor does not
+        #       display SVGs as nice as v1 editor does
+        if self.v2:
+            preferred_mimetypes = ['image/png', 'image/jpeg', 'image/svg+xml']
+        else:
+            preferred_mimetypes = ['image/svg+xml', 'image/png', 'image/jpeg']
+
+        mimetypes = node.get('mimetypes', [])
+        for mimetype in mimetypes:
+            if mimetype in preferred_mimetypes:
+                idx = node['mimetypes'].index(mimetype)
+                self.visit_image(node[idx])
+                self.depart_image(node[idx])
+                raise nodes.SkipNode
+
+        if 'text/plain' in mimetypes:
+            idx = node['mimetypes'].index('text/plain')
+            self.body.append(self.encode(node[idx].astext()))
+
+        raise nodes.SkipNode
+
     # ---------------------------------------------
     # sphinx -- extension (third party) -- nbsphinx
     # ---------------------------------------------

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -13,6 +13,7 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_latex_block
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
 from sphinxcontrib.confluencebuilder.svg import confluence_supported_svg
 from sphinxcontrib.confluencebuilder.svg import svg_initialize
+from sphinxcontrib.confluencebuilder.transmute.ext_jupyter_sphinx import replace_jupyter_sphinx_nodes
 from sphinxcontrib.confluencebuilder.transmute.ext_nbsphinx import replace_nbsphinx_nodes
 from sphinxcontrib.confluencebuilder.transmute.ext_sphinx_diagrams import replace_sphinx_diagrams_nodes
 from sphinxcontrib.confluencebuilder.transmute.ext_sphinx_gallery import replace_sphinx_gallery_nodes
@@ -72,6 +73,8 @@ def doctree_transmute(builder, doctree):
     # --------------------------
     # sphinx external extensions
     # --------------------------
+
+    replace_jupyter_sphinx_nodes(builder, doctree)
 
     replace_nbsphinx_nodes(builder, doctree)
 

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -13,6 +13,7 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_latex_block
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
 from sphinxcontrib.confluencebuilder.svg import confluence_supported_svg
 from sphinxcontrib.confluencebuilder.svg import svg_initialize
+from sphinxcontrib.confluencebuilder.transmute.ext_nbsphinx import replace_nbsphinx_nodes
 from sphinxcontrib.confluencebuilder.transmute.ext_sphinx_diagrams import replace_sphinx_diagrams_nodes
 from sphinxcontrib.confluencebuilder.transmute.ext_sphinx_gallery import replace_sphinx_gallery_nodes
 from sphinxcontrib.confluencebuilder.transmute.ext_sphinx_toolbox import replace_sphinx_toolbox_nodes
@@ -71,6 +72,8 @@ def doctree_transmute(builder, doctree):
     # --------------------------
     # sphinx external extensions
     # --------------------------
+
+    replace_nbsphinx_nodes(builder, doctree)
 
     replace_sphinx_diagrams_nodes(builder, doctree)
 

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -65,7 +65,7 @@ def doctree_transmute(builder, doctree):
     # replace graphviz nodes with images
     replace_graphviz_nodes(builder, doctree)
 
-    # replace math blocks with images
+    # replace math blocks with Confluence LaTeX blocks
     replace_math_blocks(builder, doctree)
 
     # --------------------------
@@ -84,8 +84,79 @@ def doctree_transmute(builder, doctree):
     # post-transmute work
     # -------------------
 
+    # replace Confluence LaTeX blocks with images (if configured/supported)
+    prepare_math_images(builder, doctree)
+
     # re-work svg entries to support confluence
     prepare_svgs(builder, doctree)
+
+
+def prepare_math_images(builder, doctree):
+    """
+    replace Confluence LaTeX blocks with images
+
+    If configured and supported, Confluence LaTeX blocks can be replaced with
+    images. This can help render LaTeX content on a Confluence instance that
+    does not support a LaTeX macro. Math support will work on systems which
+    have latex/dvipng installed.
+
+    Args:
+        builder: the builder
+        doctree: the doctree to replace blocks on
+    """
+
+    # disable automatic conversion of latex blocks to images if a latex
+    # macro is configured
+    if builder.config.confluence_latex_macro:
+        return
+
+    if imgmath is None:
+        return
+
+    # convert Confluence LaTeX blocks into image blocks
+    #
+    # imgmath's render_math call expects a translator to be passed
+    # in; mock a translator tied to our builder
+    class MockTranslator:
+        def __init__(self, builder):
+            self.builder = builder
+    mock_translator = MockTranslator(builder)
+
+    math_image_ids = []
+
+    for node in itertools.chain(findall(doctree, confluence_latex_inline),
+            findall(doctree, confluence_latex_block)):
+        try:
+            mf, depth = imgmath.render_math(mock_translator, node.astext())
+            if not mf:
+                continue
+
+            new_node = nodes.image(
+                candidates={'?'},
+                uri=path.join(builder.outdir, mf),
+                **node.attributes)
+
+            if depth is not None:
+                new_node['math_depth'] = depth
+
+            node.replace_self(new_node)
+
+            if builder.config.confluence_editor == 'v2':
+                if 'ids' in new_node:
+                    math_image_ids.extend(new_node['ids'])
+
+        except imgmath.MathExtError as exc:
+            ConfluenceLogger.warn('inline latex {}: {}'.format(
+                node.astext(), exc))
+
+    # v2 editor will manually inject anchors in an image-managed
+    # section to avoid a newline spacing between the anchor and
+    # the image; keep track of ids for these images, and then
+    # remove any targets with matching ids to prevent anchors from
+    # being created
+    for node in findall(doctree, nodes.target):
+        if 'refid' in node and node['refid'] in math_image_ids:
+            node.parent.remove(node)
 
 
 def prepare_svgs(builder, doctree):
@@ -223,10 +294,10 @@ def replace_math_blocks(builder, doctree):
     """
     replace math blocks with images
 
-    Math blocks are pre-processed and replaced with respective images in the
-    list of documents to process. This is to help prepare additional images into
-    the asset management for this extension. Math support will work on systems
-    which have latex/dvipng installed.
+    Math blocks are pre-processed and replaced with Confluence LaTeX blocks.
+    This is to help prepare nodes that can later be used for user-configured
+    LaTeX macros, or help converting LaTeX blocks into images (if supported on
+    the system).
 
     Args:
         builder: the builder
@@ -238,7 +309,7 @@ def replace_math_blocks(builder, doctree):
     if 'ext-imgmath' in restricted:
         return
 
-    # phase 1 -- convert math blocks into Confluence LaTeX blocks
+    # convert math blocks into Confluence LaTeX blocks
     for node in itertools.chain(findall(doctree, nodes.math),
             findall(doctree, nodes.math_block)):
         if not isinstance(node, nodes.math):
@@ -258,56 +329,3 @@ def replace_math_blocks(builder, doctree):
             new_node['align'] = 'center'
 
         node.replace_self(new_node)
-
-    # disable automatic conversion of latex blocks to images if a latex
-    # macro is configured
-    if builder.config.confluence_latex_macro:
-        return
-
-    if imgmath is None:
-        return
-
-    # phase 2 -- convert Confluence LaTeX blocks into image blocks
-    #
-    # imgmath's render_math call expects a translator to be passed
-    # in; mock a translator tied to our builder
-    class MockTranslator:
-        def __init__(self, builder):
-            self.builder = builder
-    mock_translator = MockTranslator(builder)
-
-    math_image_ids = []
-
-    for node in itertools.chain(findall(doctree, confluence_latex_inline),
-            findall(doctree, confluence_latex_block)):
-        try:
-            mf, depth = imgmath.render_math(mock_translator, node.astext())
-            if not mf:
-                continue
-
-            new_node = nodes.image(
-                candidates={'?'},
-                uri=path.join(builder.outdir, mf),
-                **node.attributes)
-
-            if depth is not None:
-                new_node['math_depth'] = depth
-
-            node.replace_self(new_node)
-
-            if builder.config.confluence_editor == 'v2':
-                if 'ids' in new_node:
-                    math_image_ids.extend(new_node['ids'])
-
-        except imgmath.MathExtError as exc:
-            ConfluenceLogger.warn('inline latex {}: {}'.format(
-                node.astext(), exc))
-
-    # v2 editor will manually inject anchors in an image-managed
-    # section to avoid a newline spacing between the anchor and
-    # the image; keep track of ids for these images, and then
-    # remove any targets with matching ids to prevent anchors from
-    # being created
-    for node in findall(doctree, nodes.target):
-        if 'refid' in node and node['refid'] in math_image_ids:
-            node.parent.remove(node)

--- a/sphinxcontrib/confluencebuilder/transmute/ext_jupyter_sphinx.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_jupyter_sphinx.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
+
+# ##############################################################################
+# disable import/except warnings for third-party modules
+# pylint: disable=E
+
+# load jupyter_sphinx extension if available
+try:
+    from jupyter_sphinx.ast import CellOutputNode as jupyter_celloutputnode
+    from jupyter_sphinx.ast import MimeBundleNode as jupyter_mimebundlenode
+    jupyter_sphinx = True
+except:  # noqa: E722
+    jupyter_sphinx = False
+
+# re-enable pylint warnings from above
+# pylint: enable=E
+# ##############################################################################
+
+
+def replace_jupyter_sphinx_nodes(builder, doctree):
+    """
+    replace jupyter-sphinx nodes
+
+    jupyter-sphinx nodes are pre-processed and replaced with compatible nodes
+    in the processed documentation set.
+
+    Args:
+        builder: the builder
+        doctree: the doctree to replace blocks on
+    """
+
+    # allow users to disabled third-party implemented extension changes
+    restricted = builder.config.confluence_adv_restricted
+    if 'ext-jupyter' in restricted:
+        return
+
+    if not jupyter_sphinx:
+        return
+
+    # replace mime bundle nodes with already-prepared Confluence LaTeX nodes;
+    # this allows a translator to directly process a Confluence LaTeX node in
+    # cell output node (or an image, if Confluence LaTeX nodes have been
+    # transformed)
+    for base in findall(doctree, jupyter_celloutputnode):
+        for node in base.findall(jupyter_mimebundlenode):
+            mimetypes = node.get('mimetypes', [])
+            if 'text/latex' in mimetypes:
+                idx = node['mimetypes'].index('text/latex')
+                base.replace(node, node[idx])

--- a/sphinxcontrib/confluencebuilder/transmute/ext_nbsphinx.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_nbsphinx.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from docutils import nodes
+from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
+import itertools
+
+# ##############################################################################
+# disable import/except warnings for third-party modules
+# pylint: disable=E
+
+# load nbsphinx extension if available
+try:
+    from nbsphinx import CodeAreaNode as nbsphinx_codeareanode
+    from nbsphinx import FancyOutputNode as nbsphinx_fancyoutputnode
+    nbsphinx = True
+except:  # noqa: E722
+    nbsphinx = False
+
+# re-enable pylint warnings from above
+# pylint: enable=E
+# ##############################################################################
+
+
+def replace_nbsphinx_nodes(builder, doctree):
+    """
+    replace nbsphinx nodes
+
+    nbsphinx nodes are pre-processed and replaced with compatible nodes
+    in the processed documentation set.
+
+    Args:
+        builder: the builder
+        doctree: the doctree to replace blocks on
+    """
+
+    # allow users to disabled third-party implemented extension changes
+    restricted = builder.config.confluence_adv_restricted
+    if 'ext-nbsphinx' in restricted:
+        return
+
+    if not nbsphinx:
+        return
+
+    for node in itertools.chain(findall(doctree, nbsphinx_codeareanode),
+            findall(doctree, nbsphinx_fancyoutputnode)):
+
+        for raw_node in node.findall(nodes.raw):
+            if 'text' in raw_node.get('format', '').split():
+                new_node = nodes.literal_block(
+                    raw_node.astext(), raw_node.astext(), language='none')
+                raw_node.replace_self(new_node)


### PR DESCRIPTION
The following pull request brings initial support for various nbsphinx/jupyter capabilities.

There was an initial request (#198) to support Jupyter Notebooks which did not fit into the desired maintenance work for the Confluence builder extension. Since late 2021, the Confluence builder extension started to add support for some third-party extensions. With the recent request to support the [Jupyter Sphinx Extension](https://jupyter-sphinx.readthedocs.io/) (#733) and text-support in the nbsphinx last year, the ability to support Jupyter Notebook has improved.

This pull request takes into consideration some implementation suggestion from the work @planetmarshall has [performed](https://github.com/planetmarshall/sphinx-confluence-nbsphinx-test) (e.g. placing prompt values in code block headers). For output blocks, the rendered content will use the available text-mode output provided. Initial work should provide support for the following capabilities:

- nbsphinx admonitions
- nbsphinx Input/Output code blocks
- Rendering image/LaTeX output blocks

There will be several limitations in supporting these third-party extensions. For example, features such as interactive elements (e.g. JavaScript-based media), Thebe, etc. can not be supported (due to limitations in stock Confluence instances).

If a user finds a specific feature related to Jupyter Notebooks or the Jupyter Sphinx extension that should appear to be possible which does not appear to work, feel free to bring this up in a new issue (outlining specifics to help maintainers).