### PR TITLE
.readthedocs.yaml: use newer os/python version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,11 @@
 # readthedocs configuration script
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 sphinx:
   builder: dirhtml
   configuration: doc/conf.py


### PR DESCRIPTION
Explicitly indicate to use the most recent Ubuntu image and Python version available. This should allow the most recent version of Sphinx to be installed.

This is based off this error and the RTD logs seems to still default to Python 3.7:

```
ERROR: Ignored the following versions that require a different python version: 6.0.0 Requires-Python >=3.8; 6.0.0b1 Requires-Python >=3.8; 6.0.0b2 Requires-Python >=3.8
```