### PR TITLE
maintenance (2023-04-16)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,9 @@ Development
 ===========
 
 * Allow users to configure legacy page search mode for cleanup
+* Fixed anchor page links with v2 editor
 * Fixed document processing issues with Sphinx 6.1.x
+* Introduce the Confluence strike role
 * Perform an attachment re-upload attempt on an unexpected Confluence 503 error
 * Provide fallback styling for code languages with a similar style
 * Support ``confluence_full_width`` with v1 editor

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ optionally publish them to a Confluence instance.
 Requirements
 ============
 
-* Confluence_ Cloud or Data Center / Server 7.11+
+* Confluence_ Cloud or Data Center / Server 7.12+
 * Python_ 3.7+
 * Requests_ 2.14.0+
 * Sphinx_ 5.0+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,7 @@ author = 'Sphinx Confluence Builder Contributors'
 version = sphinxcontrib.confluencebuilder.__version__
 release = sphinxcontrib.confluencebuilder.__version__
 
-supported_confluence_ver = '7.11+'
+supported_confluence_ver = '7.12+'
 supported_python_ver = '3.7+'
 supported_sphinx_ver = '5.0+'
 

--- a/tests/validation-sets/sphinx/code.rst
+++ b/tests/validation-sets/sphinx/code.rst
@@ -82,6 +82,8 @@ markup ``:linenos:``):
 Presenting another code block which contains CDATA information (which should be
 escaped to prevent publishing issues or display issues):
 
+.. Broken in v8.2.0, v8.0.4, v8.1.1; see also: CONFSERVER-82849
+
 .. code-block:: html
 
     <html>


### PR DESCRIPTION
- README.rst: sync eol confluence versions
- doc: sync eol confluence versions
- tests: comment about confluence v8.x issues with cdata code blocks
- CHANGES.rst: adding features/changes
