### PR TITLE
place orphan pages under configured publish root

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 
 See also:

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -241,7 +241,7 @@ reported a success (which can be permitted for anonymous users).
         return ancestors
 
     def get_base_page_id(self):
-        base_page_id = None
+        base_page_id = self.config.confluence_publish_root
 
         if not self.parent_ref:
             return base_page_id


### PR DESCRIPTION
When a configuration specifies a root to publish under (i.e. the `confluence_publish_root` option), ensure any orphan pages that are generated are placed under this group (instead of the root of the configured space).
