### PR TITLE
tox: add support for python 3.12.x series

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,12 +38,12 @@ deps =
     -r{toxinidir}/requirements_dev.txt
 pip_pre = true
 
-[testenv:{,py37-,py38-,py39-,py310-,py311-}interactive]
+[testenv:{,py37-,py38-,py39-,py310-,py311-,py312-}interactive]
 commands =
     {envpython} -m sphinxcontrib.confluencebuilder {posargs}
 passenv = *
 
-[testenv:{,py37-,py38-,py39-,py310-,py311-}prerelease]
+[testenv:{,py37-,py38-,py39-,py310-,py311-,py312-}prerelease]
 pip_pre = true
 
 [testenv:flake8]
@@ -65,7 +65,7 @@ commands =
     sphinxcontrib \
     tests
 
-[testenv:{,py37-,py38-,py39-,py310-,py311-}sandbox]
+[testenv:{,py37-,py38-,py39-,py310-,py311-,py312-}sandbox]
 deps =
     -r{toxinidir}/sandbox/requirements.txt
 commands =


### PR DESCRIPTION
Python 3.12 has an alpha revision available. Adding an environment to help test this specific interpreter.