### PR TITLE
support numfig for tables and codeblocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ Development
 ===========
 
 * Fixed issue publishing orphan pages when a publish root is configured
+* Fixed issue where captioned code blocks may not be numbered with ``numfig``
+* Fixed issue where captioned tables were not be numbered with ``numfig``
 * Hierarchy mode is now enabled by default
 * Improve look of quote-like directives
 * Introduce the Confluence excerpt (macro) directives

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -958,6 +958,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         if title_node:
             self.body.append(self._start_tag(node, 'p'))
             self.body.append(self._start_tag(node, 'strong'))
+            self.add_fignumber(node)
             self.body.append(self.encode(title_node.astext()))
             self.body.append(self._end_tag(node))
             self.body.append(self._end_tag(node))


### PR DESCRIPTION
### translator: support numfigs on tables

While the `numfig` option hints to supporting number tables if captioned, the translator never attempted to add a number for captioned tables. This commit addresses this by injection a number for table captions.

### translator: support numfigs on code blocks

While the `numfig` option hints to supporting code blocks if captioned, the translator never attempted to add a number for captioned code blocks if the caption is injected into the macro title value. Tweaking the implementation to allow building a numbered caption for these title parameters.