### PR TITLE
publisher: ensure new pages include a configured version comment

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1557,6 +1557,14 @@ Advanced publishing configuration
 .. confval:: confluence_version_comment
 
     .. versionadded:: 1.8
+    .. versionchanged:: 2.1
+
+        Support comments for first/new pages on Confluence Cloud.
+
+    .. note::
+
+        Confluence Server/DC does not support setting a version comment for
+        the first/new page revision.
 
     A string value to be added as a comment to Confluence's version history.
 

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -931,6 +931,10 @@ reported a success (which can be permitted for anonymous users).
             'space': {
                 'key': self.space_key,
             },
+            'version': {
+                'number': 1,
+                'message': self.config.confluence_version_comment,
+            },
         }
 
         if self.editor:
@@ -972,10 +976,7 @@ reported a success (which can be permitted for anonymous users).
 
         update_page = self._build_page(page_name, data)
         update_page['id'] = page['id']
-        update_page['version'] = {
-            'number': last_version + 1,
-            'message': self.config.confluence_version_comment,
-        }
+        update_page['version']['number'] = last_version + 1
 
         labels = list(data['labels'])
         if self.append_labels:


### PR DESCRIPTION
When a user configures `confluence_version_comment`, the value used will only show in a page's history for page updates. This is due to the original implementation only populate the version message for page updates. This commit adjusts the implementation to always populate a `version` entry for a page with a configured message value.

Note that new page comments only appear to work on Confluence Cloud. Tests with Confluence server (v7.19.x) does not appear to accept a message value (ignored?).