### PR TITLE
configurable cleanup search modes

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -587,6 +587,7 @@ Publishing configuration
 
     - |confluence_cleanup_from_root|_
     - |confluence_cleanup_purge|_
+    - |confluence_cleanup_search_mode|_
     - |confluence_publish_dryrun|_
 
 .. |confluence_cleanup_from_root| replace:: ``confluence_cleanup_from_root``
@@ -658,6 +659,7 @@ Publishing configuration
 
     - |confluence_cleanup_archive|_
     - |confluence_cleanup_from_root|_
+    - |confluence_cleanup_search_mode|_
     - |confluence_publish_dryrun|_
 
 .. |confluence_disable_notifications| replace:: ``confluence_disable_notifications``
@@ -1130,6 +1132,44 @@ Advanced publishing configuration
     - |confluence_client_cert_pass|_
     - |confluence_client_cert|_
     - |confluence_disable_ssl_validation|_
+
+.. |confluence_cleanup_search_mode| replace:: ``confluence_cleanup_search_mode``
+.. _confluence_cleanup_search_mode:
+
+.. confval:: confluence_cleanup_search_mode
+
+    .. versionadded:: 2.1
+
+    .. note::
+
+        Prior to the introduction of this configuration, the internal search
+        mode for this extension followed a ``search`` styled mode.
+
+    Configures the search mode used for finding descendant pages to be cleaned
+    up (when configured for archiving/purging legacy pages). By default, this
+    extension will ask Confluence for known descendants for the root page:
+
+    .. code-block:: python
+
+        confluence_cleanup_search_mode = 'direct'
+
+    However, in some cases, the provided list of descendants may be incorrect
+    (due to the Confluence version used, the state of Confluence's ancestors
+    table caching, etc.). This configuration can be used to tweak how this
+    extension searches for descendants, if a user experiences issues with the
+    default method of searching. Supported modes are as follows:
+
+    - ``direct`` `(default)`: Query known descendants from a page's cache.
+    - ``search``: Search for descendants using Confluence's CQL capability.
+
+    Users can also postfix ``-aggressive`` (e.g. ``search-aggressive``) on a
+    mode to perform a recursive search for descendants ensure all descendants
+    are found. Note that an aggressive search will increase the amount of API
+    calls to a configured Confluence instance.
+    See also:
+
+    - |confluence_cleanup_archive|_
+    - |confluence_cleanup_purge|_
 
 .. |confluence_client_cert| replace:: ``confluence_client_cert``
 .. _confluence_client_cert:

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -118,6 +118,8 @@ def setup(app):
     cm.add_conf_bool('confluence_cleanup_from_root')
     # Enablement of purging legacy child pages.
     cm.add_conf_bool('confluence_cleanup_purge')
+    # The mode to search for legacy child pages.
+    cm.add_conf('confluence_cleanup_search_mode')
     # Explicitly prevent auto-generation of titles for titleless documents.
     cm.add_conf_bool('confluence_disable_autogen_title')
     # Explicitly prevent page notifications on update.
@@ -220,8 +222,6 @@ def setup(app):
     cm.add_conf_bool('confluence_remove_title', 'env')
 
     # (configuration - undocumented)
-    # Enablement for aggressive descendents search (for cleanup).
-    cm.add_conf_bool('confluence_adv_aggressive_search')
     # Enablement for bulk archiving of packages (for premium environments).
     cm.add_conf_bool('confluence_adv_bulk_archiving')
     # Flag to permit the use of embedded certificates from requests.
@@ -242,6 +242,8 @@ def setup(app):
     cm.add_conf_bool('confluence_adv_writer_no_section_cap', 'env')
 
     # (configuration - deprecated)
+    # replaced by confluence_cleanup_search_mode
+    cm.add_conf_bool('confluence_adv_aggressive_search')
     # replaced by confluence_root_homepage
     cm.add_conf('confluence_master_homepage')
     # replaced by confluence_publish_allowlist

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -548,10 +548,9 @@ class ConfluenceBuilder(Builder):
             if (conf.confluence_cleanup_from_root and
                     conf.confluence_publish_dryrun and not baseid):
                 self.legacy_pages = []
-            elif self.config.confluence_adv_aggressive_search is True:
-                self.legacy_pages = self.publisher.get_descendants_compat(baseid)
             else:
-                self.legacy_pages = self.publisher.get_descendants(baseid)
+                self.legacy_pages = self.publisher.get_descendants(
+                    baseid, conf.confluence_cleanup_search_mode)
 
             # remove any configured orphan root id from a cleanup check
             orphan_root_id = str(conf.confluence_publish_orphan_container)

--- a/sphinxcontrib/confluencebuilder/cmd/wipe.py
+++ b/sphinxcontrib/confluencebuilder/cmd/wipe.py
@@ -72,7 +72,6 @@ To use this action, the argument '--danger' must be set.
                     status=sys.stdout,   # sphinx status output
                     warning=sys.stderr)  # sphinx warning output
 
-                aggressive_search = app.config.confluence_adv_aggressive_search
                 dryrun = app.config.confluence_publish_dryrun
                 server_url = app.config.confluence_server_url
                 space_key = app.config.confluence_space_key
@@ -128,10 +127,9 @@ pages. Only use this action if you know what you are doing.
     if args.parent:
         base_page_id = publisher.get_base_page_id()
 
-    if aggressive_search:
-        legacy_pages = publisher.get_descendants_compat(base_page_id)
-    else:
-        legacy_pages = publisher.get_descendants(base_page_id)
+    # find all legacy pages; always search aggressive to prevent any Confluence
+    # caching issues/delays
+    legacy_pages = publisher.get_descendants(base_page_id, 'search-aggressive')
 
     print('         URL:', server_url)
     print('       Space:', space_key)

--- a/sphinxcontrib/confluencebuilder/config/__init__.py
+++ b/sphinxcontrib/confluencebuilder/config/__init__.py
@@ -29,6 +29,10 @@ def handle_config_inited(app, config):
     legacy('confluence_root_homepage', 'confluence_master_homepage')
     legacy('confluence_space_key', 'confluence_space_name')
 
+    if getattr(config, 'confluence_adv_aggressive_search') is True:
+        if getattr(config, 'confluence_cleanup_search_mode') is None:
+            config['confluence_cleanup_search_mode'] = 'search-aggressive'
+
 
 def process_ask_configs(config):
     """

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -133,6 +133,25 @@ def validate_configuration(builder):
 
     # ##################################################################
 
+    # confluence_cleanup_search_mode
+    try:
+        validator.conf('confluence_cleanup_search_mode').matching(
+            'direct',
+            'direct-aggressive',
+            'search',
+            'search-aggressive',
+        )
+    except ConfluenceConfigurationError as e:
+        raise ConfluenceConfigurationError('''\
+{msg}
+
+The option 'confluence_cleanup_search_mode' has been provided to override the
+default search method for page descendants. Accepted values include 'direct',
+'search' and '<mode>-aggressive'.
+'''.format(msg=e))
+
+    # ##################################################################
+
     if config.confluence_client_cert is not None:
         client_cert = config.confluence_client_cert
         if isinstance(client_cert, tuple):

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -40,6 +40,9 @@ def apply_defaults(builder):
     if conf.confluence_adv_restricted is None:
         conf.confluence_adv_restricted = []
 
+    if conf.confluence_cleanup_search_mode is None:
+        conf.confluence_cleanup_search_mode = 'direct'
+
     if conf.confluence_client_cert is not None:
         if not isinstance(conf.confluence_client_cert, tuple):
             conf.confluence_client_cert = (conf.confluence_client_cert, None)

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -7,6 +7,8 @@ import mimetypes
 
 # dictionary of deprecated configuration entries and associated message
 DEPRECATED_CONFIGS = {
+    'confluence_adv_aggressive_search':
+        'use "confluence_cleanup_search_mode" instead',
     'confluence_adv_trace_data':
         'to be removed in a future version',
     'confluence_adv_writer_no_section_cap':

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -234,6 +234,23 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_client_cert_pass'] = 'dummy'  # noqa: S105
         self._try_config()
 
+    def test_config_check_cleanup_purge_mode(self):
+        self.config['confluence_cleanup_search_mode'] = 'direct'
+        self._try_config()
+
+        self.config['confluence_cleanup_search_mode'] = 'direct-aggressive'
+        self._try_config()
+
+        self.config['confluence_cleanup_search_mode'] = 'search'
+        self._try_config()
+
+        self.config['confluence_cleanup_search_mode'] = 'search-aggressive'
+        self._try_config()
+
+        self.config['confluence_cleanup_search_mode'] = 'invalid'
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
     def test_config_check_default_alignment(self):
         self.config['confluence_default_alignment'] = 'left'
         self._try_config()


### PR DESCRIPTION
Provides the ability for a user to configure how to search for legacy pages when a cleanup option is configured. When a project is configured to cleanup old documents, this extension will search for any legacy pages found on the Confluence instance. As it uploads new documents (and attachments), it will update the internal list of tracked documents to indicate which ones are active. At the end of the process, the remaining set of documents/attachments are considered legacy and will be cleaned up.

A problem observed is that sometimes Confluence does not always report expected page dependencies through the API. Originally, this implementation would query specific pages descendants; however, after initial testing, not all descendants would always appear. The implementation was switched to use a search API instead, which seemed to provide more consistent results (~5 years ago). Unfortunately, a search request did not always show expected results. A hidden "aggressive" search option was added to force search for descendants on each detect page, which always seemed to give us the expected page count, but this took a lot of API calls.

Since it is hard to know the "right" the way of searching for legacy pages, this commit now exposes the option for a user to force pick an option which may best suit them. We default to "direct" searching, which "should" be the preferred way of searching for descendants. And if users have issues, they may chose to opt to using a search or aggressive variant search style.