### PR TITLE
tests: move parse utility call into a new file

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
-from bs4 import BeautifulSoup
 from contextlib import contextmanager
 from contextlib import suppress
 from copy import deepcopy
@@ -428,35 +427,6 @@ def mock_input(mock):
             builtins.input = original
     finally:
         pass
-
-
-@contextmanager
-def parse(filename, dirname=None):
-    """
-    parse the output of a generated sphinx document
-
-    Parses the provided filename for generated Confluence-supported markup which
-    can be examined for expected content. This function will return an instance
-    of BeautifulSoup which a tester can take advantage of the utility calls the
-    library provides.
-
-    Args:
-        filename: the filename to parse
-        dirname (optional): the directory the provided filename exists in
-
-    Returns:
-        the parsed output
-    """
-    if dirname:
-        target = os.path.join(dirname, filename)
-    else:
-        target = filename
-
-    target += '.conf'
-
-    with open(target, encoding='utf-8') as fp:
-        soup = BeautifulSoup(fp, 'html.parser')
-        yield soup
 
 
 def prepare_conf():

--- a/tests/lib/parse.py
+++ b/tests/lib/parse.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from bs4 import BeautifulSoup
+from contextlib import contextmanager
+import os
+
+
+@contextmanager
+def parse(filename, dirname=None):
+    """
+    parse the output of a generated sphinx document
+
+    Parses the provided filename for generated Confluence-supported markup which
+    can be examined for expected content. This function will return an instance
+    of BeautifulSoup which a tester can take advantage of the utility calls the
+    library provides.
+
+    Args:
+        filename: the filename to parse
+        dirname (optional): the directory the provided filename exists in
+
+    Returns:
+        the parsed output
+    """
+    if dirname:
+        target = os.path.join(dirname, filename)
+    else:
+        target = filename
+
+    target += '.conf'
+
+    with open(target, encoding='utf-8') as fp:
+        soup = BeautifulSoup(fp, 'html.parser')
+        yield soup

--- a/tests/unit-tests/test_config_header_footer.py
+++ b/tests/unit-tests/test_config_header_footer.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_config_postfix_formatting.py
+++ b/tests/unit-tests/test_config_postfix_formatting.py
@@ -5,8 +5,8 @@ import os
 from sphinxcontrib.confluencebuilder.exceptions import \
     ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
-from tests.lib import parse
 from tests.lib.testcase import setup_builder
 from unittest.mock import patch
 

--- a/tests/unit-tests/test_config_sourcelink.py
+++ b/tests/unit-tests/test_config_sourcelink.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_config_titlefix.py
+++ b/tests/unit-tests/test_config_titlefix.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_confluence_code_params.py
+++ b/tests/unit-tests/test_confluence_code_params.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_confluence_emoticon.py
+++ b/tests/unit-tests/test_confluence_emoticon.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_confluence_excerpt.py
+++ b/tests/unit-tests/test_confluence_excerpt.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_confluence_expand.py
+++ b/tests/unit-tests/test_confluence_expand.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_confluence_jira.py
+++ b/tests/unit-tests/test_confluence_jira.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 from sphinx.errors import SphinxWarning
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_confluence_mentions.py
+++ b/tests/unit-tests/test_confluence_mentions.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_confluence_newline.py
+++ b/tests/unit-tests/test_confluence_newline.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_confluence_status.py
+++ b/tests/unit-tests/test_confluence_status.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_confluence_toc.py
+++ b/tests/unit-tests/test_confluence_toc.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_admonitions.py
+++ b/tests/unit-tests/test_rst_admonitions.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_attribution.py
+++ b/tests/unit-tests/test_rst_attribution.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_bibliographic.py
+++ b/tests/unit-tests/test_rst_bibliographic.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_block_quotes.py
+++ b/tests/unit-tests/test_rst_block_quotes.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_citations.py
+++ b/tests/unit-tests/test_rst_citations.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_contents.py
+++ b/tests/unit-tests/test_rst_contents.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 import re
 

--- a/tests/unit-tests/test_rst_definition_lists.py
+++ b/tests/unit-tests/test_rst_definition_lists.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_epigraph.py
+++ b/tests/unit-tests/test_rst_epigraph.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_figure.py
+++ b/tests/unit-tests/test_rst_figure.py
@@ -2,9 +2,9 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_ALIGNMENT
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_footnotes.py
+++ b/tests/unit-tests/test_rst_footnotes.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_headings.py
+++ b/tests/unit-tests/test_rst_headings.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_highlights.py
+++ b/tests/unit-tests/test_rst_highlights.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_image.py
+++ b/tests/unit-tests/test_rst_image.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_list_table.py
+++ b/tests/unit-tests/test_rst_list_table.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_lists.py
+++ b/tests/unit-tests/test_rst_lists.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_literal.py
+++ b/tests/unit-tests/test_rst_literal.py
@@ -2,9 +2,9 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from bs4 import CData
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_markup.py
+++ b/tests/unit-tests/test_rst_markup.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_option_lists.py
+++ b/tests/unit-tests/test_rst_option_lists.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_parsed_literal.py
+++ b/tests/unit-tests/test_rst_parsed_literal.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_pull_quote.py
+++ b/tests/unit-tests/test_rst_pull_quote.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_raw.py
+++ b/tests/unit-tests/test_rst_raw.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_references.py
+++ b/tests/unit-tests/test_rst_references.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_tables.py
+++ b/tests/unit-tests/test_rst_tables.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_targets.py
+++ b/tests/unit-tests/test_rst_targets.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_rst_transitions.py
+++ b/tests/unit-tests/test_rst_transitions.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sdoc_genindex.py
+++ b/tests/unit-tests/test_sdoc_genindex.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sdoc_modindex.py
+++ b/tests/unit-tests/test_sdoc_modindex.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sdoc_search.py
+++ b/tests/unit-tests/test_sdoc_search.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_shared_asset.py
+++ b/tests/unit-tests/test_shared_asset.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_singlepage_assets.py
+++ b/tests/unit-tests/test_singlepage_assets.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_singlepage_docref.py
+++ b/tests/unit-tests/test_singlepage_docref.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_singlepage_toctree.py
+++ b/tests/unit-tests/test_singlepage_toctree.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_alignment.py
+++ b/tests/unit-tests/test_sphinx_alignment.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_codeblock.py
+++ b/tests/unit-tests/test_sphinx_codeblock.py
@@ -2,9 +2,9 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from bs4 import CData
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_codeblock_highlight.py
+++ b/tests/unit-tests/test_sphinx_codeblock_highlight.py
@@ -2,9 +2,9 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from sphinx.errors import SphinxWarning
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_deprecated.py
+++ b/tests/unit-tests/test_sphinx_deprecated.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_domains.py
+++ b/tests/unit-tests/test_sphinx_domains.py
@@ -2,9 +2,9 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from sphinx.locale import _
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_download.py
+++ b/tests/unit-tests/test_sphinx_download.py
@@ -2,9 +2,9 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from bs4 import CData
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_glossary.py
+++ b/tests/unit-tests/test_sphinx_glossary.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_image_candidate.py
+++ b/tests/unit-tests/test_sphinx_image_candidate.py
@@ -2,9 +2,9 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from sphinxcontrib.confluencebuilder.std.confluence import SUPPORTED_IMAGE_TYPES
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 from tests.lib import prepare_dirs
 import mimetypes
 import os

--- a/tests/unit-tests/test_sphinx_manpage.py
+++ b/tests/unit-tests/test_sphinx_manpage.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_productionlist.py
+++ b/tests/unit-tests/test_sphinx_productionlist.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_toctree.py
+++ b/tests/unit-tests/test_sphinx_toctree.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_versionadded.py
+++ b/tests/unit-tests/test_sphinx_versionadded.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_sphinx_versionchanged.py
+++ b/tests/unit-tests/test_sphinx_versionchanged.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 

--- a/tests/unit-tests/test_svg.py
+++ b/tests/unit-tests/test_svg.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 import xml.etree.ElementTree as xml_et
 

--- a/tests/unit-tests/test_usecase_nested_ref.py
+++ b/tests/unit-tests/test_usecase_nested_ref.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-from tests.lib import parse
 import os
 
 


### PR DESCRIPTION
The `parse` utility call, which helps parse an output file using BeautifulSoup, is being moved into its own file. This is in preparation for some "sample" test logic which will rely on some capabilities in the `tests` module, but does not want a dependency on the BeautifulSoup package.