### PR TITLE
restrict publishing with empty allow list

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1239,6 +1239,8 @@ Advanced publishing configuration
 .. confval:: confluence_publish_allowlist
 
     .. versionadded:: 1.3
+    .. versionchanged:: 2.0 An empty allow list will no longer publish any
+                            documents.
 
     .. note::
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :copyright: Copyright 2007-2021 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -39,6 +39,7 @@ from sphinxcontrib.confluencebuilder.transmute import doctree_transmute
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
 from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import first
+from sphinxcontrib.confluencebuilder.util import handle_cli_file_subset
 from sphinxcontrib.confluencebuilder.writer import ConfluenceWriter
 import io
 import os
@@ -73,8 +74,8 @@ class ConfluenceBuilder(Builder):
         self.nav_next = {}
         self.nav_prev = {}
         self.omitted_docnames = []
-        self.publish_allowlist = []
-        self.publish_denylist = []
+        self.publish_allowlist = None
+        self.publish_denylist = None
         self.publish_docnames = []
         self.publisher = ConfluencePublisher()
         self.root_doc_page_id = None
@@ -176,19 +177,19 @@ class ConfluenceBuilder(Builder):
 
         def prepare_subset(option):
             value = getattr(config, option)
-            if not value:
+            if value is None:
                 return None
 
-            # if provided via command line, treat as a list
-            if option in config['overrides'] and isinstance(value, str):
-                value = value.split(',')
+            value = handle_cli_file_subset(config, option, value)
+            if value is None:
+                return None
 
             if isinstance(value, str):
                 files = extract_strings_from_file(value)
             else:
                 files = value
 
-            return set(files) if files else None
+            return set(files)
 
         self.publish_allowlist = prepare_subset('confluence_publish_allowlist')
         self.publish_denylist = prepare_subset('confluence_publish_denylist')
@@ -755,7 +756,8 @@ class ConfluenceBuilder(Builder):
         if self.publish_denylist and docname in self.publish_denylist:
             return True
 
-        if self.publish_allowlist and docname not in self.publish_allowlist:
+        if self.publish_allowlist is not None and \
+                docname not in self.publish_allowlist:
             return True
 
         return False

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -9,6 +9,7 @@ from sphinxcontrib.confluencebuilder.config.notifications import warnings
 from sphinxcontrib.confluencebuilder.config.validation import ConfigurationValidation
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.std.confluence import EDITORS
+from sphinxcontrib.confluencebuilder.util import handle_cli_file_subset
 from requests.auth import AuthBase
 import os
 
@@ -484,11 +485,9 @@ navigational buttons onto generated pages. Accepted values include 'bottom',
         if not value:
             continue
 
-        # if provided via command line, treat as a list
+        # if provided a file via command line, treat as a list
         def conf_translate(value):
-            if option in config['overrides'] and isinstance(value, str):
-                value = value.split(',')
-            return value
+            return handle_cli_file_subset(config, option, value)
         value = conf_translate(value)
 
         try:

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -290,6 +290,36 @@ def getpass2(prompt='Password: '):
         return getpass.getpass(prompt=prompt)
 
 
+def handle_cli_file_subset(config, option, value):
+    """
+    process a file subset entry based on a cli-provided value
+
+    If the value of an option is provided in the "overrides", this is (most
+    likely) an option set from the command line. If this string points to an
+    existing file, we will return the provided file name as is. However, if
+    this is a string, it is most likely a list of files from the command line.
+
+    Args:
+        config: the sphinx configuration
+        option: the key associated to this configuration value
+        value: the configuration value
+
+    Returns:
+        the resolved configuration value
+    """
+
+    if option in config['overrides'] and isinstance(value, str):
+        if not value:
+            # an empty command line subset is an "unset" request
+            # (and not an empty list); if no values are detected,
+            # return `None`
+            return None
+        elif not os.path.isfile(value):
+            value = value.split(',')
+
+    return value
+
+
 def remove_nonspace_control_chars(text):
     """
     remove any non-space control characters from text

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2018-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2018-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/unit-tests/datasets/publish-list/folder/page-b.rst
+++ b/tests/unit-tests/datasets/publish-list/folder/page-b.rst
@@ -1,0 +1,4 @@
+page-b
+------
+
+content

--- a/tests/unit-tests/datasets/publish-list/index.rst
+++ b/tests/unit-tests/datasets/publish-list/index.rst
@@ -1,0 +1,7 @@
+index
+=====
+
+.. toctree::
+
+    page-a
+    folder/page-b

--- a/tests/unit-tests/datasets/publish-list/page-a.rst
+++ b/tests/unit-tests/datasets/publish-list/page-a.rst
@@ -1,0 +1,4 @@
+page-a
+------
+
+content

--- a/tests/unit-tests/datasets/publish-list/publish-list-default
+++ b/tests/unit-tests/datasets/publish-list/publish-list-default
@@ -1,0 +1,2 @@
+page-a
+folder/page-b

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -625,7 +625,11 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         ]
 
         for option in options:
-            # empty value (list; ignore state)
+            # empty value (None; ignore state)
+            self.config[option] = None
+            self._try_config(dataset=dataset)
+
+            # empty value (list; no publish or no denied state)
             self.config[option] = []
             self._try_config(dataset=dataset)
 
@@ -676,6 +680,11 @@ class TestConfluenceConfigChecks(unittest.TestCase):
 
             # cleanup
             self.config[option] = None
+
+            # enumalate command line empty string to unset (valid)
+            config = dict(self.minimal_config)
+            config[option] = ''
+            self._try_config(config=config, dataset=dataset)
 
             # enumalate command line csv string to list (valid)
             config = dict(self.minimal_config)

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2016-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2016-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/tests/unit-tests/test_config_publish_list.py
+++ b/tests/unit-tests/test_config_publish_list.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2023 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
+from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
+from tests.lib.testcase import ConfluenceTestCase
+from unittest.mock import ANY
+from unittest.mock import call
+from unittest.mock import patch
+import os
+
+
+class TestConfluenceConfigPublishList(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestConfluenceConfigPublishList, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'publish-list')
+
+        cls.config['confluence_publish'] = True
+        cls.config['confluence_server_url'] = 'https://dummy.example.com/'
+        cls.config['confluence_space_key'] = 'DUMMY'
+
+    def run(self, result=None):
+        with patch.object(ConfluencePublisher, 'connect'), \
+                patch.object(ConfluencePublisher, 'disconnect'), \
+                patch.object(ConfluenceBuilder, 'publish_asset'):
+            super(TestConfluenceConfigPublishList, self).run(result)
+
+    def test_config_publishlist_allow_empty(self):
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = []
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_not_called()
+
+    def test_config_publishlist_allow_list_cli_default(self):
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = 'page-a,folder/page-b'
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_allow_list_cli_empty(self):
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = ''
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        # special case: typically, a set allow list that is empty could be
+        # considered as an empty list which hints to no documents published;
+        # however, we want to ensure support for users trying to "unset" the
+        # configured option via command line -- if users wanted to help
+        # enforce denying publication for all documents via command line, they
+        # can achieve this by forcing the publish option off
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_allow_list_file_default(self):
+        publish_list = os.path.join(self.dataset, 'publish-list-default')
+
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = publish_list
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_allow_list_file_empty(self):
+        publish_list = os.path.join(self.dataset, 'publish-list-empty')
+
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = publish_list
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_not_called()
+
+    def test_config_publishlist_allow_multiple(self):
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = ['index', 'page-a']
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('page-a', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_allow_none(self):
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = None
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_allow_singledoc_root(self):
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = ['page-a']
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('page-a', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_allow_singledoc_subfolder(self):
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = ['folder/page-b']
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_default(self):
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_empty(self):
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = []
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_list_cli_default(self):
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = 'page-a,folder/page-b'
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_list_cli_empty(self):
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = ''
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_list_file_default(self):
+        publish_list = os.path.join(self.dataset, 'publish-list-default')
+
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = publish_list
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_list_file_empty(self):
+        publish_list = os.path.join(self.dataset, 'publish-list-empty')
+
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = publish_list
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_multiple(self):
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = ['index', 'page-a']
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_none(self):
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = None
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_singledoc_root(self):
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = ['page-a']
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_singledoc_subfolder(self):
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = ['folder/page-b']
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('page-a', ANY),
+        ], any_order=True)


### PR DESCRIPTION
Users taking advantage of `confluence_publish_allowlist` may be using this feature to detect which documents have changed to decide what documents are to be published. In such systems, if an allow-list is generated which is empty, the resulting state would be that all documents will be published. This can be counter-intuitive for users of this feature. This commit tweaks the allow list setup where users can configure an empty allow list to indicate no pages will be published.

The default state, `confluence_publish_allowlist` is set to `None` to not use this feature (i.e. all pages can be published). If an empty list is assigned to this value:

    confluence_publish_allowlist = []

No documents will be published. This also applies to when using a file:

    confluence_publish_allowlist = 'allow-list.txt'

And if this file is empty, no files will be published.

Users may use the command line to override a persisted configuration by setting `-Dconfluence_publish_allowlist=` (no value), to disable the allow-list option. And if users need to support a command line override hint to not publish any documents for their run state, users can still override the `-Dconfluence_publish=0` option to disable publishing.