### PR TITLE
enable preliminary linkcode support

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -48,6 +48,7 @@ class ConfluenceBuilder(Builder):
     name = 'confluence'
     format = 'confluence_storage'
     supported_image_types = ConfluenceSupportedImages()
+    supported_linkcode = True
     supported_remote_images = True
 
     def __init__(self, app, env=None):

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1140,9 +1140,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         next_child = first(findall(node, include_self=False))
         if isinstance(next_child, nodes.inline):
             if 'viewcode-link' in next_child.get('classes', []):
-                self.body.append(self._start_tag(node, 'div',
-                    **{'style': 'float: right'}))
-                self._reference_context.append(self._end_tag(node))
+                if self.v2:
+                    self.body.append(' ')
+                else:
+                    self.body.append(self._start_tag(node, 'div',
+                        **{'style': 'float: right'}))
+                    self._reference_context.append(self._end_tag(node))
 
         if 'reftitle' in node:
             title = node['reftitle']


### PR DESCRIPTION
For `sphinx.ext.linkcode` extension, prospect changes \[1\] will provide support for other Sphinx extensions to take advantage of linkcode-generated references. Updating this extension to hint that it
will support `sphinx.ext.linkcode`. This should help ensure a future release the Confluence Builder extension will automatically be ready to utilize the Sphinx-managed extension (if Sphinx does update to include linkcode support for custom builders).

If Sphinx changes the way of integrating with linkcode or opts to not support such an extension, the introduced line in this commit can be modified or dropped at a later time.

\[1\]: https://github.com/sphinx-doc/sphinx/pull/10585