### PR TITLE
maintenance work (early January 2023)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,32 +41,32 @@ jobs:
     strategy:
       matrix:
         include:
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx44, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx45, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx52, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx44, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx45, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx53, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx51, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx44, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx45, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx52, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx53, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx60, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx52, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx44, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx45, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx53, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx60, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx52, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx44, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx45, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx53, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx60, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx52, cache: ~/.cache/pip }
-            - { os:   macos-latest, python: "3.10", toxenv: py310-sphinx52, cache: ~/Library/Caches/pip }
-            - { os: windows-latest, python: "3.11", toxenv: py311-sphinx52, cache: ~\AppData\Local\pip\Cache }
+            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx53, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx60, cache: ~/.cache/pip }
+            - { os:   macos-latest, python: "3.11", toxenv: py311-sphinx60, cache: ~/Library/Caches/pip }
+            - { os: windows-latest, python: "3.11", toxenv: py311-sphinx60, cache: ~\AppData\Local\pip\Cache }
             - { os:  ubuntu-latest, python: "3.11", toxenv:         flake8, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv:         pylint, cache: ~/.cache/pip }
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,15 @@
 Development
 ===========
 
+* Fixed issue publishing orphan pages when a publish root is configured
 * Hierarchy mode is now enabled by default
 * Improve look of quote-like directives
+* Introduce the Confluence excerpt (macro) directives
 * Support Confluence Cloud's "Fabric" (v2) editor
+* Support collapsible code blocks
 * Support for Python 2.7 has been dropped
 * Support for ``confluence_max_doc_depth`` has been dropped
+* Support no publishing with an empty ``confluence_publish_allowlist``
 
 1.9.0 (2022-08-21)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -28,19 +28,17 @@ Requirements
 
 Active release (v1.9) requirements:
 
+* Confluence_ Cloud or Data Center / Server 7.8+
 * Python_ 2.7 or 3.7+
 * Requests_ 2.14.0+
 * Sphinx_ 1.8 or 4.1+
 
 Next release requirements:
 
+* Confluence_ Cloud or Data Center / Server 7.11+
 * Python_ 3.7+
 * Requests_ 2.14.0+
 * Sphinx_ 4.4+
-
-If publishing:
-
-* Confluence_ Cloud or Data Center / Server 7.9+
 
 Installing
 ==========

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Next release requirements:
 * Confluence_ Cloud or Data Center / Server 7.11+
 * Python_ 3.7+
 * Requests_ 2.14.0+
-* Sphinx_ 4.4+
+* Sphinx_ 5.0+
 
 Installing
 ==========

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,7 @@ author = 'Sphinx Confluence Builder Contributors'
 version = sphinxcontrib.confluencebuilder.__version__
 release = sphinxcontrib.confluencebuilder.__version__
 
-supported_confluence_ver = '7.9+'
+supported_confluence_ver = '7.11+'
 supported_python_ver = '3.7+'
 supported_sphinx_ver = '4.4+'
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2017-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2017-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 
@@ -9,7 +9,7 @@ from sphinx.transforms.post_transforms import SphinxPostTransform
 import sphinxcontrib.confluencebuilder
 
 project = 'Sphinx Confluence Builder'
-copyright = '2022 Sphinx Confluence Builder Contributors'
+copyright = '2023 Sphinx Confluence Builder Contributors'
 author = 'Sphinx Confluence Builder Contributors'
 version = sphinxcontrib.confluencebuilder.__version__
 release = sphinxcontrib.confluencebuilder.__version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',
     'Environment :: Web Environment',
+    'Framework :: Sphinx',
     'Framework :: Sphinx :: Extension',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: BSD License',
@@ -33,6 +34,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Topic :: Documentation',
+    'Topic :: Documentation :: Sphinx',
     'Topic :: Utilities',
 ]
 dynamic = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     pylint
-    py{37,38,39}-sphinx{44,50,51,52}
-    py{310,311}-sphinx{44,45,50,51,52}
+    py{37}-sphinx{50,51,52,53}
+    py{38,39,310,311}-sphinx{50,51,52,53,60}
 
 [testenv]
 deps =
@@ -13,6 +13,8 @@ deps =
     sphinx50: sphinx>=5.0,<5.1
     sphinx51: sphinx>=5.1,<5.2
     sphinx52: sphinx>=5.2,<5.3
+    sphinx53: sphinx>=5.3,<5.4
+    sphinx60: sphinx>=6.0,<6.1
 commands =
     {envpython} -m tests {posargs}
 setenv =


### PR DESCRIPTION
Perform a series of maintenance work in preparation for an upcoming release. This includes updated supported Sphinx/Confluence versions, bumping copyright year, expanding project classifiers and updating the changelog.