### PR TITLE
code cleanup to use python 3 capabilities

### DIFF
--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -84,7 +84,7 @@ class ConfluenceAssetManager:
         """
         logger.verbose('adding manual attachment: %s' % path)
         abspath = find_env_abspath(self.env, self.outdir, path)
-        return self._handle_entry(abspath, docname, True)
+        return self._handle_entry(abspath, docname, standalone=True)
 
     def build(self):
         """

--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -295,7 +295,7 @@ class ConfluenceAssetManager:
                 idx = 1
                 while key in self.keys:
                     idx += 1
-                    key = '{}_{}{}'.format(filename, idx, file_ext)
+                    key = f'{filename}_{idx}{file_ext}'
                 self.keys.add(key)
 
                 asset = ConfluenceAsset(key, path, type_, hash_)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -251,7 +251,7 @@ class ConfluenceBuilder(Builder):
             for domain_name in sorted(self.env.domains):
                 domain = self.env.domains[domain_name]
                 for indexcls in domain.indices:
-                    indexname = '%s-%s' % (domain.name, indexcls.name)
+                    indexname = f'{domain.name}-{indexcls.name}'
 
                     if isinstance(indices_config, list):
                         if indexname not in indices_config:
@@ -480,7 +480,7 @@ class ConfluenceBuilder(Builder):
                     if self.writer.output:
                         file.write(self.writer.output)
             except (IOError, OSError) as err:
-                self.warn('error writing file %s: %s' % (outfilename, err))
+                self.warn(f'error writing file {outfilename}: {err}')
 
     def publish_doc(self, docname, output):
         conf = self.config
@@ -697,7 +697,7 @@ class ConfluenceBuilder(Builder):
         # build domain indexes
         if self.domain_indices:
             for indexname, indexdata in self.domain_indices.items():
-                self.info('generating index ({})...'.format(indexname),
+                self.info(f'generating index ({indexname})...',
                     nonl=(not self._verbose))
 
                 self._generate_special_document(indexname,
@@ -737,7 +737,7 @@ class ConfluenceBuilder(Builder):
                         self.publish_doc(docname, output)
 
                 except (IOError, OSError) as err:
-                    self.warn('error reading file %s: %s' % (docfile, err))
+                    self.warn(f'error reading file {docfile}: {err}')
 
             self.info('building intersphinx... ', nonl=(not self._verbose))
             build_intersphinx(self)
@@ -768,7 +768,7 @@ class ConfluenceBuilder(Builder):
                         output = file.read()
                         self.publish_asset(key, docname, output, type_, hash_)
                 except (IOError, OSError) as err:
-                    self.warn('error reading asset %s: %s' % (key, err))
+                    self.warn(f'error reading asset {key}: {err}')
 
             self.publish_cleanup()
             self.publish_finalize()
@@ -866,7 +866,7 @@ class ConfluenceBuilder(Builder):
                     with open(fname, encoding='utf-8') as file:
                         header_template_data = file.read() + '\n'
                 except (IOError, OSError) as err:
-                    self.warn('error reading file {}: {}'.format(fname, err))
+                    self.warn(f'error reading file {fname}: {err}')
 
                 # if no data is supplied, the file is plain text
                 if self.config.confluence_header_data is None:
@@ -888,7 +888,7 @@ class ConfluenceBuilder(Builder):
                     with open(fname, encoding='utf-8') as file:
                         footer_template_data = file.read() + '\n'
                 except (IOError, OSError) as err:
-                    self.warn('error reading file {}: {}'.format(fname, err))
+                    self.warn(f'error reading file {fname}: {err}')
 
                 # if no data is supplied, the file is plain text
                 if self.config.confluence_footer_data is None:
@@ -1084,10 +1084,10 @@ class ConfluenceBuilder(Builder):
                     section_id = doc_used_names.get(target, 0)
                     doc_used_names[target] = section_id + 1
                     if section_id > 0:
-                        target = '{}.{}'.format(target, section_id)
+                        target = f'{target}.{section_id}'
 
                     for id_ in section_node['ids']:
-                        id_ = '{}#{}'.format(docname, id_)
+                        id_ = f'{docname}#{id_}'
                         self.state.register_target(id_, target)
 
     def _top_ref_check(self, node):
@@ -1120,7 +1120,7 @@ class ConfluenceBuilder(Builder):
 
         if not doctitle:
             if not self.config.confluence_disable_autogen_title:
-                doctitle = "autogen-{}".format(docname)
+                doctitle = f'autogen-{docname}'
                 if self.publish:
                     self.warn('document will be published using an '
                         'generated title value: {}'.format(docname))

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -38,7 +38,6 @@ from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import first
 from sphinxcontrib.confluencebuilder.util import handle_cli_file_subset
 from sphinxcontrib.confluencebuilder.writer import ConfluenceWriter
-import io
 import os
 import tempfile
 
@@ -477,7 +476,7 @@ class ConfluenceBuilder(Builder):
         if self.writer.output is not None:
             ensuredir(path.dirname(outfilename))
             try:
-                with io.open(outfilename, 'w', encoding='utf-8') as file:
+                with open(outfilename, 'w', encoding='utf-8') as file:
                     if self.writer.output:
                         file.write(self.writer.output)
             except (IOError, OSError) as err:
@@ -733,7 +732,7 @@ class ConfluenceBuilder(Builder):
                 docfile = path.join(self.outdir, self.file_transform(docname))
 
                 try:
-                    with io.open(docfile, 'r', encoding='utf-8') as file:
+                    with open(docfile, 'r', encoding='utf-8') as file:
                         output = file.read()
                         self.publish_doc(docname, output)
 
@@ -864,7 +863,7 @@ class ConfluenceBuilder(Builder):
                 fname = path.join(self.env.srcdir,
                     self.config.confluence_header_file)
                 try:
-                    with io.open(fname, encoding='utf-8') as file:
+                    with open(fname, encoding='utf-8') as file:
                         header_template_data = file.read() + '\n'
                 except (IOError, OSError) as err:
                     self.warn('error reading file {}: {}'.format(fname, err))
@@ -886,7 +885,7 @@ class ConfluenceBuilder(Builder):
                 fname = path.join(self.env.srcdir,
                     self.config.confluence_footer_file)
                 try:
-                    with io.open(fname, encoding='utf-8') as file:
+                    with open(fname, encoding='utf-8') as file:
                         footer_template_data = file.read() + '\n'
                 except (IOError, OSError) as err:
                     self.warn('error reading file {}: {}'.format(fname, err))
@@ -902,7 +901,7 @@ class ConfluenceBuilder(Builder):
         # generate/replace the document in the output directory
         fname = path.join(self.outdir, docname + self.file_suffix)
         try:
-            with io.open(fname, 'w', encoding='utf-8') as f:
+            with open(fname, 'w', encoding='utf-8') as f:
                 f.write(self._cached_header_data)
                 generator(self, docname, f)
                 f.write(self._cached_footer_data)

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -973,7 +973,7 @@ class ConfluenceBuilder(Builder):
                 else:
                     # unsupported source type should not pass here after this
                     # extension's configuration check
-                    assert False
+                    raise AssertionError('unsupported source type')
 
                 sourcelink['url'] = url_base + url
 

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -57,10 +57,10 @@ class ConfluenceBuilder(Builder):
         # assigned.
         if sphinx_version_info >= (5, 1):
             # pylint: disable=too-many-function-args
-            super(ConfluenceBuilder, self).__init__(app, env)
+            super().__init__(app, env)
             # pylint: enable=too-many-function-args
         else:
-            super(ConfluenceBuilder, self).__init__(app)
+            super().__init__(app)
 
         self.cache_doctrees = {}
         self.cloud = False

--- a/sphinxcontrib/confluencebuilder/cmd/build.py
+++ b/sphinxcontrib/confluencebuilder/cmd/build.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright 2020-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 
+from contextlib import suppress
 from sphinx.application import Sphinx
 from sphinx.util.docutils import docutils_namespace
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
@@ -51,10 +52,8 @@ def build_main(args_parser):
 
     verbosity = 0
     if args.verbose:
-        try:
+        with suppress(ValueError):
             verbosity = int(args.verbose)
-        except ValueError:
-            pass
 
     # run sphinx engine
     with docutils_namespace():

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -187,7 +187,7 @@ def report_main(args_parser):
                 else:
                     logger.error('bad response from server ({})'.format(
                         rsp.status_code))
-                    info += '   fetched: error ({})\n'.format(rsp.status_code)
+                    info += f'   fetched: error ({rsp.status_code})\n'
                     rv = 1
             except Exception:
                 sys.stdout.flush()
@@ -279,7 +279,7 @@ def report_main(args_parser):
     print('(configuration)')
     if config:
         for k, v in OrderedDict(sorted(config.items())).items():
-            print('{}: {}'.format(k, v))
+            print(f'{k}: {v}')
     else:
         print('~default configuration~')
 

--- a/sphinxcontrib/confluencebuilder/config/__init__.py
+++ b/sphinxcontrib/confluencebuilder/config/__init__.py
@@ -50,9 +50,9 @@ def process_ask_configs(config):
         default_user = config.confluence_server_user
         u_str = ''
         if default_user:
-            u_str = ' [{}]'.format(default_user)
+            u_str = f' [{default_user}]'
 
-        target_user = input(' User{}: '.format(u_str)) or default_user
+        target_user = input(f' User{u_str}: ') or default_user
         if not target_user:
             raise ConfluenceConfigurationError('no user provided')
 

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -45,7 +45,7 @@ def deprecated(validator):
     # inform users of a deprecated configuration being used
     for key, msg in DEPRECATED_CONFIGS.items():
         if config[key] is not None:
-            logger.warn('%s deprecated; %s' % (key, msg))
+            logger.warn(f'{key} deprecated; {msg}')
 
 
 def warnings(validator):

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -163,7 +163,7 @@ class ConfigurationValidation:
                             os.path.join(self.env.srcdir, docname + suffix))
                         for suffix in self.config.source_suffix):
                     raise ConfluenceConfigurationError(
-                        '%s is missing document %s' % (self.key, docname))
+                        f'{self.key} is missing document {docname}')
 
         return self
 
@@ -198,7 +198,7 @@ class ConfigurationValidation:
                             os.path.join(self.env.srcdir, docname + suffix))
                         for suffix in self.config.source_suffix):
                     raise ConfluenceConfigurationError(
-                        '%s is missing document %s' % (self.key, docname))
+                        f'{self.key} is missing document {docname}')
 
         return self
 

--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -11,7 +11,7 @@ class ConfluenceError(SphinxError):
 
 class ConfluenceAuthenticationFailedUrlError(ConfluenceError):
     def __init__(self):
-        super(ConfluenceAuthenticationFailedUrlError, self).__init__('''
+        super().__init__('''
 ---
 Unable to authenticate with Confluence
 
@@ -25,7 +25,7 @@ browser or asking an administrator of the Confluence instance for help.
 
 class ConfluenceBadApiError(ConfluenceError):
     def __init__(self, code, details):
-        super(ConfluenceBadApiError, self).__init__('''
+        super().__init__('''
 ---
 Unsupported Confluence API call
 
@@ -43,7 +43,7 @@ class ConfluenceBadSpaceError(ConfluenceError):
         uname_value = uname if uname else '(empty)'
         pw_value = '<set>' if pw_set else '(empty)'
         token_value = '<set>' if token_set else '(empty)'
-        super(ConfluenceBadSpaceError, self).__init__('''
+        super().__init__('''
 ---
 Invalid Confluence URL detected
 
@@ -66,7 +66,7 @@ Note: Confluence space keys are case-sensitive.{details}
 
 class ConfluenceBadServerUrlError(ConfluenceError):
     def __init__(self, server_url, ex):
-        super(ConfluenceBadServerUrlError, self).__init__('''
+        super().__init__('''
 ---
 Invalid Confluence URL detected
 
@@ -83,7 +83,7 @@ inspect that the configured Confluence URL is valid:
 
 class ConfluenceCertificateError(ConfluenceError):
     def __init__(self, ex):
-        super(ConfluenceCertificateError, self).__init__('''
+        super().__init__('''
 ---
 SSL certificate issue
 
@@ -101,7 +101,7 @@ class ConfluenceConfigurationError(ConfluenceError, ConfigError):
 
 class ConfluenceMissingPageIdError(ConfluenceError):
     def __init__(self, space_key, page_id):
-        super(ConfluenceMissingPageIdError, self).__init__('''
+        super().__init__('''
 ---
 Unable to find a requested page
 
@@ -117,7 +117,7 @@ as the identifier could not be found.
 
 class ConfluencePermissionError(ConfluenceError):
     def __init__(self, details):
-        super(ConfluencePermissionError, self).__init__('''
+        super().__init__('''
 ---
 Permission denied on Confluence ({desc})
 
@@ -130,7 +130,7 @@ using a personal access token, ensure the token is not expired/revoked.
 
 class ConfluenceProxyPermissionError(ConfluenceError):
     def __init__(self):
-        super(ConfluenceProxyPermissionError, self).__init__('''
+        super().__init__('''
 ---
 Unable to authenticate with the proxy server
 
@@ -148,7 +148,7 @@ class ConfluencePublishCheckError(ConfluenceError):
 
 class ConfluencePublishAncestorError(ConfluencePublishCheckError):
     def __init__(self, page_name):
-        super(ConfluencePublishAncestorError, self).__init__('''
+        super().__init__('''
 ---
 Ancestor publish check failed for: {name}
 
@@ -177,7 +177,7 @@ please inform the maintainers of this extension.
 
 class ConfluencePublishSelfAncestorError(ConfluencePublishCheckError):
     def __init__(self, page_name):
-        super(ConfluencePublishSelfAncestorError, self).__init__('''
+        super().__init__('''
 ---
 Ancestor (self) publish check failed for: {name}
 
@@ -198,7 +198,7 @@ please inform the maintainers of this extension.
 
 class ConfluenceRateLimited(ConfluenceError):
     def __init__(self):
-        super(ConfluenceRateLimited, self).__init__('''
+        super().__init__('''
 ---
 Request has been rate limited
 
@@ -211,7 +211,7 @@ requests to make at this time.
 
 class ConfluenceSeraphAuthenticationFailedUrlError(ConfluenceError):
     def __init__(self):
-        super(ConfluenceSeraphAuthenticationFailedUrlError, self).__init__('''
+        super().__init__('''
 ---
 Unable to authenticate with the Confluence instance (Seraph)
 
@@ -226,7 +226,7 @@ Confluence instance for help.
 
 class ConfluenceSslError(ConfluenceError):
     def __init__(self, server_url, ex):
-        super(ConfluenceSslError, self).__init__('''
+        super().__init__('''
 ---
 SSL connection issue has been detected
 
@@ -249,7 +249,7 @@ option.
 
 class ConfluenceTimeoutError(ConfluenceError):
     def __init__(self, server_url):
-        super(ConfluenceTimeoutError, self).__init__('''
+        super().__init__('''
 ---
 Connection has timed out
 
@@ -265,7 +265,7 @@ configured Confluence URL is valid:
 
 class ConfluenceUnreconciledPageError(ConfluenceError):
     def __init__(self, page_name, page_id, url, ex):
-        super(ConfluenceUnreconciledPageError, self).__init__('''
+        super().__init__('''
 ---
 Unable to update unreconciled page: {name} (id: {id})
 

--- a/sphinxcontrib/confluencebuilder/intersphinx.py
+++ b/sphinxcontrib/confluencebuilder/intersphinx.py
@@ -36,9 +36,9 @@ def build_intersphinx(builder):
         # header
         f.write((
             '# Sphinx inventory version 2\n'
-            '# Project: %s\n'
-            '# Version: %s\n'
-            '# The remainder of this file is compressed using zlib.\n' % (
+            '# Project: {}\n'
+            '# Version: {}\n'
+            '# The remainder of this file is compressed using zlib.\n'.format(
                 escape(builder.env.config.project),
                 escape(builder.env.config.version))).encode())
 
@@ -53,7 +53,7 @@ def build_intersphinx(builder):
                 if not page_id:
                     continue
 
-                target_name = '{}#{}'.format(docname, raw_anchor)
+                target_name = f'{docname}#{raw_anchor}'
                 target = builder.state.target(target_name)
 
                 if raw_anchor and target:

--- a/sphinxcontrib/confluencebuilder/intersphinx.py
+++ b/sphinxcontrib/confluencebuilder/intersphinx.py
@@ -64,7 +64,7 @@ def build_intersphinx(builder):
                     # confluence will convert quotes to right-quotes for
                     # anchor values; replace and encode the anchor value
                     anchor = anchor.replace('"', '”')
-                    anchor = anchor.replace("'", '’')
+                    anchor = anchor.replace("'", '’')  # noqa: RUF001
                     anchor = requests.utils.quote(anchor.encode('utf-8'))
                 else:
                     anchor = ''

--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -118,8 +118,8 @@ class ConfluenceLogger:
         """
         try:
             with open('trace.log', 'a', encoding='utf-8') as file:
-                file.write(u'[%s]\n' % container)
+                file.write('[%s]\n' % container)
                 file.write(data)
-                file.write(u'\n')
+                file.write('\n')
         except (IOError, OSError) as err:
             ConfluenceLogger.warn('unable to trace: %s' % err)

--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -2,6 +2,7 @@
 # Copyright 2017-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 
 from collections import deque
+from contextlib import suppress
 from sphinx.util import logging
 from sphinx.util.console import bold  # pylint: disable=no-name-in-module
 import io
@@ -41,10 +42,10 @@ class ConfluenceLogger:
                     self.verbosity = 0
                     self.warningiserror = False
                     self._warncount = 0
-            try:
+
+            # fail silently if mocked application is missing something
+            with suppress(Exception):
                 logging.setup(MockSphinx(), sys.stdout, sys.stderr)
-            except Exception:
-                pass  # fail silently if mocked application is missing something
 
     @staticmethod
     def error(msg, *args, **kwargs):

--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -5,7 +5,6 @@ from collections import deque
 from contextlib import suppress
 from sphinx.util import logging
 from sphinx.util.console import bold  # pylint: disable=no-name-in-module
-import io
 import sys
 
 
@@ -118,7 +117,7 @@ class ConfluenceLogger:
         This is solely for manually debugging unexpected scenarios.
         """
         try:
-            with io.open('trace.log', 'a', encoding='utf-8') as file:
+            with open('trace.log', 'a', encoding='utf-8') as file:
                 file.write(u'[%s]\n' % container)
                 file.write(data)
                 file.write(u'\n')

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -66,7 +66,7 @@ class ConfluencePublisher:
         try:
             rsp = self.rest_client.get('space', {
                 'spaceKey': self.space_key,
-                'limit': 1
+                'limit': 1,
             })
         except ConfluenceBadApiError as e:
             raise ConfluenceBadServerUrlError(server_url, e)
@@ -258,7 +258,7 @@ reported a success (which can be permitted for anonymous users).
             'type': 'page',
             'spaceKey': self.space_key,
             'title': self.parent_ref,
-            'status': 'current'
+            'status': 'current',
         })
         if rsp['size'] == 0:
             raise ConfluenceConfigurationError(
@@ -923,7 +923,7 @@ reported a success (which can be permitted for anonymous users).
                 'storage': {
                     'representation': 'storage',
                     'value': data['content'],
-                }
+                },
             },
             'metadata': {
                 'properties': {},

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -173,7 +173,7 @@ reported a success (which can be permitted for anonymous users).
             while attempt <= MAX_WAIT_FOR_PAGE_ARCHIVE:
                 time.sleep(0.5)
 
-                rsp = self.rest_client.get('longtask/{}'.format(longtask_id))
+                rsp = self.rest_client.get(f'longtask/{longtask_id}')
                 if rsp['finished']:
                     break
 
@@ -370,7 +370,7 @@ reported a success (which can be permitted for anonymous users).
         attachment = None
         attachment_id = None
 
-        url = 'content/{}/child/attachment'.format(page_id)
+        url = f'content/{page_id}/child/attachment'
         rsp = self.rest_client.get(url, {
             'filename': name,
         })
@@ -397,7 +397,7 @@ reported a success (which can be permitted for anonymous users).
         """
         attachment_info = {}
 
-        url = 'content/{}/child/attachment'.format(page_id)
+        url = f'content/{page_id}/child/attachment'
         search_fields = {}
 
         # Configure a larger limit value than the default (no provided
@@ -474,7 +474,7 @@ reported a success (which can be permitted for anonymous users).
             the page id and page object
         """
 
-        page = self.rest_client.get('content/{}'.format(page_id), {
+        page = self.rest_client.get(f'content/{page_id}', {
             'status': 'current',
             'expand': expand,
         })
@@ -589,7 +589,7 @@ reported a success (which can be permitted for anonymous users).
         try:
             # split hash comment into chunks to minimize rendering issues with a
             # single one-world-long-hash value
-            hash_ = '{}:{}'.format(HASH_KEY, hash_)
+            hash_ = f'{HASH_KEY}:{hash_}'
             chunked_hash = '\n'.join(
                 [hash_[i:i + 16] for i in range(0, len(hash_), 16)])
 
@@ -603,7 +603,7 @@ reported a success (which can be permitted for anonymous users).
                 data['minorEdit'] = 'true'
 
             if not attachment:
-                url = 'content/{}/child/attachment'.format(page_id)
+                url = f'content/{page_id}/child/attachment'
                 rsp = self.rest_client.post(url, None, files=data)
                 uploaded_attachment_id = rsp['results'][0]['id']
             else:
@@ -711,7 +711,7 @@ reported a success (which can be permitted for anonymous users).
                     # initial labels need to be applied in their own request
                     labels = new_page['metadata']['labels']
                     if not self.cloud and labels:
-                        url = 'content/{}/label'.format(uploaded_page_id)
+                        url = f'content/{uploaded_page_id}/label'
                         self.rest_client.post(url, labels)
 
                 except ConfluenceBadApiError as ex:
@@ -1064,7 +1064,7 @@ reported a success (which can be permitted for anonymous users).
         if id_ and id_ in self._name_cache:
             s += ' ' + self._name_cache[id_]
         if id_:
-            s += ' ({})'.format(id_)
+            s += f' ({id_})'
         if misc:
             s += ' ' + misc
         logger.info(s + min(80, 80 - len(s)) * ' ')  # 80c-min clearing
@@ -1086,7 +1086,7 @@ reported a success (which can be permitted for anonymous users).
         if id_ and id_ in self._name_cache:
             s += ' ' + self._name_cache[id_]
         if id_:
-            s += ' ({})'.format(id_)
+            s += f' ({id_})'
         logger.info(s + min(80, 80 - len(s)) * ' ')  # 80c-min clearing
 
     def _populate_labels(self, page, labels):

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -38,7 +38,7 @@ RATE_LIMITED_MAX_RETRY_DURATION = 30
 class SslAdapter(HTTPAdapter):
     def __init__(self, config, *args, **kwargs):
         self._config = config
-        super(SslAdapter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def init_poolmanager(self, *args, **kwargs):
         context = ssl.create_default_context()
@@ -60,10 +60,10 @@ class SslAdapter(HTTPAdapter):
             context.check_hostname = False
 
         kwargs['ssl_context'] = context
-        return super(SslAdapter, self).init_poolmanager(*args, **kwargs)
+        return super().init_poolmanager(*args, **kwargs)
 
     def cert_verify(self, conn, url, verify, *args, **kwargs):
-        super(SslAdapter, self).cert_verify(conn, url, verify, *args, **kwargs)
+        super().cert_verify(conn, url, verify, *args, **kwargs)
 
         # prevent requests from injected an embedded certificates to instead
         # rely on the default certificate stores loaded by the context

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -218,7 +218,7 @@ class Rest(object):
         elif config.confluence_server_user:
             passwd = config.confluence_server_pass
             if passwd is None:
-                passwd = ''
+                passwd = ''  # noqa: S105
             session.auth = (config.confluence_server_user, passwd)
 
         if config.confluence_server_cookies:

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -326,12 +326,12 @@ class Rest:
 
     def _format_error(self, rsp, key):
         err = ""
-        err += "REQ: {0}\n".format(rsp.request.method)
+        err += f"REQ: {rsp.request.method}\n"
         err += "RSP: " + str(rsp.status_code) + "\n"
         err += "URL: " + self.url + self.bind_path + "\n"
         err += "API: " + key + "\n"
         try:
-            err += 'DATA: {}'.format(json.dumps(rsp.json(), indent=2))
+            err += f'DATA: {json.dumps(rsp.json(), indent=2)}'
         except:  # noqa: E722
             err += 'DATA: <not-or-invalid-json>'
         return err

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -159,7 +159,7 @@ def requests_exception_wrappers():
     return _decorator
 
 
-class Rest(object):
+class Rest:
     CONFLUENCE_DEFAULT_ENCODING = 'utf-8'
 
     def __init__(self, config):

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -33,7 +33,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
 
         for docname, secnums in self.env.toc_secnumbers.items():
             for id_, secnum in secnums.items():
-                alias = '{}/{}'.format(docname, id_)
+                alias = f'{docname}/{id_}'
                 new_secnumbers[alias] = secnum
 
         return {self.config.root_doc: new_secnumbers}
@@ -43,7 +43,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
 
         for docname, fignumlist in self.env.toc_fignumbers.items():
             for figtype, fignums in fignumlist.items():
-                alias = '{}/{}'.format(docname, figtype)
+                alias = f'{docname}/{figtype}'
                 new_fignumbers.setdefault(alias, {})
 
                 for id_, fignum in fignums.items():
@@ -215,7 +215,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
                     for id_ in section_node['ids']:
                         target = title_name
 
-                        anchorname = '%s/#%s' % (docname, id_)
+                        anchorname = f'{docname}/#{id_}'
                         if anchorname not in secnumbers:
                             anchorname = '%s/' % id_
 
@@ -228,7 +228,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
                         section_id = doc_used_names.get(target, 0)
                         doc_used_names[target] = section_id + 1
                         if section_id > 0:
-                            target = '{}.{}'.format(target, section_id)
+                            target = f'{target}.{section_id}'
 
                         self.state.register_target(anchorname, target)
 

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -241,4 +241,4 @@ class ConfluenceState:
         prehash += str(config.project)
         prehash += str(config.confluence_parent_page)
         prehash += str(config.confluence_publish_root)
-        return hashlib.sha1(prehash.encode()).hexdigest()
+        return hashlib.sha1(prehash.encode()).hexdigest()  # noqa: S324

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -83,7 +83,7 @@ class ConfluenceState:
 
             postfix = ConfluenceState._format_postfix(
                 postfix=config.confluence_publish_postfix, docname=docname,
-                config=config
+                config=config,
             )
 
         if prefix:

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -38,8 +38,7 @@ class ConfluenceState:
         [1]: http://www.sphinx-doc.org/en/stable/markup/toctree.html#directive-toctree
         """
         ConfluenceState.doc2parentDoc[docname] = parent_docname
-        logger.verbose(
-            'setting parent of %s to: %s' % (docname, parent_docname))
+        logger.verbose(f'setting parent of {docname} to: {parent_docname}')
 
     @staticmethod
     def register_target(refid, target):
@@ -55,7 +54,7 @@ class ConfluenceState:
         writer can properly prepare a link; see also `target`).
         """
         ConfluenceState.refid2target[refid] = target
-        logger.verbose('mapping %s to target: %s' % (refid, target))
+        logger.verbose(f'mapping {refid} to target: {target}')
 
     @staticmethod
     def register_title(docname, title, config):
@@ -110,7 +109,7 @@ class ConfluenceState:
                     "'{}' and '{}'".format(
                         ConfluenceState.title2doc[title.lower()], docname))
 
-            tail = ' ({}){}'.format(offset, base_tail)
+            tail = f' ({offset}){base_tail}'
             if len(base_title) + len(tail) > try_max:
                 base_title = base_title[0:(try_max - len(tail))]
 
@@ -119,7 +118,7 @@ class ConfluenceState:
 
         ConfluenceState.doc2title[docname] = title
         ConfluenceState.title2doc[title.lower()] = docname
-        logger.verbose('mapping %s to title: %s' % (docname, title))
+        logger.verbose(f'mapping {docname} to title: {title}')
         return title
 
     @staticmethod
@@ -135,7 +134,7 @@ class ConfluenceState:
         [1]: http://www.sphinx-doc.org/en/stable/markup/toctree.html#id3
         """
         ConfluenceState.doc2ttd[docname] = depth
-        logger.verbose('track %s toc-depth: %s' % (docname, depth))
+        logger.verbose(f'track {docname} toc-depth: {depth}')
 
     @staticmethod
     def register_upload_id(docname, id_):
@@ -152,7 +151,8 @@ class ConfluenceState:
         tracked in this state (see also `uploadId`).
         """
         ConfluenceState.doc2uploadId[docname] = id_
-        logger.verbose("tracking docname %s's upload id: %s" % (docname, id_))
+        logger.verbose(
+            f"tracking docname {docname}'s upload id: {id_}")
 
     @staticmethod
     def reset():

--- a/sphinxcontrib/confluencebuilder/storage/__init__.py
+++ b/sphinxcontrib/confluencebuilder/storage/__init__.py
@@ -55,7 +55,7 @@ def intern_uri_anchor_value(docname, refuri):
     anchor_value = None
     if '#' in refuri:
         anchor = refuri.split('#')[1]
-        target_name = '{}#{}'.format(docname, anchor)
+        target_name = f'{docname}#{anchor}'
 
         # check if this target is reachable without an anchor; if so, use
         # the identifier value instead

--- a/sphinxcontrib/confluencebuilder/storage/index.py
+++ b/sphinxcontrib/confluencebuilder/storage/index.py
@@ -32,12 +32,12 @@ def generate_storage_format_domainindex(builder, docname, f):
     for key, entries in content:
         for (i, entry) in enumerate(entries):
             if isinstance(entry, list):
-                refuri = '{}#{}'.format(entry[2], entry[3])
+                refuri = f'{entry[2]}#{entry[3]}'
                 doctitle, anchor_value = process_doclink(builder.config, refuri)
                 entry[2] = doctitle
                 entry[3] = anchor_value
             else:
-                refuri = '{}#{}'.format(entry.docname, entry.anchor)
+                refuri = f'{entry.docname}#{entry.anchor}'
                 doctitle, anchor_value = process_doclink(builder.config, refuri)
                 entries[i] = entries[i]._replace(
                     docname=doctitle, anchor=anchor_value)

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -78,7 +78,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if self.builder.name == 'singleconfluence':
                 docname = self._docnames[-1]
                 raw_anchor = node.parent['ids'][0]
-                anchorname = '%s/#%s' % (docname, node.parent['ids'][0])
+                anchorname = '{}/#{}'.format(docname, node.parent['ids'][0])
                 if anchorname not in self.builder.secnumbers:
                     anchorname = '%s/' % raw_anchor
             else:
@@ -115,7 +115,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             return ''
 
         if self.builder.name == 'singleconfluence':
-            key = '%s/%s' % (self._docnames[-1], figtype)
+            key = f'{self._docnames[-1]}/{figtype}'
         else:
             key = figtype
 
@@ -159,7 +159,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     def visit_title(self, node):
         if isinstance(node.parent, (nodes.section, nodes.topic)):
             self.body.append(
-                self._start_tag(node, 'h{}'.format(self._title_level)))
+                self._start_tag(node, f'h{self._title_level}'))
 
             # generate anchors inside headers for v2, to avoid extra
             # spacing from an anchor macro
@@ -308,7 +308,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         if isinstance(node.parent, nodes.list_item):
             try:
                 if node.parent.__confluence_list_item_margin:
-                    attribs['style'] = 'margin-top: {}px;'.format(FCMMO)
+                    attribs['style'] = f'margin-top: {FCMMO}px;'
             except AttributeError:
                 pass
 
@@ -383,7 +383,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         attribs = {}
         try:
             if node.__confluence_list_item_margin:
-                attribs['style'] = 'margin-top: {}px;'.format(FCMMO)
+                attribs['style'] = f'margin-top: {FCMMO}px;'
         except AttributeError:
             pass
 
@@ -788,7 +788,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             # Confluence's WYSIWYG, when indenting paragraphs, will produce
             # paragraphs will margin values offset by 30 pixels units. The same
             # indentation is applied here via a style value.
-            style += 'margin-left: {}px;'.format(INDENT)
+            style += f'margin-left: {INDENT}px;'
 
             # Confluence's provided styles remove first-child elements leading
             # margins. This causes some unexpected styling issues when various
@@ -825,7 +825,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 firstchild_margin = False
 
             if firstchild_margin:
-                style += 'padding-top: {}px;'.format(FCMMO)
+                style += f'padding-top: {FCMMO}px;'
 
             self.body.append(self._start_tag(node, 'div', suffix=self.nl,
                 **{'style': style}))
@@ -1157,11 +1157,11 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         if self.builder.name == 'singleconfluence':
             docname = self._docnames[-1]
-            anchorname = '%s/#%s' % (docname, raw_anchor)
+            anchorname = f'{docname}/#{raw_anchor}'
             if anchorname not in self.builder.secnumbers:
                 anchorname = '%s/' % raw_anchor
         else:
-            anchorname = '{}#{}'.format(self.docname, raw_anchor)
+            anchorname = f'{self.docname}#{raw_anchor}'
 
         # check if this target is reachable without an anchor; if so, use the
         # identifier value instead
@@ -1300,7 +1300,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
             # only build an anchor if required (e.g. is a reference label
             # already provided by a build section element)
-            target_name = '{}#{}'.format(self.docname, anchor)
+            target_name = f'{self.docname}#{anchor}'
             target = self.state.target(target_name)
             if not target:
                 self.body.append(self._start_ac_macro(node, 'anchor'))
@@ -1417,7 +1417,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self._building_footnotes = False
 
     def visit_footnote_reference(self, node):
-        text = "[{}]".format(node.astext())
+        text = f"[{node.astext()}]"
 
         # build an anchor for back reference
         self.body.append(self._start_ac_macro(node, 'anchor'))
@@ -1591,7 +1591,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if self.builder.config.math_numfig and self.builder.config.numfig:
                 figtype = 'displaymath'
                 if self.builder.name == 'singleconfluence':
-                    key = '%s/%s' % (self._docnames[-1], figtype)
+                    key = f'{self._docnames[-1]}/{figtype}'
                 else:
                     key = figtype
 
@@ -1604,7 +1604,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         if not self.v2 and node.math_number:
             self.body.append(self._start_tag(node, 'div',
                 **{'style': 'float: right'}))
-            self.body.append('({})'.format(node.math_number))
+            self.body.append(f'({node.math_number})')
             self.body.append(self._end_tag(node))
 
         attribs = {}
@@ -1627,12 +1627,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             style = 'display: inline-block;'
 
             if hu == '%':
-                style += 'height: {}%;'.format(height)
+                style += f'height: {height}%;'
                 height = None
                 hu = None
 
             if wu == '%':
-                style += 'width: {}%;'.format(width)
+                style += f'width: {width}%;'
                 width = None
                 wu = None
 
@@ -1718,7 +1718,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
             self.body.append(self._start_tag(node, 'p',
                 **{'style': 'text-align: right'}))
-            self.body.append('({})'.format(node.math_number))
+            self.body.append(f'({node.math_number})')
             self.body.append(self._end_tag(node))
 
             self.body.append(self._end_tag(node))  # layout-cell
@@ -1729,7 +1729,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         attribs = {}
         alignment = self._fetch_alignment(node)
         if alignment and alignment != 'left':
-            attribs['style'] = 'text-align: {};'.format(alignment)
+            attribs['style'] = f'text-align: {alignment};'
 
         self.body.append(self._start_tag(node, 'div', **attribs))
         self.context.append(self._end_tag(node))
@@ -1916,7 +1916,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if production['tokenname']:
                 formatted_token = production['tokenname'].ljust(max_len)
                 formatted_token = self.encode(formatted_token)
-                self.body.append('{} ::='.format(formatted_token))
+                self.body.append(f'{formatted_token} ::=')
                 lastname = production['tokenname']
             else:
                 self.body.append('{}    '.format(' ' * len(lastname)))
@@ -2385,7 +2385,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if self.builder.config.math_numfig and self.builder.config.numfig:
                 figtype = 'displaymath'
                 if self.builder.name == 'singleconfluence':
-                    key = '%s/%s' % (self._docnames[-1], figtype)
+                    key = f'{self._docnames[-1]}/{figtype}'
                 else:
                     key = figtype
 
@@ -2397,7 +2397,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
             self.body.append(self._start_tag(node, 'div',
                 **{'style': 'float: right'}))
-            self.body.append('({})'.format(number))
+            self.body.append(f'({number})')
             self.body.append(self._end_tag(node))
 
         self.body.append(self._start_ac_macro(node, macro))
@@ -2606,7 +2606,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         attribs = {}
         alignment = self._fetch_alignment(node)
         if alignment and alignment != 'left':
-            attribs['style'] = 'text-align: {};'.format(alignment)
+            attribs['style'] = f'text-align: {alignment};'
 
         ri_url = self._start_tag(
             node, 'ri:url', empty=True, **{'ri:value': self.encode(uri)})
@@ -2681,7 +2681,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             # parent is not a line-block, add some separation from a previous
             # sibling element
             if node.parent[0] != node and not isinstance(node.parent, nodes.line_block):
-                style += 'padding-top: {}px;'.format(FCMMO)
+                style += f'padding-top: {FCMMO}px;'
 
         # indent this line-block if its not the first element in the parent
         # (excluding titles for a new section), or if the parent is
@@ -2697,7 +2697,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if self.v2:
                 indent = INDENT * (self._indent_level + 1)
 
-            style += 'margin-left: {}px;'.format(indent)
+            style += f'margin-left: {indent}px;'
         elif self.v2:
             # (see "visit_paragraph")
             style += 'margin-left: {}px;'.format(INDENT * self._indent_level)
@@ -2764,7 +2764,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             attribs[key.lower()] = value
 
         for key, value in sorted(attribs.items()):
-            data.append('{}="{}"'.format(key, value))
+            data.append(f'{key}="{value}"')
 
         if suffix is None:
             suffix = ''
@@ -2804,7 +2804,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         if suffix is None:
             suffix = self.nl
 
-        return '</{}>{}'.format(tag, suffix)
+        return f'</{tag}>{suffix}'
 
     def _build_ac_param(self, node, name, value):
         """

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1843,7 +1843,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     def depart_hlist(self, node):
         if self.v2:
             # add empty sections to complete the three column requirement
-            for x in range(self._hlist_columns_left % 3):
+            for _ in range(self._hlist_columns_left % 3):
                 self.body.append(self._start_tag(node, 'ac:layout-cell'))
                 self.body.append(self._end_tag(node))
 

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2,6 +2,7 @@
 # Copyright 2016-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 # Copyright 2018-2020 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 
+from contextlib import suppress
 from docutils import nodes
 from os import path
 from sphinx import addnodes
@@ -709,10 +710,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         firstline = None
         if num == 'true':
-            try:
+            with suppress(KeyError):
                 firstline = node.attributes['highlight_args']['linenostart']
-            except KeyError:
-                pass
 
         self.body.append(self._start_ac_macro(node, 'code'))
         self.body.append(self._build_ac_param(node, 'language', lang))

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -222,9 +222,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         # attribute; if set, attempt to apply the style
         if isinstance(node.parent, nodes.entry):
             for class_ in node.parent.get('classes', []):
-                if 'text-center' == class_:
+                if class_ == 'text-center':
                     style += 'text-align: center;'
-                elif 'text-right' == class_:
+                elif class_ == 'text-right':
                     style += 'text-align: right;'
                 # (legacy)
                 elif class_.startswith('text-align:'):

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2283,12 +2283,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             # v2: does not support font-size assignment; use sup tag
             # to make small
             self.body.append(self._start_tag(node, 'span', **{
-                'style': 'color: #707070;'
+                'style': 'color: #707070;',
             }))
             self.body.append(self._start_tag(node, 'sup'))
         else:
             self.body.append(self._start_tag(node, 'div', **{
-                'style': 'color: #707070; font-size: 12px;'
+                'style': 'color: #707070; font-size: 12px;',
             }))
 
         self.body.append(self.encode(

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -687,7 +687,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             lang = node.get('language', self._highlight).lower()
         if self.builder.lang_transform:
             lang = self.builder.lang_transform(lang)
-        elif lang in lang_map.keys():
+        elif lang in lang_map:
             lang = lang_map[lang]
         else:
             if lang not in self._tracked_unknown_code_lang:

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -15,7 +15,6 @@ from sphinxcontrib.confluencebuilder.svg import confluence_supported_svg
 from sphinxcontrib.confluencebuilder.util import convert_length
 from sphinxcontrib.confluencebuilder.util import extract_length
 from sphinxcontrib.confluencebuilder.util import remove_nonspace_control_chars
-import io
 import sys
 
 
@@ -92,7 +91,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
             header_file = path.join(self.builder.env.srcdir,
                 self.builder.config.confluence_header_file)
             try:
-                with io.open(header_file, encoding='utf-8') as file:
+                with open(header_file, encoding='utf-8') as file:
                     header_template_data = file.read()
             except (IOError, OSError) as err:
                 self.warn('error reading file {}: {}'.format(header_file, err))
@@ -115,7 +114,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
             footer_file = path.join(self.builder.env.srcdir,
                 self.builder.config.confluence_footer_file)
             try:
-                with io.open(footer_file, encoding='utf-8') as file:
+                with open(footer_file, encoding='utf-8') as file:
                     footer_template_data = file.read()
             except (IOError, OSError) as err:
                 self.warn('error reading file {}: {}'.format(footer_file, err))

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -94,7 +94,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
                 with open(header_file, encoding='utf-8') as file:
                     header_template_data = file.read()
             except (IOError, OSError) as err:
-                self.warn('error reading file {}: {}'.format(header_file, err))
+                self.warn(f'error reading file {header_file}: {err}')
 
             # if no data is supplied, the file is plain text
             if self.builder.config.confluence_header_data is None:
@@ -117,7 +117,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
                 with open(footer_file, encoding='utf-8') as file:
                     footer_template_data = file.read()
             except (IOError, OSError) as err:
-                self.warn('error reading file {}: {}'.format(footer_file, err))
+                self.warn(f'error reading file {footer_file}: {err}')
 
             # if no data is supplied, the file is plain text
             if self.builder.config.confluence_footer_data is None:
@@ -141,7 +141,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
         node_name = node.__class__.__name__
         ignore_nodes = self.builder.config.confluence_adv_ignore_nodes
         if node_name in ignore_nodes:
-            self.verbose('ignore node {} (conf)'.format(node_name))
+            self.verbose(f'ignore node {node_name} (conf)')
             raise nodes.SkipNode
 
         # allow users to override unknown nodes

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -319,7 +319,7 @@ def replace_math_blocks(builder, doctree):
             if node['nowrap']:
                 latex = node.astext()
             else:
-                latex = wrap_displaymath(node.astext(), None, False)
+                latex = wrap_displaymath(node.astext(), None, numbering=False)
             new_node_type = confluence_latex_block
         else:
             latex = '$' + node.astext() + '$'

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -289,7 +289,7 @@ def replace_inheritance_diagram(builder, doctree):
                 new_node['align'] = node['align']
             node.replace_self(new_node)
         except GraphvizError as exc:
-            ConfluenceLogger.warn('dot code {}: {}'.format(dotcode, exc))
+            ConfluenceLogger.warn(f'dot code {dotcode}: {exc}')
             node.parent.remove(node)
 
 

--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
@@ -95,9 +95,9 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
                 break
 
             if isinstance(node, sphinx_toolbox_IssueNodeWithName):
-                title = '{}#{}'.format(node.repo_name, node.issue_number)
+                title = f'{node.repo_name}#{node.issue_number}'
             else:
-                title = '#{}'.format(node.issue_number)
+                title = f'#{node.issue_number}'
 
             new_node = nodes.reference(title, title, refuri=node.issue_url)
             node.replace_self(new_node)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -80,7 +80,7 @@ def main():
         print('running specific test(s) (total: {})'.format(
             len(target_unit_tests)))
         for target_unit_test in target_unit_tests:
-            print(' {}'.format(target_unit_test.id()))
+            print(f' {target_unit_test.id()}')
         print('')
         sys.stdout.flush()
 
@@ -105,7 +105,7 @@ def find_tests(entity, pattern):
     issued_tests = []
 
     if isinstance(entity, unittest.case.TestCase):
-        if fnmatch.fnmatch(entity.id(), '*{}*'.format(pattern)):
+        if fnmatch.fnmatch(entity.id(), f'*{pattern}*'):
             return [entity], None
 
         failed_test_check = ['LoadTestsFailure', 'ModuleImportFailure']

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -47,7 +47,7 @@ def main():
         enable_sphinx_info(verbosity=verbosity)
     else:
         # disable short descriptions to minimize output (one test per line)
-        unittest.TestCase.shortDescription = lambda x: None
+        unittest.TestCase.shortDescription = lambda _: None
 
     # discover unit tests
     test_base = os.path.dirname(os.path.realpath(__file__))

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -139,7 +139,7 @@ class ConfluenceInstanceServer(server_socket.ThreadingMixIn,
         except IndexError:
             return None
 
-    def register_delete_rsp(self, code,):
+    def register_delete_rsp(self, code):
         """
         register a delete response
 
@@ -375,7 +375,7 @@ def mock_confluence_instance(config=None, ignore_requests=False):
                 sync.set()
                 daemon.serve_forever()
 
-            serve_thread = Thread(target=serve_forever, args=(daemon, sync,))
+            serve_thread = Thread(target=serve_forever, args=(daemon, sync))
             serve_thread.start()
 
             # wait for the serving thread to be running

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -16,7 +16,6 @@ from threading import Thread
 import builtins
 import http.server as http_server
 import inspect
-import io
 import json
 import os
 import shutil
@@ -455,7 +454,7 @@ def parse(filename, dirname=None):
 
     target += '.conf'
 
-    with io.open(target, encoding='utf-8') as fp:
+    with open(target, encoding='utf-8') as fp:
         soup = BeautifulSoup(fp, 'html.parser')
         yield soup
 

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -3,6 +3,7 @@
 
 from bs4 import BeautifulSoup
 from contextlib import contextmanager
+from contextlib import suppress
 from copy import deepcopy
 from sphinx.application import Sphinx
 from sphinx.util.console import color_terminal
@@ -575,10 +576,8 @@ def prepare_sphinx(src_dir, config=None, out_dir=None, extra_config=None,
 
     verbosity = 0
     if 'SPHINX_VERBOSITY' in os.environ:
-        try:
+        with suppress(ValueError):
             verbosity = int(os.environ['SPHINX_VERBOSITY'])
-        except ValueError:
-            pass
 
     # default to using this extension's builder
     if not builder:

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -364,7 +364,7 @@ def mock_confluence_instance(config=None, ignore_requests=False):
 
         host, port = daemon.server_address
         if config:
-            config.confluence_server_url = 'http://{}:{}/'.format(host, port)
+            config.confluence_server_url = f'http://{host}:{port}/'
 
         # start accepting requests
         if not ignore_requests:

--- a/tests/lib/testcase.py
+++ b/tests/lib/testcase.py
@@ -31,7 +31,7 @@ class ConfluenceTestCase(unittest.TestCase):
                 ...
         """
 
-        super(ConfluenceTestCase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.builder = DEFAULT_BUILDER
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -8,7 +8,6 @@ from tests.lib import enable_sphinx_info
 from tests.lib import prepare_dirs
 from tests.lib import prepare_sphinx
 import argparse
-import io
 import os
 import sys
 
@@ -48,7 +47,7 @@ def process_raw_upload(target_sandbox):
                 'labels': [],
             }
 
-            with io.open(raw_file, 'r', encoding='utf-8') as f:
+            with open(raw_file, 'r', encoding='utf-8') as f:
                 data['content'] = f.read()
 
             print('[sandbox] publishing page...')

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -231,7 +231,7 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_cert_pass(self):
-        self.config['confluence_client_cert_pass'] = 'dummy'
+        self.config['confluence_client_cert_pass'] = 'dummy'  # noqa: S105
         self._try_config()
 
     def test_config_check_default_alignment(self):
@@ -754,10 +754,10 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_publish_token(self):
-        self.config['confluence_publish_token'] = ''
+        self.config['confluence_publish_token'] = ''  # noqa: S105
         self._try_config()
 
-        self.config['confluence_publish_token'] = 'dummy'
+        self.config['confluence_publish_token'] = 'dummy'  # noqa: S105
         self._try_config()
 
     def test_config_check_secnumber_suffix(self):
@@ -802,7 +802,7 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_server_pass(self):
-        self.config['confluence_server_pass'] = 'dummy'
+        self.config['confluence_server_pass'] = 'dummy'  # noqa: S105
         self._try_config()
 
         # enable publishing enabled checks

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -640,7 +640,7 @@ class TestConfluenceConfigChecks(unittest.TestCase):
 
             # explicitly force unicode strings to help verify python 2.x series
             # dealing with unicode strings inside the document subset
-            self.config[option] = [u'doc-c']
+            self.config[option] = ['doc-c']
             self._try_config(dataset=dataset)
 
             # file with a valid document list

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -30,7 +30,7 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         # unique configuration each run to avoid copying it in each test
         self.config = prepare_conf()
 
-        super(TestConfluenceConfigChecks, self).run(result)
+        super().run(result)
 
     def _prepare_valid_publish(self):
         self.config['confluence_publish'] = True

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -368,8 +368,8 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_jira_servers'] = {
             'server-1': {
                 'id': '92d94d0e-ac8b-4f2e-92a5-2217ad88e5f2',
-                'name': 'MyAwesomeServer'
-            }
+                'name': 'MyAwesomeServer',
+            },
         }
         self._try_config()
 
@@ -380,20 +380,20 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_jira_servers'] = {
             None: {
                 'id': '92d94d0e-ac8b-4f2e-92a5-2217ad88e5f2',
-                'name': 'MyAwesomeServer'
-            }
+                'name': 'MyAwesomeServer',
+            },
         }
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
         self.config['confluence_jira_servers'] = {
-            'server-1': None
+            'server-1': None,
         }
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
         self.config['confluence_jira_servers'] = {
-            'server-1': {}
+            'server-1': {},
         }
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
@@ -401,15 +401,15 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_jira_servers'] = {
             'server-1': {
                 'id': '92d94d0e-ac8b-4f2e-92a5-2217ad88e5f2',
-            }
+            },
         }
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
         self.config['confluence_jira_servers'] = {
             'server-1': {
-                'name': 'MyAwesomeServer'
-            }
+                'name': 'MyAwesomeServer',
+            },
         }
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
@@ -791,7 +791,7 @@ class TestConfluenceConfigChecks(unittest.TestCase):
 
         self.config['confluence_server_cookies'] = {
             'SESSION_ID': 'b8e536f5-895a-4054-b370-e0c579cb8d6b',
-            'U_ID': 'myusername'
+            'U_ID': 'myusername',
         }
         self._try_config()
 

--- a/tests/unit-tests/test_config_env.py
+++ b/tests/unit-tests/test_config_env.py
@@ -20,7 +20,7 @@ class TestConfluenceConfigEnvironment(unittest.TestCase):
         # ensure environment overrides do not leak between tests
         old_env = dict(os.environ)
         try:
-            super(TestConfluenceConfigEnvironment, self).run(result)
+            super().run(result)
         finally:
             os.environ.clear()
             os.environ.update(old_env)

--- a/tests/unit-tests/test_config_header_footer.py
+++ b/tests/unit-tests/test_config_header_footer.py
@@ -60,10 +60,10 @@ class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
         config['confluence_footer_file'] = '../../templates/sample-footer-with-jinja.tpl'
         config['confluence_header_file'] = '../../templates/sample-header-with-jinja.tpl'
         config['confluence_footer_data'] = {
-            "variable": "footer_value"
+            'variable': 'footer_value',
         }
         config['confluence_header_data'] = {
-            "variable": "header_value"
+            'variable': 'header_value',
         }
 
         out_dir = self.build(self.dataset, config=config)

--- a/tests/unit-tests/test_config_header_footer.py
+++ b/tests/unit-tests/test_config_header_footer.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceConfigHeaderFooter, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'header-footer')
 

--- a/tests/unit-tests/test_config_hierarchy.py
+++ b/tests/unit-tests/test_config_hierarchy.py
@@ -9,7 +9,7 @@ import os
 class TestConfluenceHierarchy(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceHierarchy, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'hierarchy')
 

--- a/tests/unit-tests/test_config_orphan.py
+++ b/tests/unit-tests/test_config_orphan.py
@@ -13,7 +13,7 @@ import os
 class TestConfluenceConfigOrphan(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceConfigOrphan, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'orphan')
 
@@ -25,7 +25,7 @@ class TestConfluenceConfigOrphan(ConfluenceTestCase):
         with patch.object(ConfluencePublisher, 'connect'), \
                 patch.object(ConfluencePublisher, 'disconnect'), \
                 patch.object(ConfluenceBuilder, 'publish_asset'):
-            super(TestConfluenceConfigOrphan, self).run(result)
+            super().run(result)
 
     def test_config_orphan_allow_explicit(self):
         config = dict(self.config)

--- a/tests/unit-tests/test_config_postfix_formatting.py
+++ b/tests/unit-tests/test_config_postfix_formatting.py
@@ -63,7 +63,7 @@ class TestFormatPostfix(ConfluenceTestCase):
         postfix = ConfluenceState._format_postfix(
             postfix=confluence_publish_prefix, docname=test_docname,
             config=config)
-        self.assertEqual(postfix, '- ({hash})'.format(hash=self.test_hash))
+        self.assertEqual(postfix, f'- ({self.test_hash})')
 
     def test_no_placeholders(self):
         test_docname = 'docs/test_file.rst'

--- a/tests/unit-tests/test_config_postfix_formatting.py
+++ b/tests/unit-tests/test_config_postfix_formatting.py
@@ -8,12 +8,7 @@ from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib import parse
 from tests.lib.testcase import setup_builder
-# python2.7 is still supported so unittest will not contain mock so we must
-# catch the import error and import it from the installed module instead
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 class TestCreateDocnameUniqueHash(ConfluenceTestCase):

--- a/tests/unit-tests/test_config_postfix_formatting.py
+++ b/tests/unit-tests/test_config_postfix_formatting.py
@@ -102,7 +102,7 @@ class TestFormatPostfix(ConfluenceTestCase):
 class TestRegisterTitle(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestRegisterTitle, cls).setUpClass()
+        super().setUpClass()
         cls.config['root_doc'] = 'index'
         cls.dataset = os.path.join(cls.datasets, 'postfix_formatting')
 

--- a/tests/unit-tests/test_config_postfix_formatting.py
+++ b/tests/unit-tests/test_config_postfix_formatting.py
@@ -54,7 +54,7 @@ class TestFormatPostfix(ConfluenceTestCase):
         self.create_docname_unique_hash_patch = patch(
             'sphinxcontrib.confluencebuilder.state.ConfluenceState.'
             '_create_docname_unique_hash',
-            return_value=self.test_hash
+            return_value=self.test_hash,
         )
         self.create_docname_unique_hash_patch.start()
 

--- a/tests/unit-tests/test_config_postfix_formatting.py
+++ b/tests/unit-tests/test_config_postfix_formatting.py
@@ -114,7 +114,8 @@ class TestRegisterTitle(ConfluenceTestCase):
         out_dir = self.build(self.dataset, config=config)
         with parse('index', out_dir) as data:
             page_refs = data.find_all('ri:page')
-            assert len(page_refs) == 2
+            self.assertEqual(len(page_refs), 2)
+
             self.assertEqual(
                 page_refs[0]['ri:content-title'], 'readme -cef4211633')
             self.assertEqual(

--- a/tests/unit-tests/test_config_postfix_formatting.py
+++ b/tests/unit-tests/test_config_postfix_formatting.py
@@ -19,33 +19,33 @@ except ImportError:
 class TestCreateDocnameUniqueHash(ConfluenceTestCase):
     def test_no_parent_or_root_page_or_project_configured(self):
         test_docname = 'docs/test_file.rst'
-        hash = ConfluenceState._create_docname_unique_hash(
+        hv = ConfluenceState._create_docname_unique_hash(
             docname=test_docname, config=self.config)
-        self.assertEqual(hash, '75b0047d7552a5e4d91481e992f5ed339d868b3c')
+        self.assertEqual(hv, '75b0047d7552a5e4d91481e992f5ed339d868b3c')
 
     def test_parent_page_configured(self):
         test_docname = 'docs/test_file.rst'
         config = self.config
         config['confluence_parent_page'] = 'parent_page'
-        hash = ConfluenceState._create_docname_unique_hash(
+        hv = ConfluenceState._create_docname_unique_hash(
             docname=test_docname, config=self.config)
-        self.assertEqual(hash, '9ca6dcc0b0e9eff175f1182ed75a2c43f359ed24')
+        self.assertEqual(hv, '9ca6dcc0b0e9eff175f1182ed75a2c43f359ed24')
 
     def test_publish_root_configured(self):
         test_docname = 'docs/test_file.rst'
         config = self.config
         config['confluence_publish_root'] = 'publish_root'
-        hash = ConfluenceState._create_docname_unique_hash(
+        hv = ConfluenceState._create_docname_unique_hash(
             docname=test_docname, config=self.config)
-        self.assertEqual(hash, '02fe177ef99b746ed60cb1959d6134d3ea54fab9')
+        self.assertEqual(hv, '02fe177ef99b746ed60cb1959d6134d3ea54fab9')
 
     def test_project_configured(self):
         test_docname = 'docs/test_file.rst'
         config = self.config
         config['project'] = 'grand_project'
-        hash = ConfluenceState._create_docname_unique_hash(
+        hv = ConfluenceState._create_docname_unique_hash(
             docname=test_docname, config=self.config)
-        self.assertEqual(hash, '67e8ac11ab088e763c3cf2e577037b510a54ba41')
+        self.assertEqual(hv, '67e8ac11ab088e763c3cf2e577037b510a54ba41')
 
 
 class TestFormatPostfix(ConfluenceTestCase):

--- a/tests/unit-tests/test_config_prev_next.py
+++ b/tests/unit-tests/test_config_prev_next.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceConfigPrevNext(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceConfigPrevNext, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'prevnext')
 

--- a/tests/unit-tests/test_config_prev_next.py
+++ b/tests/unit-tests/test_config_prev_next.py
@@ -2,7 +2,6 @@
 # Copyright 2020-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 
 from tests.lib.testcase import ConfluenceTestCase
-import io
 import os
 
 
@@ -58,7 +57,7 @@ class TestConfluenceConfigPrevNext(ConfluenceTestCase):
         self.assertTrue(os.path.exists(test_path),
             'missing output file: {}'.format(test_path))
 
-        with io.open(test_path, encoding='utf8') as test_file:
+        with open(test_path, encoding='utf8') as test_file:
             data = ''.join([o.strip() + '\n' for o in test_file.readlines()])
             for char, count in expected.items():
                 found = data.count(char)

--- a/tests/unit-tests/test_config_prev_next.py
+++ b/tests/unit-tests/test_config_prev_next.py
@@ -55,7 +55,7 @@ class TestConfluenceConfigPrevNext(ConfluenceTestCase):
     def _character_check(self, name, output, expected):
         test_path = os.path.join(output, name + '.conf')
         self.assertTrue(os.path.exists(test_path),
-            'missing output file: {}'.format(test_path))
+            f'missing output file: {test_path}')
 
         with open(test_path, encoding='utf8') as test_file:
             data = ''.join([o.strip() + '\n' for o in test_file.readlines()])

--- a/tests/unit-tests/test_config_prev_next.py
+++ b/tests/unit-tests/test_config_prev_next.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright 2020-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 
-from __future__ import unicode_literals
 from tests.lib.testcase import ConfluenceTestCase
 import io
 import os

--- a/tests/unit-tests/test_config_publish_list.py
+++ b/tests/unit-tests/test_config_publish_list.py
@@ -13,7 +13,7 @@ import os
 class TestConfluenceConfigPublishList(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceConfigPublishList, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'publish-list')
 
@@ -25,7 +25,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
         with patch.object(ConfluencePublisher, 'connect'), \
                 patch.object(ConfluencePublisher, 'disconnect'), \
                 patch.object(ConfluenceBuilder, 'publish_asset'):
-            super(TestConfluenceConfigPublishList, self).run(result)
+            super().run(result)
 
     def test_config_publishlist_allow_empty(self):
         config = dict(self.config)

--- a/tests/unit-tests/test_config_sourcelink.py
+++ b/tests/unit-tests/test_config_sourcelink.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceConfigSourceLink(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceConfigSourceLink, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'minimal')
 

--- a/tests/unit-tests/test_config_titlefix.py
+++ b/tests/unit-tests/test_config_titlefix.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceConfigTitlefix(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceConfigTitlefix, cls).setUpClass()
+        super().setUpClass()
 
         cls.config['root_doc'] = 'titlefix'
         cls.dataset = os.path.join(cls.datasets, 'titlefix')

--- a/tests/unit-tests/test_confluence_code_params.py
+++ b/tests/unit-tests/test_confluence_code_params.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceCodeParams(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceCodeParams, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'code-block-params')
 

--- a/tests/unit-tests/test_confluence_emoticon.py
+++ b/tests/unit-tests/test_confluence_emoticon.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceEmoticon(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceEmoticon, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'emoticon')
 

--- a/tests/unit-tests/test_confluence_excerpt.py
+++ b/tests/unit-tests/test_confluence_excerpt.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceExcerpt(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceExcerpt, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'excerpt')
 

--- a/tests/unit-tests/test_confluence_expand.py
+++ b/tests/unit-tests/test_confluence_expand.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceExpand(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceExpand, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'expand')
 

--- a/tests/unit-tests/test_confluence_jira.py
+++ b/tests/unit-tests/test_confluence_jira.py
@@ -67,7 +67,7 @@ class TestConfluenceJira(ConfluenceTestCase):
             'test-jira-server': {
                 'name': 'test-server-name',
                 'id': '00000000-1234-0000-5678-000000000009',
-            }
+            },
         }
 
         out_dir = self.build(dataset, config=config)

--- a/tests/unit-tests/test_confluence_jira.py
+++ b/tests/unit-tests/test_confluence_jira.py
@@ -11,7 +11,7 @@ import os
 class TestConfluenceJira(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceJira, cls).setUpClass()
+        super().setUpClass()
 
         cls.container = os.path.join(cls.datasets, 'jira')
 

--- a/tests/unit-tests/test_confluence_mentions.py
+++ b/tests/unit-tests/test_confluence_mentions.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceMentions(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceMentions, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'mentions')
 

--- a/tests/unit-tests/test_confluence_mentions.py
+++ b/tests/unit-tests/test_confluence_mentions.py
@@ -79,7 +79,7 @@ class TestConfluenceMentions(ConfluenceTestCase):
 
         with parse('index', out_dir) as data:
             links = data.find_all('ac:link')
-            self.assertTrue(len(links) >= 3)
+            self.assertGreaterEqual(len(links), 3)
 
             # ##########################################################
             # Replaced ID mention

--- a/tests/unit-tests/test_confluence_metadata.py
+++ b/tests/unit-tests/test_confluence_metadata.py
@@ -9,7 +9,7 @@ import os
 class TestConfluenceMetadata(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceMetadata, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'metadata')
 

--- a/tests/unit-tests/test_confluence_newline.py
+++ b/tests/unit-tests/test_confluence_newline.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceNewline(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceNewline, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'newline')
 

--- a/tests/unit-tests/test_confluence_status.py
+++ b/tests/unit-tests/test_confluence_status.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceStatus(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceStatus, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'status')
 

--- a/tests/unit-tests/test_confluence_toc.py
+++ b/tests/unit-tests/test_confluence_toc.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceToc(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceToc, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'confluence-toc')
 

--- a/tests/unit-tests/test_publisher_base_id.py
+++ b/tests/unit-tests/test_publisher_base_id.py
@@ -61,7 +61,7 @@ class TestConfluencePublisherBaseId(unittest.TestCase):
             self.assertIsNotNone(fetch_req)
             req_path, _ = fetch_req
 
-            expected_request = '/rest/api/content/{}'.format(expected_page_id)
+            expected_request = f'/rest/api/content/{expected_page_id}'
             self.assertTrue(req_path.startswith(expected_request))
 
             # verify that no other request was made
@@ -112,7 +112,7 @@ class TestConfluencePublisherBaseId(unittest.TestCase):
             self.assertIsNotNone(fetch_req)
             req_path, _ = fetch_req
 
-            expected_opt = 'title={}'.format(expected_page_name)
+            expected_opt = f'title={expected_page_name}'
             self.assertTrue(req_path.startswith('/rest/api/content'))
             self.assertTrue(expected_opt in expected_opt)
 

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -102,7 +102,7 @@ class TestConfluencePublisherConnect(unittest.TestCase):
         # Verify that a publisher will issue an `Authorization` header when
         # configure to use a personal access token.
 
-        token = 'dummy-pat-value'
+        token = 'dummy-pat-value'  # noqa: S105
         expected_auth_value = 'Bearer {}'.format(token)
 
         config = self.config.clone()

--- a/tests/unit-tests/test_publisher_connect.py
+++ b/tests/unit-tests/test_publisher_connect.py
@@ -103,7 +103,7 @@ class TestConfluencePublisherConnect(unittest.TestCase):
         # configure to use a personal access token.
 
         token = 'dummy-pat-value'  # noqa: S105
-        expected_auth_value = 'Bearer {}'.format(token)
+        expected_auth_value = f'Bearer {token}'
 
         config = self.config.clone()
         config.confluence_publish_token = token
@@ -161,7 +161,7 @@ class TestConfluencePublisherConnect(unittest.TestCase):
                     mock_confluence_instance() as proxy_daemon:
 
                 proxy_host, proxy_port = proxy_daemon.server_address
-                proxy_url = 'http://{}:{}/'.format(proxy_host, proxy_port)
+                proxy_url = f'http://{proxy_host}:{proxy_port}/'
 
                 # check default space is accessible
                 default_daemon.register_get_rsp(200, std_rsp)

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -74,7 +74,7 @@ class TestConfluencePublisherPage(unittest.TestCase):
             self.assertIsNotNone(fetch_req)
             req_path, _ = fetch_req
 
-            expected_request = '/rest/api/content/{}?'.format(expected_page_id)
+            expected_request = f'/rest/api/content/{expected_page_id}?'
             self.assertTrue(req_path.startswith(expected_request))
 
             # check that an update request is processed
@@ -137,7 +137,7 @@ class TestConfluencePublisherPage(unittest.TestCase):
             self.assertIsNotNone(fetch_req)
             req_path, _ = fetch_req
 
-            expected_request = '/rest/api/content/{}?'.format(expected_page_id)
+            expected_request = f'/rest/api/content/{expected_page_id}?'
             self.assertTrue(req_path.startswith(expected_request))
 
             # check that an update request is processed
@@ -148,7 +148,7 @@ class TestConfluencePublisherPage(unittest.TestCase):
             unwatch_req = daemon.pop_delete_request()
             self.assertIsNotNone(unwatch_req)
             req_path, _ = unwatch_req
-            ereq = '/rest/api/user/watch/content/{}'.format(expected_page_id)
+            ereq = f'/rest/api/user/watch/content/{expected_page_id}'
             self.assertEqual(req_path, ereq)
 
             # verify that no other request was made
@@ -194,7 +194,7 @@ class TestConfluencePublisherPage(unittest.TestCase):
             self.assertIsNotNone(fetch_req)
             req_path, _ = fetch_req
 
-            expected_request = '/rest/api/content/{}?'.format(expected_page_id)
+            expected_request = f'/rest/api/content/{expected_page_id}?'
             self.assertTrue(req_path.startswith(expected_request))
 
             # verify that no update request was made

--- a/tests/unit-tests/test_rst_admonitions.py
+++ b/tests/unit-tests/test_rst_admonitions.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstAdmonitions(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstAdmonitions, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'admonitions')
 

--- a/tests/unit-tests/test_rst_attribution.py
+++ b/tests/unit-tests/test_rst_attribution.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstAttribution(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstAttribution, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'attribution')
 

--- a/tests/unit-tests/test_rst_bibliographic.py
+++ b/tests/unit-tests/test_rst_bibliographic.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstBibliographic(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstBibliographic, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'bibliographic')
 

--- a/tests/unit-tests/test_rst_block_quotes.py
+++ b/tests/unit-tests/test_rst_block_quotes.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstBlockQuotes(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstBlockQuotes, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'block-quotes')
 

--- a/tests/unit-tests/test_rst_citations.py
+++ b/tests/unit-tests/test_rst_citations.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstCitations(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstCitations, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'citations')
 

--- a/tests/unit-tests/test_rst_contents.py
+++ b/tests/unit-tests/test_rst_contents.py
@@ -11,7 +11,7 @@ import re
 class TestConfluenceRstContents(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstContents, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'contents')
 

--- a/tests/unit-tests/test_rst_definition_lists.py
+++ b/tests/unit-tests/test_rst_definition_lists.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstDefinitionLists(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstDefinitionLists, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'definition-lists')
 

--- a/tests/unit-tests/test_rst_epigraph.py
+++ b/tests/unit-tests/test_rst_epigraph.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstEpigraph(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstEpigraph, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'epigraph')
 

--- a/tests/unit-tests/test_rst_figure.py
+++ b/tests/unit-tests/test_rst_figure.py
@@ -11,7 +11,7 @@ import os
 class TestConfluenceRstFigure(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstFigure, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'figure')
 

--- a/tests/unit-tests/test_rst_footnotes.py
+++ b/tests/unit-tests/test_rst_footnotes.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstFootnotes(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstFootnotes, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'footnotes')
 

--- a/tests/unit-tests/test_rst_headings.py
+++ b/tests/unit-tests/test_rst_headings.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstHeadings(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstHeadings, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'headings')
 

--- a/tests/unit-tests/test_rst_highlights.py
+++ b/tests/unit-tests/test_rst_highlights.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstHighlights(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstHighlights, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'highlights')
 

--- a/tests/unit-tests/test_rst_image.py
+++ b/tests/unit-tests/test_rst_image.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstImage(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstImage, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'image')
 

--- a/tests/unit-tests/test_rst_list_table.py
+++ b/tests/unit-tests/test_rst_list_table.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstListTable(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstListTable, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'list-table')
 

--- a/tests/unit-tests/test_rst_lists.py
+++ b/tests/unit-tests/test_rst_lists.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstLists(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstLists, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'lists')
 

--- a/tests/unit-tests/test_rst_literal.py
+++ b/tests/unit-tests/test_rst_literal.py
@@ -11,7 +11,7 @@ import os
 class TestConfluenceRstLiteral(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstLiteral, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'literal')
 

--- a/tests/unit-tests/test_rst_markup.py
+++ b/tests/unit-tests/test_rst_markup.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstMarkup(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstMarkup, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'markup')
 

--- a/tests/unit-tests/test_rst_option_lists.py
+++ b/tests/unit-tests/test_rst_option_lists.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstOptionLists(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstOptionLists, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'option-lists')
 

--- a/tests/unit-tests/test_rst_parsed_literal.py
+++ b/tests/unit-tests/test_rst_parsed_literal.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstParsedLiteral(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstParsedLiteral, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'parsed-literal')
 

--- a/tests/unit-tests/test_rst_pull_quote.py
+++ b/tests/unit-tests/test_rst_pull_quote.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceConfigHeaderFooter, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'pull-quote')
 

--- a/tests/unit-tests/test_rst_raw.py
+++ b/tests/unit-tests/test_rst_raw.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstRaw(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstRaw, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'raw-storage')
 

--- a/tests/unit-tests/test_rst_references.py
+++ b/tests/unit-tests/test_rst_references.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstReferences(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstReferences, cls).setUpClass()
+        super().setUpClass()
 
         cls.config['root_doc'] = 'references'
         cls.dataset = os.path.join(cls.datasets, 'rst', 'references')

--- a/tests/unit-tests/test_rst_tables.py
+++ b/tests/unit-tests/test_rst_tables.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstTables(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstTables, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'tables')
 

--- a/tests/unit-tests/test_rst_targets.py
+++ b/tests/unit-tests/test_rst_targets.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstTargets(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstTargets, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'targets')
 

--- a/tests/unit-tests/test_rst_transitions.py
+++ b/tests/unit-tests/test_rst_transitions.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceRstTransitions(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceRstTransitions, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'rst', 'transitions')
 

--- a/tests/unit-tests/test_shared_asset.py
+++ b/tests/unit-tests/test_shared_asset.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSharedAsset(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSharedAsset, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'shared-asset')
 

--- a/tests/unit-tests/test_singlepage_assets.py
+++ b/tests/unit-tests/test_singlepage_assets.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSinglepageAssets(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSinglepageAssets, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'shared-asset')
 

--- a/tests/unit-tests/test_sphinx_alignment.py
+++ b/tests/unit-tests/test_sphinx_alignment.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSphinxAlignment(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxAlignment, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'alignment')
 

--- a/tests/unit-tests/test_sphinx_codeblock.py
+++ b/tests/unit-tests/test_sphinx_codeblock.py
@@ -11,7 +11,7 @@ import os
 class TestConfluenceSphinxCodeblock(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxCodeblock, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'code-block')
 

--- a/tests/unit-tests/test_sphinx_codeblock_highlight.py
+++ b/tests/unit-tests/test_sphinx_codeblock_highlight.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxCodeblockHighlight, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'code-block')
 

--- a/tests/unit-tests/test_sphinx_deprecated.py
+++ b/tests/unit-tests/test_sphinx_deprecated.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSphinxDeprecated(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxDeprecated, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'deprecated')
 

--- a/tests/unit-tests/test_sphinx_domains.py
+++ b/tests/unit-tests/test_sphinx_domains.py
@@ -11,7 +11,7 @@ import os
 class TestConfluenceSphinxDomains(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxDomains, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'domains')
 

--- a/tests/unit-tests/test_sphinx_download.py
+++ b/tests/unit-tests/test_sphinx_download.py
@@ -11,7 +11,7 @@ import os
 class TestConfluenceSphinxDownload(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxDownload, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'download')
 

--- a/tests/unit-tests/test_sphinx_glossary.py
+++ b/tests/unit-tests/test_sphinx_glossary.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSphinxDomains(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxDomains, cls).setUpClass()
+        super().setUpClass()
 
         cls.config['root_doc'] = 'glossary'
         cls.dataset = os.path.join(cls.datasets, 'glossary')

--- a/tests/unit-tests/test_sphinx_image_candidate.py
+++ b/tests/unit-tests/test_sphinx_image_candidate.py
@@ -29,8 +29,8 @@ class TestConfluenceSphinxImageCandidate(ConfluenceTestCase):
 
             pyver = 'py{}{}'.format(sys.version_info.major,
                 sys.version_info.minor)
-            doc_dir = prepare_dirs(postfix='-{}-docs-{}'.format(pyver, ext[1:]))
-            out_dir = prepare_dirs(postfix='-{}-out-{}'.format(pyver, ext[1:]))
+            doc_dir = prepare_dirs(postfix=f'-{pyver}-docs-{ext[1:]}')
+            out_dir = prepare_dirs(postfix=f'-{pyver}-out-{ext[1:]}')
 
             # prepare documentation set
             #  - create and index document with an asterisk image extension

--- a/tests/unit-tests/test_sphinx_manpage.py
+++ b/tests/unit-tests/test_sphinx_manpage.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSphinxManpage(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxManpage, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'manpage')
 

--- a/tests/unit-tests/test_sphinx_productionlist.py
+++ b/tests/unit-tests/test_sphinx_productionlist.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSphinxProductionList(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxProductionList, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'production-list')
 

--- a/tests/unit-tests/test_sphinx_versionadded.py
+++ b/tests/unit-tests/test_sphinx_versionadded.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSphinxVersionAdded(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxVersionAdded, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'versionadded')
 

--- a/tests/unit-tests/test_sphinx_versionchanged.py
+++ b/tests/unit-tests/test_sphinx_versionchanged.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceSphinxVersionChanged(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceSphinxVersionChanged, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'versionchanged')
 

--- a/tests/unit-tests/test_svg.py
+++ b/tests/unit-tests/test_svg.py
@@ -11,7 +11,7 @@ import xml.etree.ElementTree as xml_et
 class TestSvg(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestSvg, cls).setUpClass()
+        super().setUpClass()
 
         cls.dataset = os.path.join(cls.datasets, 'svg')
 

--- a/tests/unit-tests/test_usecase_nested_ref.py
+++ b/tests/unit-tests/test_usecase_nested_ref.py
@@ -10,7 +10,7 @@ import os
 class TestConfluenceUseCaseNestedRef(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
-        super(TestConfluenceUseCaseNestedRef, cls).setUpClass()
+        super().setUpClass()
 
         cls.config['root_doc'] = 'nested-ref-contents'
         cls.dataset = os.path.join(cls.datasets, 'use-cases')

--- a/tests/unit-tests/test_util.py
+++ b/tests/unit-tests/test_util.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright 2018-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 
-from sphinxcontrib.confluencebuilder.util import ConfluenceUtil as UTIL
+from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
 import unittest
 
 
@@ -19,4 +19,4 @@ class TestConfluenceUtil(unittest.TestCase):
 'http://example.atlassian.net/wiki':              'http://example.atlassian.net/wiki/',
         }
         for key in data:
-            self.assertEqual(UTIL.normalize_base_url(key), data[key])
+            self.assertEqual(ConfluenceUtil.normalize_base_url(key), data[key])

--- a/tests/validation-sets/extensions/src/Hello.py
+++ b/tests/validation-sets/extensions/src/Hello.py
@@ -3,7 +3,7 @@ This is a module docstring
 """
 
 
-class Hello(object):
+class Hello:
     """
     This is a Hello class docstring
     """

--- a/tests/validation-sets/extensions/src/func.py
+++ b/tests/validation-sets/extensions/src/func.py
@@ -5,4 +5,3 @@ def my_custom_function(obj):
 
     :param obj: the function argument
     """
-    pass


### PR DESCRIPTION
Since the latest release of this extension, Python 3.7 is the minimum interpreter supported. This pull request includes a series of code changes to cleanup the source and drop various pre-Python 3.7 compatible calls as well as take advantage of new interpreter capabilities.

- switch to using contextlib.suppress for empty-except catches
- add trailing commas in various sequence locations for posterity
- remove possible boolean trap scenarios
- remove unnecessary import alias
- suppress flake8-bandit hard-coded password detections
- suppress flake8-bandit for use of sha1
- switch unused arguments to underscores
- remove unneeded commas in argument definitions
- switch away from "yoda" style conditions
- remove unnessiarys keys() call when iterating languages
- switch from assert-false triggers to raising assertion exceptions
- suppress ruff ambiguous unicode character for confluence anchor id
- remove unnecessary pass
- remove the shadowing of hash function
- tests: rework some assertion checks
- use newer super() variant
- drop unneeded object inheritance
- drop unneeded __future__
- switch from io.open to open
- remove unicode literals
- drop legacy patch import
- switch to f-string