### PR TITLE
support orphan page controls

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1452,6 +1452,48 @@ Advanced publishing configuration
 
         confluence_publish_onlynew = True
 
+.. |confluence_publish_orphan| replace:: ``confluence_publish_orphan``
+.. _confluence_publish_orphan:
+
+.. confval:: confluence_publish_orphan
+
+    .. versionadded:: 2.1
+
+    Whether to permit the publishing of orphan pages to a Confluence space.
+    This option must be explicitly set to ``False`` if a user wishes to not
+    publish orphan pages for their documentation. By default, the value is set
+    to ``True``.
+
+    .. code-block:: python
+
+        confluence_publish_orphan = True
+
+    See also |confluence_publish_orphan_container|_.
+
+.. |confluence_publish_orphan_container| replace:: ``confluence_publish_orphan_container``
+.. _confluence_publish_orphan_container:
+
+.. confval:: confluence_publish_orphan_container
+
+    .. versionadded:: 2.1
+
+    The page identifier of the page to hold orphan pages. The parent page
+    associated to an orphan page can vary per configuration. When a user
+    configures for a parent page/root, orphan pages will be placed under the
+    respective parent page/root configuration. If no parent page/root is
+    configured, orphan pages will not be associated with a parent page.
+    
+    Users can override where orphan pages are placed by using this option. By
+    specifying a page identifier, orphan pages will placed under the configured
+    container page. Users can also provide a special value of ``0`` to indicate
+    to always publish with no parent page.
+
+    .. code-block:: python
+
+        confluence_publish_orphan_container = 123456
+
+    See also |confluence_publish_orphan|_.
+
 .. confval:: confluence_request_session_override
 
     .. versionadded:: 1.7

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -135,6 +135,10 @@ def setup(app):
     cm.add_conf_bool('confluence_publish_dryrun')
     # Publish only new content (no page updates, etc.).
     cm.add_conf_bool('confluence_publish_onlynew')
+    # Publish orphan pages to Confluence.
+    cm.add_conf_bool('confluence_publish_orphan')
+    # Container page to publish orphan pages under.
+    cm.add_conf_int('confluence_publish_orphan_container')
     # Postfix to apply to title of published pages.
     cm.add_conf('confluence_publish_postfix', 'env')
     # Prefix to apply to published pages.

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -532,6 +532,18 @@ names are relative to the documentation's source directory.
 
     # ##################################################################
 
+    # confluence_publish_orphan
+    validator.conf('confluence_publish_orphan') \
+             .bool()
+
+    # ##################################################################
+
+    # confluence_publish_orphan_container
+    validator.conf('confluence_publish_orphan_container') \
+             .int_()
+
+    # ##################################################################
+
     # confluence_publish_postfix
     validator.conf('confluence_publish_postfix') \
              .string()

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -73,6 +73,9 @@ def apply_defaults(builder):
     if conf.confluence_publish_intersphinx is None:
         conf.confluence_publish_intersphinx = True
 
+    if conf.confluence_publish_orphan is None:
+        conf.confluence_publish_orphan = True
+
     if conf.confluence_remove_title is None:
         conf.confluence_remove_title = True
 

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -999,6 +999,11 @@ reported a success (which can be permitted for anonymous users).
             if page['id'] == parent_id:
                 raise ConfluencePublishSelfAncestorError(page_name)
 
+        # zero-id parent ~ a hint to remove the ancestor
+        # (looks like setting a value of "1" is a way to "clear" the option)
+        elif parent_id is not None:
+            update_page['ancestors'] = [{'id': '1'}]
+
         page_id_explicit = page['id'] + '?status=current'
         try:
             self.rest_client.put('content', page_id_explicit, update_page)

--- a/tests/unit-tests/datasets/orphan/index.rst
+++ b/tests/unit-tests/datasets/orphan/index.rst
@@ -1,0 +1,6 @@
+root
+====
+
+.. toctree::
+
+    pagea

--- a/tests/unit-tests/datasets/orphan/pagea.rst
+++ b/tests/unit-tests/datasets/orphan/pagea.rst
@@ -1,0 +1,4 @@
+pagea
+=====
+
+content

--- a/tests/unit-tests/datasets/orphan/pageb.rst
+++ b/tests/unit-tests/datasets/orphan/pageb.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+pageb
+=====
+
+content

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -697,6 +697,23 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             with self.assertRaises(ConfluenceConfigurationError):
                 self._try_config(config=config, dataset=dataset)
 
+    def test_config_check_publish_orphan_container(self):
+        # enable publishing enabled checks
+        self._prepare_valid_publish()
+
+        self.config['confluence_publish_orphan_container'] = 0
+        self._try_config()
+
+        self.config['confluence_publish_orphan_container'] = 123456
+        self._try_config()
+
+        self.config['confluence_publish_orphan_container'] = '123456'
+        self._try_config()
+
+        self.config['confluence_publish_orphan_container'] = -123456
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
     def test_config_check_publish_postfix(self):
         self.config['confluence_publish_postfix'] = ''
         self._try_config()

--- a/tests/unit-tests/test_config_orphan.py
+++ b/tests/unit-tests/test_config_orphan.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""
+:copyright: Copyright 2023 Sphinx Confluence Builder Contributors (AUTHORS)
+:license: BSD-2-Clause (LICENSE)
+"""
+
+from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
+from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
+from tests.lib.testcase import ConfluenceTestCase
+from unittest.mock import ANY
+from unittest.mock import call
+from unittest.mock import patch
+import os
+
+
+class TestConfluenceConfigOrphan(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestConfluenceConfigOrphan, cls).setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'orphan')
+
+        cls.config['confluence_publish'] = True
+        cls.config['confluence_server_url'] = 'https://dummy.example.com/'
+        cls.config['confluence_space_key'] = 'DUMMY'
+
+    def run(self, result=None):
+        with patch.object(ConfluencePublisher, 'connect'), \
+                patch.object(ConfluencePublisher, 'disconnect'), \
+                patch.object(ConfluenceBuilder, 'publish_asset'):
+            super(TestConfluenceConfigOrphan, self).run(result)
+
+    def test_config_orphan_allow_explicit(self):
+        config = dict(self.config)
+        config['confluence_publish_orphan'] = True
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        self.assertEqual(mm.call_count, 3)
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('pagea', ANY),
+            call('pageb', ANY),
+        ], any_order=True)
+
+    def test_config_orphan_allow_default(self):
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset)
+
+        self.assertEqual(mm.call_count, 3)
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('pagea', ANY),
+            call('pageb', ANY),
+        ], any_order=True)
+
+    def test_config_orphan_deny_explicit(self):
+        config = dict(self.config)
+        config['confluence_publish_orphan'] = False
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        self.assertEqual(mm.call_count, 2)
+        mm.assert_has_calls([
+            call('index', ANY),
+            call('pagea', ANY),
+        ], any_order=True)


### PR DESCRIPTION
Provides support for allowing users ways to deal with orphan pages. This includes:

- Allowing users to opt to not publish orphan pages.
- Allowing users to customize where orphan pages will be published.

Orphan pages (published by default) can be disabled by using the option:

```
confluence_publish_orphan = False
```

If users want to configure a page to store orphan pages under, a container option can be set:

```
confluence_publish_orphan_container = 123456
```

As of this extension v2.0, orphan pages respect the configure parent page/root configurations to hold orphan pages. Users who wish to emulate the previous behavior can specifying a container configuration such as:

```
confluence_publish_orphan_container = 0
```