### PR TITLE
Initial idea to handle Confluence Links

### DIFF
--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -532,6 +532,136 @@ Confluence page.
 
 See also :ref:`LaTeX roles <latex-roles>`.
 
+.. index:: Smart links (directive)
+.. _smart-link-directives:
+
+Smart links
+-----------
+
+.. note::
+
+    Smart links will only render when using the v2 editor
+    (see ``confluence_editor``; :ref:`ref<confluence_editor>`).
+
+.. rst:directive:: confluence_doc
+
+    .. versionadded:: 2.1
+
+    The ``confluence_doc`` directive allows a user to define a link to a
+    document that is styled with a card appearance. The directive accepts the
+    name of a document in an absolute or relative fashion (in the same manner
+    as Sphinx's `:doc: <role-doc_>`_ role). For example:
+
+    .. code-block:: rst
+
+        .. confluence_doc:: my-other-page
+
+    This directive supports the following options:
+
+    .. rst:directive:option:: card: card type
+        :type: block, embed
+
+        When using ``block``, a smart link card is generated for the document
+        link. The card will provide a summary of the target document. When
+        using ``embed``, the contents of the document will rendered on the
+        page.
+
+        .. code-block:: rst
+
+            .. confluence_doc:: my-other-page
+                :card: block
+
+    .. rst:directive:option:: layout: layout type
+        :type: align-start, align-end, center, wrap-left, wrap-right
+
+        .. note:: This option is only applicable when using an ``embed`` card.
+
+        Specifies how an embedded card will be laid out on a page. Embedded
+        cards will default to 100% width. Therefore, to take advantage of
+        certain layout capabilities, users should also assign an appropriate
+        width as well.
+
+        .. code-block:: rst
+
+            .. confluence_doc:: my-other-page
+                :card: embed
+                :layout: align-end
+                :width: 20
+
+    .. rst:directive:option:: width: value
+        :type: integer
+
+        .. note:: This option is only applicable when using an ``embed`` card.
+
+        Specifies the width to apply for an embedded card. The width is a value
+        from 0 to 100 (e.g. a value of ``80`` for 80% of the page).
+
+        .. code-block:: rst
+
+            .. confluence_doc:: my-other-page
+                :card: embed
+                :width: 50
+
+.. rst:directive:: confluence_link
+
+    .. versionadded:: 2.1
+
+    The ``confluence_link`` directive allows a user to define a link to a
+    page that is styled with a card appearance. The directive accepts a URL.
+    How Confluence renders the context of a link card will vary based on
+    which link targets Confluence supports. For example:
+
+    .. code-block:: rst
+
+        .. confluence_link:: https://example.com
+
+    This directive supports the following options:
+
+    .. rst:directive:option:: card: card type
+        :type: block, embed
+
+        When using ``block``, a smart link card is generated for the link.
+        The card will provide a summary of the target link. When using
+        ``embed``, the contents of the link will rendered on the page.
+
+        .. code-block:: rst
+
+            .. confluence_link:: https://example.com
+                :card: block
+
+    .. rst:directive:option:: layout: layout type
+        :type: align-start, align-end, center, wrap-left, wrap-right
+
+        .. note:: This option is only applicable when using an ``embed`` card.
+
+        Specifies how an embedded card will be laid out on a page. Embedded
+        cards will default to 100% width. Therefore, to take advantage of
+        certain layout capabilities, users should also assign an appropriate
+        width as well.
+
+        .. code-block:: rst
+
+            .. confluence_link:: https://example.com
+                :card: embed
+                :layout: align-end
+                :width: 20
+
+    .. rst:directive:option:: width: value
+        :type: integer
+
+        .. note:: This option is only applicable when using an ``embed`` card.
+
+        Specifies the width to apply for an embedded card. The width is a value
+        from 0 to 100 (e.g. a value of ``80`` for 80% of the page).
+
+        .. code-block:: rst
+
+            .. confluence_link:: https://example.com
+                :card: embed
+                :width: 50
+
+See also :ref:`smart link roles <smart-link-roles>`.
+
 
 .. references ------------------------------------------------------------------
 
@@ -541,5 +671,6 @@ See also :ref:`LaTeX roles <latex-roles>`.
 .. _Sphinx's toctree directive: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#table-of-contents
 .. _Table of Contents Macro: https://support.atlassian.com/confluence-cloud/docs/insert-the-table-of-contents-macro/
 .. _directives: https://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html
-.. _reStructuredText's Table of Contents: https://docutils.sourceforge.io/docs/ref/rst/directives.html#table-of-contents
 .. _only: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-only
+.. _reStructuredText's Table of Contents: https://docutils.sourceforge.io/docs/ref/rst/directives.html#table-of-contents
+.. _role-doc: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-doc

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -532,7 +532,7 @@ Confluence page.
 
 See also :ref:`LaTeX roles <latex-roles>`.
 
-.. index:: Smart links (directive)
+.. index:: Smart links; Directives
 .. _smart-link-directives:
 
 Smart links

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -121,7 +121,7 @@ generated Confluence documents.
     A user mapping table can also be configured using the
     ``confluence_mentions`` (:ref:`ref<confluence_mentions>`) option.
 
-.. index:: Smart links (role)
+.. index:: Smart links; Roles
 .. _smart-link-roles:
 
 Smart links

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -121,6 +121,47 @@ generated Confluence documents.
     A user mapping table can also be configured using the
     ``confluence_mentions`` (:ref:`ref<confluence_mentions>`) option.
 
+.. index:: Smart links (role)
+.. _smart-link-roles:
+
+Smart links
+-----------
+
+.. note::
+
+    Smart links will only render when using the v2 editor
+    (see ``confluence_editor``; :ref:`ref<confluence_editor>`).
+
+Support for inlined smart links can be created using the following roles.
+
+.. rst:role:: confluence_doc
+
+    .. versionadded:: 2.1
+
+    The ``confluence_doc`` role allows a user to define an inlined link to a
+    document that is styled with a card appearance. The role accepts the
+    name of a document in an absolute or relative fashion (in the same manner
+    as Sphinx's `:doc: <role-doc_>`_ role). For example:
+
+    .. code-block:: rst
+
+        See :confluence_doc:`my-other-page`.
+
+.. rst:role:: confluence_link
+
+    .. versionadded:: 2.1
+
+    The ``confluence_link`` role allows a user to define an inlined link to a
+    page that is styled with a card appearance. The role accepts a URL.
+    How Confluence renders the context of a link card will vary based on
+    which link targets Confluence supports. For example:
+
+    .. code-block:: rst
+
+        See :confluence_link:`https://example.com`.
+
+See also :ref:`smart link directives <smart-link-directives>`.
+
 .. index:: Macros; Status Macro (role)
 .. index:: Status Macro
 
@@ -197,4 +238,5 @@ generated Confluence documents.
 
 .. _Confluence mentions: https://support.atlassian.com/confluence-cloud/docs/mention-a-person-or-team/
 .. _Confluence status macro: https://support.atlassian.com/confluence-cloud/docs/insert-the-status-macro/
+.. _role-doc: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-doc
 .. _roles: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -26,6 +26,7 @@ from sphinxcontrib.confluencebuilder.roles import ConfluenceLatexRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceMentionRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceStatusRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceStrikeRole
+from sphinxcontrib.confluencebuilder.roles import ConfluenceLinkRole
 from sphinxcontrib.confluencebuilder.roles import JiraRole
 from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
 
@@ -313,6 +314,7 @@ def confluence_builder_inited(app):
     app.add_role('confluence_status', ConfluenceStatusRole)
     app.add_role('confluence_strike', ConfluenceStrikeRole)
     app.add_role('jira', JiraRole)
+    app.add_role('confluence_link', ConfluenceLinkRole)
 
     # inject compatible autosummary nodes if the extension is available/loaded
     if autosummary:

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -6,10 +6,12 @@ from sphinx.util import docutils
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.config import handle_config_inited
 from sphinxcontrib.confluencebuilder.config.manager import ConfigManager
+from sphinxcontrib.confluencebuilder.directives import ConfluenceDocDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceExcerptDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceExcerptIncludeDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceExpandDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceLatexDirective
+from sphinxcontrib.confluencebuilder.directives import ConfluenceLinkDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceMetadataDirective
 from sphinxcontrib.confluencebuilder.directives import ConfluenceNewline
 from sphinxcontrib.confluencebuilder.directives import ConfluenceToc
@@ -21,12 +23,13 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.nodes import jira
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
+from sphinxcontrib.confluencebuilder.roles import ConfluenceDocRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceEmoticonRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceLatexRole
+from sphinxcontrib.confluencebuilder.roles import ConfluenceLinkRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceMentionRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceStatusRole
 from sphinxcontrib.confluencebuilder.roles import ConfluenceStrikeRole
-from sphinxcontrib.confluencebuilder.roles import ConfluenceLinkRole
 from sphinxcontrib.confluencebuilder.roles import JiraRole
 from sphinxcontrib.confluencebuilder.singlebuilder import SingleConfluenceBuilder
 
@@ -296,11 +299,13 @@ def confluence_builder_inited(app):
         app.add_node(jira_issue)
 
     # register directives
+    app.add_directive('confluence_doc', ConfluenceDocDirective)
     app.add_directive('confluence_excerpt', ConfluenceExcerptDirective)
     app.add_directive('confluence_excerpt_include',
         ConfluenceExcerptIncludeDirective)
     app.add_directive('confluence_expand', ConfluenceExpandDirective)
     app.add_directive('confluence_latex', ConfluenceLatexDirective)
+    app.add_directive('confluence_link', ConfluenceLinkDirective)
     app.add_directive('confluence_metadata', ConfluenceMetadataDirective)
     app.add_directive('confluence_newline', ConfluenceNewline)
     app.add_directive('confluence_toc', ConfluenceToc)
@@ -308,13 +313,14 @@ def confluence_builder_inited(app):
     app.add_directive('jira_issue', JiraIssueDirective)
 
     # register roles
+    app.add_role('confluence_doc', ConfluenceDocRole)
     app.add_role('confluence_emoticon', ConfluenceEmoticonRole)
     app.add_role('confluence_latex', ConfluenceLatexRole)
+    app.add_role('confluence_link', ConfluenceLinkRole)
     app.add_role('confluence_mention', ConfluenceMentionRole)
     app.add_role('confluence_status', ConfluenceStatusRole)
     app.add_role('confluence_strike', ConfluenceStrikeRole)
     app.add_role('jira', JiraRole)
-    app.add_role('confluence_link', ConfluenceLinkRole)
 
     # inject compatible autosummary nodes if the extension is available/loaded
     if autosummary:

--- a/sphinxcontrib/confluencebuilder/directives.py
+++ b/sphinxcontrib/confluencebuilder/directives.py
@@ -3,10 +3,12 @@
 
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
+from sphinxcontrib.confluencebuilder.nodes import confluence_doc_card
 from sphinxcontrib.confluencebuilder.nodes import confluence_expand
 from sphinxcontrib.confluencebuilder.nodes import confluence_excerpt
 from sphinxcontrib.confluencebuilder.nodes import confluence_excerpt_include
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_block
+from sphinxcontrib.confluencebuilder.nodes import confluence_link_card
 from sphinxcontrib.confluencebuilder.nodes import confluence_metadata
 from sphinxcontrib.confluencebuilder.nodes import confluence_newline
 from sphinxcontrib.confluencebuilder.nodes import confluence_toc
@@ -37,6 +39,46 @@ def string_list(argument):
                     data.append(label)
 
     return data
+
+
+class ConfluenceCardDirective(Directive):
+    has_content = False
+    option_spec = {
+        'card': lambda x: directives.choice(x, ('block', 'embed')),
+        'layout': lambda x: directives.choice(x, ('align-start', 'align-end',
+            'center', 'wrap-left', 'wrap-right')),
+        'width': directives.positive_int,
+    }
+    required_arguments = 1
+    final_argument_whitespace = True
+
+    def run(self):
+        node = self._build_card_node()
+        node.params['href'] = self.arguments[0]
+
+        if 'card' in self.options:
+            node.params['data-card-appearance'] = self.options['card']
+
+        if 'layout' in self.options:
+            node.params['data-layout'] = self.options['layout']
+
+        if 'width' in self.options:
+            node.params['data-width'] = self.options['width']
+
+        return [node]
+
+    def _build_card_node(self):
+        raise NotImplementedError()
+
+
+class ConfluenceDocDirective(ConfluenceCardDirective):
+    def _build_card_node(self):
+        return confluence_doc_card()
+
+
+class ConfluenceLinkDirective(ConfluenceCardDirective):
+    def _build_card_node(self):
+        return confluence_link_card()
 
 
 class ConfluenceExcerptDirective(Directive):

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -25,6 +25,15 @@ class ConfluenceParams(nodes.Element):
         self.params = self.attributes.setdefault('confluence-params', {})
 
 
+class confluence_link_inline(nodes.Inline, nodes.Element):
+    """
+    confluence link inline node
+
+    A Confluence builder defined link inline node, used to manage how a link
+    is displayed: embed, inline, as an url or as a card.
+    """
+
+
 class confluence_emoticon_inline(nodes.Inline, nodes.TextElement):
     """
     confluence emoticon inline node

--- a/sphinxcontrib/confluencebuilder/nodes.py
+++ b/sphinxcontrib/confluencebuilder/nodes.py
@@ -25,12 +25,21 @@ class ConfluenceParams(nodes.Element):
         self.params = self.attributes.setdefault('confluence-params', {})
 
 
-class confluence_link_inline(nodes.Inline, nodes.Element):
+class confluence_doc_card(nodes.Structural, ConfluenceParams):
     """
-    confluence link inline node
+    confluence document card node
 
-    A Confluence builder defined link inline node, used to manage how a link
-    is displayed: embed, inline, as an url or as a card.
+    A Confluence builder defined document card node, used to help add
+    Confluence document-CARD for a block section.
+    """
+
+
+class confluence_doc_card_inline(nodes.Inline, ConfluenceParams):
+    """
+    confluence document card inline node
+
+    A Confluence builder defined document card inline node, used to help add
+    Confluence document-CARD for an inlined section of a paragraph.
     """
 
 
@@ -124,6 +133,24 @@ class confluence_latex_inline(nodes.Inline, nodes.TextElement):
 
     A Confluence builder defined LaTeX inline node, used to help manage LaTeX
     content designed for an inlined section of a paragraph.
+    """
+
+
+class confluence_link_card(nodes.Structural, ConfluenceParams):
+    """
+    confluence link card node
+
+    A Confluence builder defined link card node, used to help add
+    Confluence link-CARD for a block section.
+    """
+
+
+class confluence_link_card_inline(nodes.Inline, ConfluenceParams):
+    """
+    confluence card inline node
+
+    A Confluence builder defined inline card node, used to help add
+    Confluence link-CARD for an inlined section of a paragraph.
     """
 
 

--- a/sphinxcontrib/confluencebuilder/roles.py
+++ b/sphinxcontrib/confluencebuilder/roles.py
@@ -8,12 +8,18 @@ See also docutils roles:
 """
 
 from docutils import nodes
+from sphinxcontrib.confluencebuilder.nodes import confluence_doc_card_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_emoticon_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
+from sphinxcontrib.confluencebuilder.nodes import confluence_link_card_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_mention_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_status_inline
-from sphinxcontrib.confluencebuilder.nodes import confluence_link_inline
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
+from sphinx.roles import XRefRole
+
+
+ConfluenceDocRole = XRefRole(nodeclass=confluence_doc_card_inline,
+    innernodeclass=nodes.inline, warn_dangling=True)
 
 
 def ConfluenceEmoticonRole(name, rawtext, text, lineno, inliner, options=None, content=None):
@@ -62,6 +68,32 @@ def ConfluenceLatexRole(name, rawtext, text, lineno, inliner, options=None, cont
     """
 
     node = confluence_latex_inline(rawsource=text, text=text)
+
+    return [node], []
+
+
+def ConfluenceLinkRole(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """
+    a confluence link role
+
+    Defines an inline Confluence link role where users can inject inlined
+    card link (v2 editor) for a target link.
+
+    Args:
+        name: local name of the interpreted text role
+        rawtext: the entire interpreted text construct
+        text: the interpreted text content
+        lineno: the line number where the interpreted text beings
+        inliner: inliner object that called the role function
+        options: dictionary of directive options for customization
+        content: list of strings, the directive content for customization
+
+    Returns:
+        returns a tuple include a list of nodes and a list of system messages
+    """
+
+    node = confluence_link_card_inline(rawsource=text, text=text)
+    node.params['href'] = text
 
     return [node], []
 
@@ -187,47 +219,5 @@ def JiraRole(name, rawtext, text, lineno, inliner, options=None, content=None):
     node = jira_issue()
     node.params['key'] = text
     node.params['showSummary'] = 'false'
-
-    return [node], []
-
-
-def ConfluenceLinkRole(name, rawtext, text, lineno, inliner, options=None, content=None):
-    """
-    a confluence link role
-
-    Defines an inline Confluence link role that helps users define the rendering
-    style.
-
-    Args:
-        name: local name of the interpreted text role
-        rawtext: the entire interpreted text construct
-        text: the interpreted text content
-        lineno: the line number where the interpreted text beings
-        inliner: inliner object that called the role function
-        options: dictionary of directive options for customization
-        content: list of strings, the directive content for customization
-
-    Returns:
-        returns a tuple include a list of nodes and a list of system messages
-    """
-
-    flavour = ''
-
-    try:
-        leading_txt, opts = text.rsplit(' ', 1)
-
-        parse_opts = False
-        if opts.startswith('<') and opts.endswith('>'):
-            parse_opts = True
-
-        if parse_opts:
-            text = leading_txt
-            flavour = opts[1:-1]
-    except ValueError:
-        pass
-
-    node = confluence_link_inline(rawsource=rawtext, text=text)
-    node.attributes['flavour'] = flavour
-    node.attributes['href'] = text
 
     return [node], []

--- a/sphinxcontrib/confluencebuilder/roles.py
+++ b/sphinxcontrib/confluencebuilder/roles.py
@@ -12,6 +12,7 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_emoticon_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_latex_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_mention_inline
 from sphinxcontrib.confluencebuilder.nodes import confluence_status_inline
+from sphinxcontrib.confluencebuilder.nodes import confluence_link_inline
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
 
 
@@ -186,5 +187,47 @@ def JiraRole(name, rawtext, text, lineno, inliner, options=None, content=None):
     node = jira_issue()
     node.params['key'] = text
     node.params['showSummary'] = 'false'
+
+    return [node], []
+
+
+def ConfluenceLinkRole(name, rawtext, text, lineno, inliner, options=None, content=None):
+    """
+    a confluence link role
+
+    Defines an inline Confluence link role that helps users define the rendering
+    style.
+
+    Args:
+        name: local name of the interpreted text role
+        rawtext: the entire interpreted text construct
+        text: the interpreted text content
+        lineno: the line number where the interpreted text beings
+        inliner: inliner object that called the role function
+        options: dictionary of directive options for customization
+        content: list of strings, the directive content for customization
+
+    Returns:
+        returns a tuple include a list of nodes and a list of system messages
+    """
+
+    flavour = ''
+
+    try:
+        leading_txt, opts = text.rsplit(' ', 1)
+
+        parse_opts = False
+        if opts.startswith('<') and opts.endswith('>'):
+            parse_opts = True
+
+        if parse_opts:
+            text = leading_txt
+            flavour = opts[1:-1]
+    except ValueError:
+        pass
+
+    node = confluence_link_inline(rawsource=rawtext, text=text)
+    node.attributes['flavour'] = flavour
+    node.attributes['href'] = text
 
     return [node], []

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2621,6 +2621,28 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         raise nodes.SkipNode
 
+    # ------------------------------------------
+    # confluence-builder -- enhancements -- link
+    # ------------------------------------------
+
+    def visit_confluence_link_inline(self, node):
+        attribs = {
+            "data-card-appearance": node.attributes["flavour"],
+            "href": node.attributes["href"]
+        }
+        self.body.append(
+            self._start_tag(
+                node,
+                'a',
+                **attribs
+            )
+        )
+        self.body.append(attribs["href"])
+        self.context.append(self._end_tag(node))
+
+    def depart_confluence_link_inline(self, node):
+        self.body.append(self.context.pop())
+
     # ---------------------------------------------------
     # sphinx -- extension (third party) -- jupyter-sphinx
     # ---------------------------------------------------

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2487,6 +2487,106 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         raise nodes.SkipNode
 
+    # ------------------------------------------
+    # confluence-builder -- enhancements -- card
+    # ------------------------------------------
+
+    def visit_confluence_doc_card(self, node):
+        # v1 editor does not support cards; contain in a panel to emulate a
+        # block feel
+        if not self.v2:
+            self.body.append(self._start_ac_macro(node, 'panel'))
+            self.body.append(self._start_ac_rich_text_body_macro(node))
+
+        docname = posixpath.normpath(self.docparent +
+            path.splitext(node.params['href'].split('#')[0])[0])
+        doctitle = self.state.title(docname)
+        if doctitle:
+            attribs = {}
+
+            if 'data-card-appearance' in node.params:
+                attribs['ac:card-appearance'] = \
+                    node.params['data-card-appearance']
+
+            if 'data-layout' in node.params:
+                attribs['ac:layout'] = node.params['data-layout']
+
+            if 'data-width' in node.params:
+                attribs['ac:width'] = node.params['data-width']
+
+            doctitle = self.encode(doctitle)
+            self.body.append(self._start_tag(node, 'ac:link', **attribs))
+            self.body.append(self._start_tag(node, 'ri:page',
+                suffix=self.nl, empty=True, **{'ri:content-title': doctitle}))
+            self.body.append(self._start_ac_link_body(node))
+            self.body.append(node.astext())
+            self.body.append(self._end_ac_link_body(node))
+            self.body.append(self._end_tag(node, suffix=''))
+        else:
+            self.warn('unable to build link to document card due to '
+                'missing title (in {}): {}'.format(self.docname, docname))
+            self.body.append(node.astext())
+
+        if not self.v2:
+            self.body.append(self._end_ac_rich_text_body_macro(node))
+            self.body.append(self._end_ac_macro(node))  # panel
+
+        raise nodes.SkipNode
+
+    def visit_confluence_doc_card_inline(self, node):
+        docname = posixpath.normpath(self.docparent +
+            path.splitext(node['reftarget'].split('#')[0])[0])
+        doctitle = self.state.title(docname)
+        if doctitle:
+            doctitle = self.encode(doctitle)
+            self.body.append(self._start_ac_link(node, appearance='inline'))
+            self.body.append(self._start_tag(node, 'ri:page',
+                suffix=self.nl, empty=True, **{'ri:content-title': doctitle}))
+            self.body.append(self._start_ac_link_body(node))
+            self.body.append(node.astext())
+            self.body.append(self._end_ac_link_body(node))
+            self.body.append(self._end_ac_link(node))
+        else:
+            self.warn('unable to build link to document card due to '
+                'missing title (in {}): {}'.format(self.docname, docname))
+            self.body.append(node.astext())
+
+        raise nodes.SkipNode
+
+    def visit_confluence_link_card(self, node):
+        options = dict(node.params)
+        url = self.encode(options.pop('href'))
+        options['href'] = url
+
+        # v1 editor does not support cards; contain in a panel to emulate a
+        # block feel
+        if not self.v2:
+            self.body.append(self._start_ac_macro(node, 'panel'))
+            self.body.append(self._start_ac_rich_text_body_macro(node))
+
+        self.body.append(self._start_tag(node, 'a', **options))
+        self.body.append(url)
+        self.body.append(self._end_tag(node, suffix=''))
+
+        if not self.v2:
+            self.body.append(self._end_ac_rich_text_body_macro(node))
+            self.body.append(self._end_ac_macro(node))  # panel
+
+        raise nodes.SkipNode
+
+    def visit_confluence_link_card_inline(self, node):
+        # raw href | give it an inline card appearance
+        attribs = {
+            'data-card-appearance': 'inline',
+            'href': self.encode(node.params['href']),
+        }
+
+        self.body.append(self._start_tag(node, 'a', **attribs))
+        self.body.append(attribs['href'])
+        self.body.append(self._end_tag(node, suffix=''))
+
+        raise nodes.SkipNode
+
     # ----------------------------------------------
     # confluence-builder -- enhancements -- emoticon
     # ----------------------------------------------
@@ -2620,28 +2720,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self._end_ac_macro(node))
 
         raise nodes.SkipNode
-
-    # ------------------------------------------
-    # confluence-builder -- enhancements -- link
-    # ------------------------------------------
-
-    def visit_confluence_link_inline(self, node):
-        attribs = {
-            "data-card-appearance": node.attributes["flavour"],
-            "href": node.attributes["href"]
-        }
-        self.body.append(
-            self._start_tag(
-                node,
-                'a',
-                **attribs
-            )
-        )
-        self.body.append(attribs["href"])
-        self.context.append(self._end_tag(node))
-
-    def depart_confluence_link_inline(self, node):
-        self.body.append(self.context.pop())
 
     # ---------------------------------------------------
     # sphinx -- extension (third party) -- jupyter-sphinx
@@ -3011,7 +3089,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         """
         return self._end_tag(node, suffix='')
 
-    def _start_ac_link(self, node, anchor=None):
+    def _start_ac_link(self, node, anchor=None, appearance=None):
         """
         generates a confluence link start tag
 
@@ -3023,6 +3101,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         Args:
             node: the node processing the link
             anchor (optional): the anchor value to use (defaults to None)
+            appearance (optional): card appearance to use (defaults to None)
 
         Returns:
             the content
@@ -3030,6 +3109,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         attribs = {}
         if anchor:
             attribs['ac:anchor'] = anchor
+        if appearance:
+            attribs['ac:card-appearance'] = appearance
         return self._start_tag(node, 'ac:link', suffix=self.nl, **attribs)
 
     def _end_ac_link(self, node):

--- a/tests/sample-sets/confluence-card/conf.py
+++ b/tests/sample-sets/confluence-card/conf.py
@@ -1,0 +1,5 @@
+extensions = [
+    'sphinxcontrib.confluencebuilder',
+]
+
+confluence_editor = 'v2'

--- a/tests/sample-sets/confluence-card/index.rst
+++ b/tests/sample-sets/confluence-card/index.rst
@@ -1,0 +1,77 @@
+confluence-card
+===============
+
+.. toctree::
+    :maxdepth: 1
+
+    second
+
+----
+
+An :confluence_doc:`second` inlined card.
+
+
+.. confluence_doc:: second
+    :card: block
+
+.. confluence_doc:: second
+    :card: embed
+    :width: 60
+
+
+.. confluence_doc:: second
+    :card: embed
+    :layout: align-start
+    :width: 40
+
+
+.. confluence_doc:: second
+    :card: embed
+    :layout: center
+    :width: 55
+
+
+.. confluence_doc:: second
+    :card: embed
+    :layout: align-end
+    :width: 80
+
+
+.. confluence_doc:: second
+    :card: embed
+    :width: 60
+
+
+----
+
+An :confluence_link:`https://example.com` inlined card.
+
+
+.. confluence_link:: https://www.youtube.com/watch?v=Z-9lDJlWNW4
+    :card: block
+
+.. confluence_link:: https://www.youtube.com/watch?v=Z-9lDJlWNW4
+    :card: embed
+    :width: 60
+
+
+.. confluence_link:: https://www.youtube.com/watch?v=Z-9lDJlWNW4
+    :card: embed
+    :layout: align-start
+    :width: 30
+
+
+.. confluence_link:: https://www.youtube.com/watch?v=Z-9lDJlWNW4
+    :card: embed
+    :layout: center
+    :width: 30
+
+
+.. confluence_link:: https://www.youtube.com/watch?v=Z-9lDJlWNW4
+    :card: embed
+    :layout: align-end
+    :width: 30
+
+
+.. confluence_link:: https://www.youtube.com/watch?v=Z-9lDJlWNW4
+    :width: 21

--- a/tests/sample-sets/confluence-card/second.rst
+++ b/tests/sample-sets/confluence-card/second.rst
@@ -1,0 +1,18 @@
+second page 📇
+==============
+
+A second page.
+
+
+.. confluence_link:: https://jdknight.atlassian.net/wiki/spaces/TEST/pages/2701230351/confluence-card
+    :card: block
+
+
+.. confluence_link:: https://jdknight.atlassian.net/wiki/spaces/TEST/pages/2701230351
+    :card: block
+
+.. confluence_link:: https://jdknight.atlassian.net/wiki/pages/viewinfo.action?pageId=2703294477
+    :card: block
+
+.. confluence_link:: https://jdknight.atlassian.net/wiki/x/DQAhoQ
+    :card: block

--- a/tests/sample-sets/confluence-card/tox.ini
+++ b/tests/sample-sets/confluence-card/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+package_root={toxinidir}{/}..{/}..{/}..
+
+[testenv]
+commands =
+    {envpython} -m tests.test_sample {posargs}
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+    TOX_INI_DIR={toxinidir}
+passenv = *
+use_develop = true

--- a/tests/unit-tests/datasets/confluence-doc-invalid-doc/index.rst
+++ b/tests/unit-tests/datasets/confluence-doc-invalid-doc/index.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+confluence doc
+==============
+
+.. confluence_doc:: missing
+    :card: block

--- a/tests/unit-tests/datasets/confluence-doc-invalid-layout/index.rst
+++ b/tests/unit-tests/datasets/confluence-doc-invalid-layout/index.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+confluence doc
+==============
+
+.. confluence_doc:: second
+    :card: block
+    :layout: align-end

--- a/tests/unit-tests/datasets/confluence-doc-invalid-width/index.rst
+++ b/tests/unit-tests/datasets/confluence-doc-invalid-width/index.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+confluence doc
+==============
+
+.. confluence_doc:: second
+    :card: block
+    :width: 80

--- a/tests/unit-tests/datasets/confluence-doc/index.rst
+++ b/tests/unit-tests/datasets/confluence-doc/index.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+confluence doc
+==============
+
+An :confluence_doc:`second` inlined card.
+
+.. confluence_doc:: second
+    :card: embed
+
+.. confluence_doc:: second
+    :card: embed
+    :width: 30
+
+.. confluence_doc:: second
+    :card: embed
+    :layout: align-end
+
+.. confluence_doc:: third
+    :card: block

--- a/tests/unit-tests/datasets/confluence-doc/second.rst
+++ b/tests/unit-tests/datasets/confluence-doc/second.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+second page
+===========
+
+Another page.

--- a/tests/unit-tests/datasets/confluence-doc/third.rst
+++ b/tests/unit-tests/datasets/confluence-doc/third.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+third page
+==========
+
+Another page.

--- a/tests/unit-tests/datasets/confluence-link-invalid-layout/index.rst
+++ b/tests/unit-tests/datasets/confluence-link-invalid-layout/index.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+confluence link
+===============
+
+.. confluence_link:: https://example.org
+    :card: block
+    :layout: align-end

--- a/tests/unit-tests/datasets/confluence-link-invalid-width/index.rst
+++ b/tests/unit-tests/datasets/confluence-link-invalid-width/index.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+confluence link
+===============
+
+.. confluence_link:: https://example.com
+    :card: block
+    :width: 80

--- a/tests/unit-tests/datasets/confluence-link/index.rst
+++ b/tests/unit-tests/datasets/confluence-link/index.rst
@@ -1,0 +1,20 @@
+:orphan:
+
+link
+----
+
+.. flavour = url
+
+:confluence_link:`https://example.com/ <url>`
+
+.. flavour = inline
+
+:confluence_link:`https://example.com/ <inline>`
+
+.. flavour = card
+
+:confluence_link:`https://example.com/ <card>`
+
+.. flavour = embed
+
+:confluence_link:`https://example.com/ <embed>`

--- a/tests/unit-tests/datasets/confluence-link/index.rst
+++ b/tests/unit-tests/datasets/confluence-link/index.rst
@@ -1,20 +1,20 @@
 :orphan:
 
-link
-----
+confluence link
+===============
 
-.. flavour = url
+An :confluence_link:`https://example.com` inlined card.
 
-:confluence_link:`https://example.com/ <url>`
+.. confluence_link:: https://www.example.org
+    :card: embed
 
-.. flavour = inline
+.. confluence_link:: https://example.com
+    :card: embed
+    :width: 80
 
-:confluence_link:`https://example.com/ <inline>`
+.. confluence_link:: https://example.org
+    :card: embed
+    :layout: align-end
 
-.. flavour = card
-
-:confluence_link:`https://example.com/ <card>`
-
-.. flavour = embed
-
-:confluence_link:`https://example.com/ <embed>`
+.. confluence_link:: https://www.example.com
+    :card: block

--- a/tests/unit-tests/test_confluence_doc.py
+++ b/tests/unit-tests/test_confluence_doc.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from sphinx.errors import SphinxWarning
+from tests.lib.parse import parse
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+import os
+
+
+class TestConfluenceDoc(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'confluence-doc')
+
+    @setup_builder('html')
+    def test_html_confluence_doc_ignore(self):
+        # build attempt should not throw an exception/error
+        self.build(self.dataset, relax=True)
+
+    @setup_builder('confluence')
+    def test_storage_confluence_doc_default(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            links = data.find_all('ac:link')
+            self.assertEqual(len(links), 5)
+
+            # ##########################################################
+            # inline card
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertTrue(link.has_attr('ac:card-appearance'))
+            self.assertEqual(link['ac:card-appearance'], 'inline')
+
+            page_ref = link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'second page')
+
+            # ##########################################################
+            # embed card (default)
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertTrue(link.has_attr('ac:card-appearance'))
+            self.assertEqual(link['ac:card-appearance'], 'embed')
+
+            page_ref = link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'second page')
+
+            # ##########################################################
+            # embed card with a width percentage provided
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertTrue(link.has_attr('ac:card-appearance'))
+            self.assertEqual(link['ac:card-appearance'], 'embed')
+            self.assertTrue(link.has_attr('ac:width'))
+            self.assertEqual(link['ac:width'], '30')
+
+            page_ref = link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'second page')
+
+            # ##########################################################
+            # embed card with a layout provided
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertTrue(link.has_attr('ac:card-appearance'))
+            self.assertEqual(link['ac:card-appearance'], 'embed')
+            self.assertTrue(link.has_attr('ac:layout'))
+            self.assertEqual(link['ac:layout'], 'align-end')
+
+            page_ref = link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'second page')
+
+            # ##########################################################
+            # block card
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertTrue(link.has_attr('ac:card-appearance'))
+            self.assertEqual(link['ac:card-appearance'], 'block')
+
+            page_ref = link.find('ri:page')
+            self.assertIsNotNone(page_ref)
+            self.assertTrue(page_ref.has_attr('ri:content-title'))
+            self.assertEqual(page_ref['ri:content-title'], 'third page')
+
+    @setup_builder('confluence')
+    def test_storage_confluence_doc_invalid_doc(self):
+        dataset = self.dataset + '-invalid-doc'
+        with self.assertRaises(SphinxWarning):
+            self.build(dataset)
+
+    @setup_builder('confluence')
+    def test_storage_confluence_doc_invalid_layout(self):
+        dataset = self.dataset + '-invalid-layout'
+        with self.assertRaises(SphinxWarning):
+            self.build(dataset)
+
+    @setup_builder('confluence')
+    def test_storage_confluence_doc_invalid_width(self):
+        dataset = self.dataset + '-invalid-width'
+        with self.assertRaises(SphinxWarning):
+            self.build(dataset)

--- a/tests/unit-tests/test_confluence_link.py
+++ b/tests/unit-tests/test_confluence_link.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from sphinx.errors import SphinxWarning
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
@@ -80,3 +81,15 @@ class TestConfluenceLink(ConfluenceTestCase):
             self.assertEqual(link['data-card-appearance'], 'block')
             self.assertTrue(link.has_attr('href'))
             self.assertEqual(link['href'], 'https://www.example.com')
+
+    @setup_builder('confluence')
+    def test_storage_confluence_link_invalid_layout(self):
+        dataset = self.dataset + '-invalid-layout'
+        with self.assertRaises(SphinxWarning):
+            self.build(dataset)
+
+    @setup_builder('confluence')
+    def test_storage_confluence_link_invalid_width(self):
+        dataset = self.dataset + '-invalid-width'
+        with self.assertRaises(SphinxWarning):
+            self.build(dataset)

--- a/tests/unit-tests/test_confluence_link.py
+++ b/tests/unit-tests/test_confluence_link.py
@@ -15,42 +15,68 @@ class TestConfluenceLink(ConfluenceTestCase):
         cls.dataset = os.path.join(cls.datasets, 'confluence-link')
 
     @setup_builder('html')
-    def test_html_confluence_status_role_ignore(self):
+    def test_html_confluence_link_ignore(self):
         # build attempt should not throw an exception/error
         self.build(self.dataset, relax=True)
 
     @setup_builder('confluence')
-    def test_storage_confluence_link_role_default(self):
+    def test_storage_confluence_link_default(self):
         out_dir = self.build(self.dataset)
 
         with parse('index', out_dir) as data:
             links = data.find_all('a')
-            self.assertEqual(len(links), 4)
+            self.assertEqual(len(links), 5)
 
             # ##########################################################
-            # flavour = url
-            # ##########################################################
-            link = links.pop(0)
-
-            self.assertEqual(link["data-card-appearance"], 'url')
-
-            # ##########################################################
-            # flavour = inline
+            # inline card
             # ##########################################################
             link = links.pop(0)
 
-            self.assertEqual(link["data-card-appearance"], 'inline')
+            self.assertTrue(link.has_attr('data-card-appearance'))
+            self.assertEqual(link['data-card-appearance'], 'inline')
+            self.assertTrue(link.has_attr('href'))
+            self.assertEqual(link['href'], 'https://example.com')
 
             # ##########################################################
-            # flavour = card
-            # ##########################################################
-            link = links.pop(0)
-
-            self.assertEqual(link["data-card-appearance"], 'card')
-
-            # ##########################################################
-            # flavour = embed
+            # embed card (default)
             # ##########################################################
             link = links.pop(0)
 
-            self.assertEqual(link["data-card-appearance"], 'embed')
+            self.assertTrue(link.has_attr('data-card-appearance'))
+            self.assertEqual(link['data-card-appearance'], 'embed')
+            self.assertTrue(link.has_attr('href'))
+            self.assertEqual(link['href'], 'https://www.example.org')
+
+            # ##########################################################
+            # embed card with a width percentage provided
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertTrue(link.has_attr('data-card-appearance'))
+            self.assertEqual(link['data-card-appearance'], 'embed')
+            self.assertTrue(link.has_attr('href'))
+            self.assertEqual(link['href'], 'https://example.com')
+            self.assertTrue(link.has_attr('data-width'))
+            self.assertEqual(link['data-width'], '80')
+
+            # ##########################################################
+            # embed card with a layout provided
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertTrue(link.has_attr('data-card-appearance'))
+            self.assertEqual(link['data-card-appearance'], 'embed')
+            self.assertTrue(link.has_attr('href'))
+            self.assertEqual(link['href'], 'https://example.org')
+            self.assertTrue(link.has_attr('data-layout'))
+            self.assertEqual(link['data-layout'], 'align-end')
+
+            # ##########################################################
+            # block card
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertTrue(link.has_attr('data-card-appearance'))
+            self.assertEqual(link['data-card-appearance'], 'block')
+            self.assertTrue(link.has_attr('href'))
+            self.assertEqual(link['href'], 'https://www.example.com')

--- a/tests/unit-tests/test_confluence_link.py
+++ b/tests/unit-tests/test_confluence_link.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from tests.lib.parse import parse
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+import os
+
+
+class TestConfluenceLink(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'confluence-link')
+
+    @setup_builder('html')
+    def test_html_confluence_status_role_ignore(self):
+        # build attempt should not throw an exception/error
+        self.build(self.dataset, relax=True)
+
+    @setup_builder('confluence')
+    def test_storage_confluence_link_role_default(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            links = data.find_all('a')
+            self.assertEqual(len(links), 4)
+
+            # ##########################################################
+            # flavour = url
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertEqual(link["data-card-appearance"], 'url')
+
+            # ##########################################################
+            # flavour = inline
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertEqual(link["data-card-appearance"], 'inline')
+
+            # ##########################################################
+            # flavour = card
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertEqual(link["data-card-appearance"], 'card')
+
+            # ##########################################################
+            # flavour = embed
+            # ##########################################################
+            link = links.pop(0)
+
+            self.assertEqual(link["data-card-appearance"], 'embed')


### PR DESCRIPTION
My initial idea on how we could start handling Confluence Smart Links. My intention is to start a discussion around this and maybe collaborate with you (=

It's just a small start since it is not supporting all the possibilities...

One one side, I've thought about having one role for each `data-card-appearance` and deal with the text similar to what Ref does.

Also there's  the possibility to actually use `<ac:link>` tags for the Links still in the editor v2.... I'd imagine we could expand it with that somehow...

Last but not least, I'm not sure this works for editor v1.

Thanks a lot o/

closes #790 