### PR TITLE
documentation cleanup

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -85,9 +85,11 @@ latex_elements = {
     ''',
     # iso datetime support
     # disable hyphenatation
+    # disable justified text
     'preamble': r'''
         \usepackage{datetime2}
         \usepackage[none]{hyphenat}
+        \usepackage[document]{ragged2e}
     ''',
 }
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 :copyright: Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 :license: BSD-2-Clause (LICENSE)

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -158,8 +158,8 @@ Essential configuration
 
         confluence_server_pass = 'vsUsrSZ6Z4kmrQMapSXBYkJh'
 
-    If `API tokens`_ are not being used, the plain password for the configured
-    username value can be used:
+    If `API tokens`_ are not being used, the plaintext password for the
+    configured username value can be used:
 
     .. code-block:: python
 
@@ -715,7 +715,7 @@ Publishing configuration
             'label-b',
         ]
 
-    For per-document labels, please consult the ``confluence_metadata``
+    For per-document labels, please see the ``confluence_metadata``
     :ref:`directive <confluence_metadata>`. See also
     |confluence_append_labels|_.
 
@@ -1563,7 +1563,7 @@ Advanced publishing configuration
 
     Note that this extension does not define custom authentication handlers.
     This configuration is a passthrough option only. For more details on various
-    ways to use authentication handlers, please consult
+    ways to use authentication handlers, please see
     `Requests -- Authentication`_. By default, no custom authentication handler
     is provided to generated REST API requests. An example OAuth 1 is as
     follows:
@@ -1758,7 +1758,7 @@ Advanced processing configuration
 
     The name of a LaTeX macro will vary based on which add-on is installed.
     For a list of known macro names or steps to determine the name of a
-    supported macro, consult the
+    supported macro, see the
     :ref:`macro table/instructions <guide_math_macro_names>`
     found in the math guide.
 

--- a/doc/guide-math.rst
+++ b/doc/guide-math.rst
@@ -142,7 +142,7 @@ LaTeX macro names
 ~~~~~~~~~~~~~~~~~
 
 What macro names to use will vary based off which macro types are installed
-(if any). Please consult the following table for reported macro names:
+(if any). Please see the following table for reported macro names:
 
 .. list-table::
     :header-rows: 1

--- a/doc/guide-math.rst
+++ b/doc/guide-math.rst
@@ -146,7 +146,7 @@ What macro names to use will vary based off which macro types are installed
 
 .. list-table::
     :header-rows: 1
-    :widths: auto
+    :widths: 40 60
 
     * - Marketplace Application
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -119,17 +119,6 @@ their configuration file. For example:
 When publishing a documentation set, the above configuration will tell this
 extension to publish all documents under the ``MyDocumentation`` page.
 
-By default, all documents published to a Confluence instance will be stored
-either in the root of the space or a configured parent space (as mentioned
-above). For larger documentation sets which include multiple nested documents,
-it may be desired to have individual documents published as children of other
-published documents. Configuring the ``confluence_page_hierarchy`` option will
-allow a user to enable hierarchy support. For example:
-
-.. code-block:: python
-
-    confluence_page_hierarchy = True
-
 For first time users, they may wish to sanity check what content will be
 published before publishing for the first time to a Confluence instance. A user
 can perform a dryrun by configuring the ``confluence_publish_dryrun`` option in

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -59,8 +59,6 @@ Next, create a configuration file ``conf.py`` with the following information:
 
 .. code-block:: python
 
-    # -*- coding: utf-8 -*-
-
     extensions = []
 
 After preparing these files, continue by


### PR DESCRIPTION
Provide a series of documentation cleanup work:

- doc: drop tutorial content on hierarchy mode
- doc: text cleanup
- doc: drop utf coding hints
- doc: tweak width of macro table entries
- doc: disable justified text in pdf builds