### PR TITLE
code language improvements

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1669,6 +1669,8 @@ Advanced processing configuration
 
 .. confval:: confluence_lang_transform
 
+    .. versionchanged:: 2.1 Support a ``None`` return to use a default value.
+
     A function to override the translation of literal block-based directive
     language values to Confluence supported code block macro language values.
     The default translation accepts `Pygments documented language types`_ to
@@ -1680,6 +1682,10 @@ Advanced processing configuration
            return 'default'
 
        confluence_lang_transform = my_language_translation
+
+    In the event that the transform returns a ``None`` value, the provided
+    language type will be transform to a default language type for a language
+    as if this transform was not provided.
 
 .. |confluence_latex_macro| replace:: ``confluence_latex_macro``
 .. _confluence_latex_macro:

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -391,6 +391,58 @@ LITERAL2LANG_MAP_V2 = {
     DEFAULT_HIGHLIGHT_STYLE: 'python'
 }
 
+# sphinx literal to confluence language map (fallbacks)
+#
+# Provides an extended map to help provide fallback language types where an
+# "unsupported code language" warning is still desired but an alternative
+# language type is better than a default/"plain" language type. For example,
+# Confluence does not support interactive Python code blocks. A warning should
+# be generated to inform users that their documentation cannot render them
+# (specifically, the interactive part); however, it will be still nice to
+# render the content as Python code instead of plain text.
+LITERAL2LANG_FBMAP_COMMON = {
+    # C-like languages
+    'arduino': 'cpp',
+    'charmci': 'cpp',
+    'clay': 'cpp',
+    'cu': 'cpp',
+    'cuda': 'cpp',
+    'ec': 'cpp',
+    'mq4': 'cpp',
+    'mq5': 'cpp',
+    'mql': 'cpp',
+    'mql4': 'cpp',
+    'mql5': 'cpp',
+    'nesc': 'cpp',
+    'omg-idl': 'cpp',
+    'pike': 'cpp',
+    'swig': 'cpp',
+    'vala': 'cpp',
+    'vapi': 'cpp',
+}
+
+LITERAL2LANG_FBMAP_V1 = {
+    **LITERAL2LANG_FBMAP_COMMON,
+    # Interactive Python
+    'ipython': 'python',
+    'ipython2': 'python',
+    'ipython3': 'python',
+    # JSON (if JSON is not explicitly supported, Python style slightly works)
+    'json': 'python',
+    'json-object': 'python',
+}
+
+LITERAL2LANG_FBMAP_V2 = {
+    **LITERAL2LANG_FBMAP_COMMON,
+    # Interactive Python
+    'ipython': 'py',
+    'ipython2': 'py',
+    'ipython3': 'py',
+    # JSON (if JSON is not explicitly supported, Python style slightly works)
+    'json': 'py',
+    'json-object': 'py',
+}
+
 # fallback highlight language
 #
 # When provided a language type that is not supported by Confluence is detected on

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -685,8 +685,13 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         if not lang:
             lang = node.get('language', self._highlight).lower()
+
+        translated_lang = None
         if self.builder.lang_transform:
-            lang = self.builder.lang_transform(lang)
+            translated_lang = self.builder.lang_transform(lang)
+
+        if translated_lang:
+            lang = translated_lang
         elif lang in lang_map:
             lang = lang_map[lang]
         else:

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -14,6 +14,8 @@ from sphinxcontrib.confluencebuilder.locale import L
 from sphinxcontrib.confluencebuilder.std.confluence import FALLBACK_HIGHLIGHT_STYLE
 from sphinxcontrib.confluencebuilder.std.confluence import FCMMO
 from sphinxcontrib.confluencebuilder.std.confluence import INDENT
+from sphinxcontrib.confluencebuilder.std.confluence import LITERAL2LANG_FBMAP_V1
+from sphinxcontrib.confluencebuilder.std.confluence import LITERAL2LANG_FBMAP_V2
 from sphinxcontrib.confluencebuilder.std.confluence import LITERAL2LANG_MAP_V1
 from sphinxcontrib.confluencebuilder.std.confluence import LITERAL2LANG_MAP_V2
 from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_HIGHLIGHT_STYLE
@@ -663,6 +665,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     def visit_literal_block(self, node):
         lang = None
         lang_map = LITERAL2LANG_MAP_V2 if self.v2 else LITERAL2LANG_MAP_V1
+        fb_map = LITERAL2LANG_FBMAP_V2 if self.v2 else LITERAL2LANG_FBMAP_V1
 
         # non-raw literal
         if node.rawsource != node.astext():
@@ -698,7 +701,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if lang not in self._tracked_unknown_code_lang:
                 self.warn('unsupported code language for confluence: ' + lang)
                 self._tracked_unknown_code_lang.append(lang)
-            lang = lang_map[FALLBACK_HIGHLIGHT_STYLE]
+            lang = fb_map.get(lang, FALLBACK_HIGHLIGHT_STYLE)
 
         data = self.nl.join(node.astext().splitlines())
 

--- a/tests/unit-tests/datasets/code-block-fallback/index.rst
+++ b/tests/unit-tests/datasets/code-block-fallback/index.rst
@@ -1,0 +1,14 @@
+:orphan:
+
+.. code-block:: omg-idl
+
+    module MyAwesomeModule
+    {
+        typedef string AnotherVar;
+        typedef float SomeVaR;
+
+        interface MyAwesomrInterface
+        {
+            void fetch(in int amount);
+        }
+    }

--- a/tests/unit-tests/test_sphinx_codeblock_highlight.py
+++ b/tests/unit-tests/test_sphinx_codeblock_highlight.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright 2016-2023 Sphinx Confluence Builder Contributors (AUTHORS)
 
+from sphinx.errors import SphinxWarning
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 from tests.lib import parse
@@ -27,6 +28,29 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
                 'python',
                 'html/xml',
                 'python',
+            ]
+
+            languages = data.find_all('ac:parameter', {'ac:name': 'language'})
+            self._verify_set_languages(languages, expected)
+
+    @setup_builder('confluence')
+    def test_storage_sphinx_codeblock_highlight_fallback_default(self):
+        dataset = os.path.join(self.datasets, 'code-block-fallback')
+
+        # check that a fallback language generates a warning
+        with self.assertRaises(SphinxWarning):
+            self.build(dataset)
+
+    @setup_builder('confluence')
+    def test_storage_sphinx_codeblock_highlight_fallback_handle(self):
+        dataset = os.path.join(self.datasets, 'code-block-fallback')
+
+        # run in relaxed mode, to ensure a fallback language is applied
+        out_dir = self.build(dataset, relax=True)
+
+        with parse('index', out_dir) as data:
+            expected = [
+                'cpp',
             ]
 
             languages = data.find_all('ac:parameter', {'ac:name': 'language'})

--- a/tests/unit-tests/test_sphinx_codeblock_highlight.py
+++ b/tests/unit-tests/test_sphinx_codeblock_highlight.py
@@ -90,7 +90,7 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
             if lang == 'csharp':
                 return 'custom-csharp'
 
-            return 'custom'
+            return None
         config['confluence_lang_transform'] = test_override_lang_method
 
         out_dir = self.build(self.dataset, config=config,
@@ -98,12 +98,12 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
 
         with parse('code-block-highlight', out_dir) as data:
             expected = [
-                'custom',
-                'custom',
+                'python',
+                'bash',
                 'custom-csharp',
-                'custom',
-                'custom',
-                'custom',
+                'python',
+                'html/xml',
+                'python',
             ]
 
             languages = data.find_all('ac:parameter', {'ac:name': 'language'})


### PR DESCRIPTION
# translator: support transform empty/none handling

While `confluence_lang_transform` can be used by users to handle or override specific language types, a user may still want to rely on "regular" language types to be processed. Tweaking the use of a configured transform to fallback to the regular language mapping calls if a transform results an empty or `None` value.

# provide fallback language mappings

Provides an extended map to help provide fallback language types where an "unsupported code language" warning is still desired but an alternative language type is better than a default/"plain" language type. For example, Confluence does not support interactive Python code blocks. A warning should be generated to inform users that their documentation cannot render them (specifically, the interactive part); however, it will be still nice to render the content as Python code instead of plain text.
