### PR TITLE
handle deprecated sphinx 6.1 imports

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -13,11 +13,11 @@ from sphinx import addnodes
 from sphinx import version_info as sphinx_version_info
 from sphinx.builders import Builder
 from sphinx.locale import _ as SL
-from sphinx.util import status_iterator
 from sphinx.util.osutil import ensuredir
 from sphinxcontrib.confluencebuilder.assets import ConfluenceAssetManager
 from sphinxcontrib.confluencebuilder.assets import ConfluenceSupportedImages
 from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
+from sphinxcontrib.confluencebuilder.compat import status_iterator
 from sphinxcontrib.confluencebuilder.config import process_ask_configs
 from sphinxcontrib.confluencebuilder.config.checks import validate_configuration
 from sphinxcontrib.confluencebuilder.config.defaults import apply_defaults

--- a/sphinxcontrib/confluencebuilder/compat.py
+++ b/sphinxcontrib/confluencebuilder/compat.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :copyright: Copyright 2007-2021 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """

--- a/sphinxcontrib/confluencebuilder/compat.py
+++ b/sphinxcontrib/confluencebuilder/compat.py
@@ -14,6 +14,15 @@ from sphinx.util.nodes import inline_all_toctrees as sphinx_inline_all_toctrees
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from typing import cast
 
+# pylint: disable=no-name-in-module
+if sphinx_version_info >= (6, 1):
+    from sphinx.util.display import status_iterator  # noqa: F401
+    from sphinx.util.display import progress_message  # noqa: F401
+else:
+    from sphinx.util import status_iterator  # noqa: F401
+    from sphinx.util import progress_message  # noqa: F401
+# pylint: enable=no-name-in-module
+
 
 # use docutil's findall call over traverse (obsolete)
 def docutils_findall(doctree, *args, **kwargs):

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -6,11 +6,11 @@
 """
 
 from docutils import nodes
-from sphinx.util import progress_message
 from sphinx.util.console import darkgreen  # pylint: disable=no-name-in-module
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.compat import inline_all_toctrees
+from sphinxcontrib.confluencebuilder.compat import progress_message
 from sphinxcontrib.confluencebuilder.locale import C
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-:copyright: Copyright 2020-2022 Sphinx Confluence Builder Contributors (AUTHORS)
+:copyright: Copyright 2020-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 :copyright: Copyright 2007-2019 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 :license: BSD-2-Clause (LICENSE)
 """


### PR DESCRIPTION
As of Sphinx v6.1.x, a series of utility calls have been moved into new locations. Specifically, `progress_message` and `status_iterator` have been moved into a `util.display` module. Tweaking the implementation to use the new imports for Sphinx v6.1.x.