### PR TITLE
Support Sphinx 6.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,32 +37,31 @@ jobs:
     strategy:
       matrix:
         include:
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx53, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx50, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx53, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx60, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx50, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx61, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx53, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx60, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx50, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx61, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx53, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx60, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx50, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx61, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx53, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx60, cache: ~/.cache/pip }
-            - { os:   macos-latest, python: "3.11", toxenv: py311-sphinx60, cache: ~/Library/Caches/pip }
-            - { os: windows-latest, python: "3.11", toxenv: py311-sphinx60, cache: ~\AppData\Local\pip\Cache }
+            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx61, cache: ~/.cache/pip }
+            - { os:   macos-latest, python: "3.11", toxenv: py311-sphinx61, cache: ~/Library/Caches/pip }
+            - { os: windows-latest, python: "3.11", toxenv: py311-sphinx61, cache: ~\AppData\Local\pip\Cache }
             - { os:  ubuntu-latest, python: "3.11", toxenv:         flake8, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv:         pylint, cache: ~/.cache/pip }
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -260,6 +260,15 @@ class ConfluenceBuilder(Builder):
         self._original_get_doctree = self.env.get_doctree
         self.env.get_doctree = self._get_doctree
 
+        # TMPFIX: as of Sphinx v6.1.x, doctrees can be cached when first
+        # written, which can prevent manipulating them between the doctree
+        # (pickle) write state and re-reading them later (specifically, this
+        # extension's means of manipulation) -- for now, if we detect the
+        # environment is performing any doctree caching, clear the entire
+        # cache
+        if getattr(self.env, '_write_doc_doctree_cache', None):
+            self.env._write_doc_doctree_cache = {}
+
         # process the document structure of the root document, populating a
         # publish order to ensure parent pages are created first (when using
         # hierarchy mode)

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     pylint
-    py{37}-sphinx{50,51,52,53}
-    py{38,39,310,311}-sphinx{50,51,52,53,60}
+    py{37}-sphinx{51,52,53}
+    py{38,39,310,311}-sphinx{51,52,53,60,61}
 
 [testenv]
 deps =
@@ -15,6 +15,7 @@ deps =
     sphinx52: sphinx>=5.2,<5.3
     sphinx53: sphinx>=5.3,<5.4
     sphinx60: sphinx>=6.0,<6.1
+    sphinx61: sphinx>=6.1,<6.2
 commands =
     {envpython} -m tests {posargs}
 setenv =


### PR DESCRIPTION
The following pull request will track effort to support Sphinx v6.1.x+ series.

With the introduction of https://github.com/sphinx-doc/sphinx/issues/11090, the confluencebuilder extension has trouble manipulating the toctree. Specifically, it looks to be a result of the commit https://github.com/sphinx-doc/sphinx/commit/463a69664c2b7f51562eb9d15597987e6e6784cd. The issue is most likely how the confluencebuilder manipulates/caches doctree's on its own (in a not-so-perfect way). We'll have a find an alternative way to address this.

Users who rely on confluencebuilder are recommended to pin to Sphinx v6.0.x series for the interim.