### PR TITLE
provide strikethrough role

### DIFF
--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -157,6 +157,41 @@ generated Confluence documents.
 
         :confluence_status:`PASSED [green]`
 
+.. index:: Strikethrough (role)
+
+Strikethrough
+-------------
+
+.. note::
+
+    This role can be used to help a user observe the ability to strikethrough
+    text on a Confluence page; however, this role only applies to Confluence
+    builders. Users attempting to support multiple builders (such as the
+    ``html`` builder), are recommended to use a ``class`` hint instead. This
+    extension supports an applied ``strike`` class on text as an indication
+    that the text should have a strikethrough format. For example:
+
+    .. code-block:: rst
+
+        .. role:: strike
+            :class: strike
+
+        This is a :strike:`strikeme` example.
+
+The following role can be used to explicitly define strikethrough text into
+generated Confluence documents.
+
+.. rst:role:: confluence_strike
+
+    .. versionadded:: 2.1
+
+    The ``confluence_strike`` role allows a user to build inlined text that has
+    been styled with a strikethrough. For example:
+
+    .. code-block:: rst
+
+        :confluence_strike:`My text`
+
 
 .. references ------------------------------------------------------------------
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -25,6 +25,7 @@ from sphinxcontrib.confluencebuilder.roles import ConfluenceEmoticonRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceLatexRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceMentionRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceStatusRole
+from sphinxcontrib.confluencebuilder.roles import ConfluenceStrikeRole
 from sphinxcontrib.confluencebuilder.roles import JiraRole
 from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
 
@@ -310,6 +311,7 @@ def confluence_builder_inited(app):
     app.add_role('confluence_latex', ConfluenceLatexRole)
     app.add_role('confluence_mention', ConfluenceMentionRole)
     app.add_role('confluence_status', ConfluenceStatusRole)
+    app.add_role('confluence_strike', ConfluenceStrikeRole)
     app.add_role('jira', JiraRole)
 
     # inject compatible autosummary nodes if the extension is available/loaded

--- a/sphinxcontrib/confluencebuilder/roles.py
+++ b/sphinxcontrib/confluencebuilder/roles.py
@@ -7,6 +7,7 @@ See also docutils roles:
     https://docutils.sourceforge.io/docs/howto/rst-roles.html#define-the-role-function
 """
 
+from docutils import nodes
 from sphinxcontrib.confluencebuilder.nodes import confluence_emoticon_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_mention_inline
@@ -133,6 +134,31 @@ def ConfluenceStatusRole(name, rawtext, text, lineno, inliner, options=None, con
     node.params['title'] = text
     if outlined:
         node.params['subtle'] = 'true'
+
+    return [node], []
+
+
+def ConfluenceStrikeRole(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """
+    a confluence strike role
+
+    Defines an inline Confluence strike role where users can inject inlined
+    node to styled with a strikethrough.
+
+    Args:
+        name: local name of the interpreted text role
+        rawtext: the entire interpreted text construct
+        text: the interpreted text content
+        lineno: the line number where the interpreted text beings
+        inliner: inliner object that called the role function
+        options: dictionary of directive options for customization
+        content: list of strings, the directive content for customization
+
+    Returns:
+        returns a tuple include a list of nodes and a list of system messages
+    """
+
+    node = nodes.inline(rawsource=text, text=text, classes=['strike'])
 
     return [node], []
 

--- a/tests/unit-tests/datasets/strikethrough/index.rst
+++ b/tests/unit-tests/datasets/strikethrough/index.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+strikethrough
+-------------
+
+:confluence_strike:`test`

--- a/tests/unit-tests/test_confluence_strikethough.py
+++ b/tests/unit-tests/test_confluence_strikethough.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from tests.lib.parse import parse
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+import os
+
+
+class TestConfluenceStrikethrough(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'strikethrough')
+
+    @setup_builder('confluence')
+    def test_html_confluence_strikethrough(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            strikethrough_elements = data.find_all('s')
+            self.assertEqual(len(strikethrough_elements), 1)
+
+            element = strikethrough_elements.pop(0)
+            self.assertEqual(element.text, 'test')


### PR DESCRIPTION
Providing a role which allows documents to explicitly use Confluence's strikethrough text capability. This is more so for documentation sets which may solely focus on Confluence and a user wants to quickly present content in a strikethrough format. For mixed documentation sets, generic role-based strikethroughs are still recommended.