### PR TITLE
support collapse hints for literal blocks

### DIFF
--- a/doc/features.rst
+++ b/doc/features.rst
@@ -102,9 +102,6 @@ Type                    Notes
 `versionchanged`_       Supported
 ======================= =====
 
-*(note: directive options "class" and "name" are ignored as they are not
-supported in a Confluence format document)*
-
 .. raw:: latex
 
     \newpage

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -88,6 +88,9 @@ Type                    Notes
                         supported in the Confluence markup. The code block macro
                         only supports a simple line numbers (configurable with
                         the ``linenos`` option).
+
+                        When the ``class`` attribute contains ``collapse``, the
+                        macro will be configured to be collapsed.
 `deprecated`_           Supported
 `download`_             Supported
 `glossary`_             Supported

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :copyright: Copyright 2018-2020 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -708,12 +708,18 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self._start_ac_macro(node, 'code'))
         self.body.append(self._build_ac_param(node, 'language', lang))
         self.body.append(self._build_ac_param(node, 'linenumbers', num))
+
         if firstline is not None and firstline > 1:
             self.body.append(
                 self._build_ac_param(node, 'firstline', str(firstline))
             )
+
         if title:
             self.body.append(self._build_ac_param(node, 'title', title))
+
+        if 'collapse' in node.get('classes', []):
+            self.body.append(self._build_ac_param(node, 'collapse', 'true'))
+
         self.body.append(self._start_ac_plain_text_body_macro(node))
         self.body.append(self._escape_cdata(data))
         self.body.append(self._end_ac_plain_text_body_macro(node))

--- a/tests/unit-tests/datasets/code-block-params/code-block-collapse.rst
+++ b/tests/unit-tests/datasets/code-block-params/code-block-collapse.rst
@@ -1,0 +1,12 @@
+:orphan:
+
+.. code-block:: python
+
+    import example
+    example.method1()
+
+.. code-block:: python
+    :class: collapse
+
+    import example
+    example.method2()

--- a/tests/unit-tests/test_confluence_code_params.py
+++ b/tests/unit-tests/test_confluence_code_params.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2023 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+from tests.lib import parse
+import os
+
+
+class TestConfluenceCodeParams(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestConfluenceCodeParams, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'code-block-params')
+
+    @setup_builder('confluence')
+    def test_storage_confluence_code_params_collapse(self):
+        out_dir = self.build(self.dataset, filenames=['code-block-collapse'])
+
+        with parse('code-block-collapse', out_dir) as data:
+            code_macros = data.find_all('ac:structured-macro')
+            self.assertIsNotNone(code_macros)
+            self.assertEqual(len(code_macros), 2)
+
+            for code_macro in code_macros:
+                self.assertTrue(code_macro.has_attr('ac:name'))
+                self.assertEqual(code_macro['ac:name'], 'code')
+
+            # code macro with no collapse
+            code_macro = code_macros.pop(0)
+
+            collapse = code_macro.find('ac:parameter', {'ac:name': 'collapse'})
+            self.assertIsNone(collapse)
+
+            # code macro with collapse
+            code_macro = code_macros.pop(0)
+
+            collapse = code_macro.find('ac:parameter', {'ac:name': 'collapse'})
+            self.assertIsNotNone(collapse)
+            self.assertEqual(collapse.text, 'true')

--- a/tests/validation-sets/sphinx/code.rst
+++ b/tests/validation-sets/sphinx/code.rst
@@ -116,6 +116,17 @@ A code block can also include a caption:
 
     print('Explicit is better than implicit.')
 
+Code macros can be collapsed when using the `class` option:
+
+.. code-block:: none
+    :class: collapse
+
+    .. code-block:: python
+        :class: collapse
+
+        import example
+        example.method()
+
 
 .. references ------------------------------------------------------------------
 


### PR DESCRIPTION
If a processing literal block builds a code macro, adding support to flag the `collapse` parameter option if the `collapse` class is specified.

---

fyi @senges, best to create new issue entries for new enhancements than update a closed issue when possible. The features/changes you proposed look good, and have been included in this pull request. This should be available next release. Please feel free to comment if there is anything missing.