### PR TITLE
support "full width" option for v1 editor

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -684,11 +684,7 @@ Publishing configuration
 .. confval:: confluence_full_width
 
     .. versionadded:: 2.0
-
-    .. note::
-
-        This option is only supported using the ``v2``
-        :ref:`editor <confluence_editor>`.
+    .. versionchanged:: 2.1 Support added for Confluence's ``v1`` editor.
 
     A boolean value to whether to publish pages using the full width of a page.
     By default, page widths will use their default/existing page widths with
@@ -700,8 +696,6 @@ Publishing configuration
     .. code-block:: python
 
         confluence_full_width = True
-
-    See also |confluence_editor|_.
 
 .. |confluence_global_labels| replace:: ``confluence_global_labels``
 .. _confluence_global_labels:

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -158,6 +158,30 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 self.body.append(self._build_ac_param(node, '', doc_id))
                 self.body.append(self._end_ac_macro(node, suffix=''))
 
+    def pre_body_data(self):
+        data = ''
+
+        # Confluence's v1 editor ignores a full-width page style on
+        # publication (most likely since the concept of page width was
+        # developed for v2 and newer). To emulate a non-full-width state with
+        # a v1 editor, apply a layout around the page contents.
+        if not self.v2 and self.builder.config.confluence_full_width is False:
+            data += '<ac:layout>'
+            data += '<ac:layout-section ac:type="fixed-width">'
+            data += '<ac:layout-cell>'
+
+        return data
+
+    def post_body_data(self):
+        data = ''
+
+        if not self.v2 and self.builder.config.confluence_full_width is False:
+            data += '</ac:layout-cell>'
+            data += '</ac:layout-section>'
+            data += '</ac:layout>'
+
+        return data
+
     def visit_title(self, node):
         if isinstance(node.parent, (nodes.section, nodes.topic)):
             self.body.append(

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -106,7 +106,9 @@ class ConfluenceBaseTranslator(BaseTranslator):
 
             self.body_final += header + self.nl
 
+        self.body_final += self.pre_body_data()
         self.body_final += ''.join(self.body)
+        self.body_final += self.post_body_data()
 
         # append footer (if any)
         if self.builder.config.confluence_footer_file is not None:
@@ -128,6 +130,12 @@ class ConfluenceBaseTranslator(BaseTranslator):
                     self.builder.config.confluence_footer_data)
 
             self.body_final += footer + self.nl
+
+    def pre_body_data(self):
+        return ''
+
+    def post_body_data(self):
+        return ''
 
     def visit_Text(self, node):
         text = node.astext()

--- a/tests/unit-tests/test_config_full_width.py
+++ b/tests/unit-tests/test_config_full_width.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from tests.lib.parse import parse
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+import os
+
+
+class TestConfluenceConfigFullWidth(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'common')
+
+    @setup_builder('confluence')
+    def test_storage_config_full_width_v1_default(self):
+        """validate full width modifications for v1 editor (default)"""
+
+        out_dir = self.build(self.dataset, config=self.config)
+
+        with parse('index', out_dir) as data:
+            layout = data.find('ac:layout')
+            self.assertIsNone(layout)
+
+    @setup_builder('confluence')
+    def test_storage_config_full_width_v1_disabled(self):
+        """validate full width modifications for v1 editor (disabled)"""
+        #
+        # The use of `confluence_full_width` would typically advise a
+        # Confluence instance the layout type on publish. However, this
+        # layout management is not supported with a v1 editor. Instead,
+        # layout modifications are made to the page's content. This check
+        # ensures when configured, these layout options are injected.
+
+        config = dict(self.config)
+        config['confluence_full_width'] = False
+
+        out_dir = self.build(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            layout = data.find('ac:layout')
+            self.assertIsNotNone(layout)
+
+            section = layout.find('ac:layout-section')
+            self.assertIsNotNone(section)
+            self.assertTrue(section.has_attr('ac:type'))
+            self.assertEqual(section['ac:type'], 'fixed-width')
+
+            cell = section.find('ac:layout-cell')
+            self.assertIsNotNone(cell)
+
+    @setup_builder('confluence')
+    def test_storage_config_full_width_v1_enabled(self):
+        """validate full width modifications for v1 editor (enabled)"""
+
+        config = dict(self.config)
+        config['confluence_full_width'] = True
+
+        out_dir = self.build(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            layout = data.find('ac:layout')
+            self.assertIsNone(layout)


### PR DESCRIPTION
Confluence's v1 editor ignores a full-width page style on publication (most likely since the concept of page width was developed for v2 and newer). To emulate a non-full-width state with a v1 editor, apply a layout around the page contents.

See also #602.