### PR TITLE
tox/ci maintenance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,11 +43,11 @@ jobs:
             texlive-latex-extra \
             texlive-latex-recommended \
             -y
-        python -m pip install --upgrade sphinx
+        sudo python -m pip install --upgrade sphinx
 
     - name: Install confluencebuilder
       run: |
-        python -m pip install -e .
+        sudo python -m pip install -e .
 
     - name: HTML
       run: make html

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 requests>=2.14.0
+sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -35,12 +35,12 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 pip_pre = true
 
-[testenv:{,py27-,py37-,py38-,py39-,py310-,py311-}interactive]
+[testenv:{,py37-,py38-,py39-,py310-,py311-}interactive]
 commands =
     {envpython} -m sphinxcontrib.confluencebuilder {posargs}
 passenv = *
 
-[testenv:{,py27-,py37-,py38-,py39-,py310-,py311-}prerelease]
+[testenv:{,py37-,py38-,py39-,py310-,py311-}prerelease]
 pip_pre = true
 
 [testenv:flake8]


### PR DESCRIPTION
### tox: always add a sphinx dependency

Ensure the Sphinx module is installed for all test cases, which should help ensure pylint checks do not complain about missing Sphinx imports.

### tox: drop py27-environment tests

Dropping various Python 2.7 targets in the tox configuration, which are no longer applicable for this project.

### .github-docs: sudo install pip packages

Invoke sudo calls for pip upgrades and the package install to prevent possible installation issues if pip only attempts to install into the system path.