### PR TITLE
support warning suppression

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1832,6 +1832,20 @@ Advanced processing configuration
     - |confluence_disable_autogen_title|_
     - |confluence_title_overrides|_
 
+Other options
+-------------
+
+.. confval:: suppress_warnings
+
+    .. versionadded:: 2.1
+
+    This extension supports suppressing warnings using Sphinx's
+    `suppress_warnings`_ configuration. The following includes additional
+    warning types that may be suppressed:
+
+    - ``confluence`` -- All warnings
+    - ``confluence.unsupported_code_lang`` -- Unsupported code language
+
 Deprecated options
 ------------------
 
@@ -1910,5 +1924,6 @@ Deprecated options
 .. _root_doc: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-root_doc
 .. _sphinx-build: https://www.sphinx-doc.org/en/master/man/sphinx-build.html
 .. _sphinx.ext.imgmath: https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.imgmath
+.. _suppress_warnings: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-suppress_warnings
 .. _toctree: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree
 .. _write_doc: https://www.sphinx-doc.org/en/master/extdev/builderapi.html#sphinx.builders.Builder.write_doc

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1482,7 +1482,7 @@ Advanced publishing configuration
     configures for a parent page/root, orphan pages will be placed under the
     respective parent page/root configuration. If no parent page/root is
     configured, orphan pages will not be associated with a parent page.
-    
+
     Users can override where orphan pages are placed by using this option. By
     specifying a page identifier, orphan pages will placed under the configured
     container page. Users can also provide a special value of ``0`` to indicate

--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -105,6 +105,7 @@ class ConfluenceLogger:
          https://docs.python.org/3/library/logging.html#logging.Logger.warning
         """
         if ConfluenceLogger.logger:
+            kwargs['type'] = 'confluence'
             ConfluenceLogger.logger.warning(msg, *args, **kwargs)
 
     @staticmethod

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -699,7 +699,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             lang = lang_map[lang]
         else:
             if lang not in self._tracked_unknown_code_lang:
-                self.warn('unsupported code language for confluence: ' + lang)
+                self.warn('unsupported code language for confluence: ' + lang,
+                    subtype='unsupported_code_lang')
                 self._tracked_unknown_code_lang.append(lang)
             lang = fb_map.get(lang, FALLBACK_HIGHLIGHT_STYLE)
 

--- a/tests/unit-tests/test_sphinx_codeblock_highlight.py
+++ b/tests/unit-tests/test_sphinx_codeblock_highlight.py
@@ -133,6 +133,18 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
             languages = data.find_all('ac:parameter', {'ac:name': 'language'})
             self._verify_set_languages(languages, expected)
 
+    @setup_builder('confluence')
+    def test_storage_sphinx_codeblock_highlight_suppress_warning(self):
+        dataset = os.path.join(self.datasets, 'code-block-fallback')
+
+        # configure to suppress the generated warning
+        config = dict(self.config)
+        config['suppress_warnings'] = [
+            'confluence.unsupported_code_lang',
+        ]
+
+        self.build(dataset, config=config)
+
     def _verify_set_languages(self, tags, languages):
         self.assertEqual(len(tags), len(languages))
 


### PR DESCRIPTION
Classify warning messages with a `confluence` hint to allow projects to suppress any extension-generated warnings using `suppress_warnings` \[1\].

In addition, this change includes a `unsupported_code_lang` subtype to allow users to ignore the specific unsupported code language warning.

\[1\[: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-suppress_warnings