### PR TITLE
introduce new tox interpreter test environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,9 @@ passenv = *
 [testenv:{,py37-,py38-,py39-,py310-,py311-,py312-}prerelease]
 pip_pre = true
 
+[testenv:{,py37-,py38-,py39-,py310-,py311-,py312-}release]
+usedevelop = false
+
 [testenv:flake8]
 deps =
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
     {envpython} -m coverage html
     {envpython} -m coverage report
 
-[testenv:develop]
+[testenv:{,py37-,py38-,py39-,py310-,py311-,py312-}develop]
 deps =
     git+https://github.com/sphinx-doc/sphinx.git@{env:SPHINX_VER:master}
     -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
### tox: allow interpreter-specific develop environment testing

Provides testers a way to test against Sphinx development versions using specific Python interpreter.

### tox: introduce release environment testing

Provides an environment to help test "release" builds of the implementation, instead of using the default development mode building.