### PR TITLE
Collapse improvements

### DIFF
--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -140,6 +140,7 @@ Common
 
 .. index:: Macros; Expand Macro (directive)
 .. index:: Expand Macro
+.. _confluence_expand-directive:
 
 .. rst:directive:: confluence_expand
 

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -25,7 +25,7 @@ Type                    Notes
 `bullet lists`_         Supported
 `citations`_            Supported
 `compound paragraph`_   Supported
-`container`_            Unsupported.
+`container`_            Limited support.
 
                         Confluence markup does not permit the use of the
                         ``class`` attribute for tags.

--- a/doc/guide-collapse.rst
+++ b/doc/guide-collapse.rst
@@ -1,0 +1,74 @@
+.. index:: Collapsed
+
+Collapsed content
+=================
+
+There are a series of collapsed element capabilities supported by the
+Confluence builder extension. This guide will cover the available options that
+can be used.
+
+Expand directive
+----------------
+
+.. versionadded:: 1.3
+
+This extension provides a ``confluence_expand`` directive to help collapse
+content. For example:
+
+.. code-block:: rst
+
+    .. confluence_expand::
+
+        This content is captured inside the expand macro.
+
+This directive will only work when using the Confluence builder. See also the
+:ref:`Confluence expand directive <confluence_expand-directive>`.
+
+Class hints
+-----------
+
+.. versionadded:: 2.1 Support added for containers.
+.. versionadded:: 2.0 Support added for code blocks.
+
+This extension provides support for managing collapsed elements when a
+``collapse`` class hint is provided. If a container is defined with the
+style configured, the contents of the directive will be collapsed:
+
+.. code-block:: rst
+
+    .. container:: collapse
+
+        This paragraph should be collapsed.
+
+When using the code block directive, providing a collapse style hint will
+also collapse the code block:
+
+.. code-block:: rst
+
+    .. code-block:: python
+        :class: collapse
+
+        import example
+        example.method()
+
+sphinx-toolbox's collapse directive
+-----------------------------------
+
+.. versionadded:: 1.7
+
+When using the `sphinx-toolbox`_ extension, the ``collapse`` directive
+should be able to manage collapsed content. For example:
+
+.. code-block:: rst
+
+    .. collapse:: Details
+
+        This paragraph should be collapsed.
+
+For more details, please see sphinx-toolbox's documentation on the
+`collapse directive <directive-collapse_>`_.
+
+.. references ------------------------------------------------------------------
+
+.. _directive-collapse: https://sphinx-toolbox.readthedocs.io/en/latest/extensions/collapse.html#directive-collapse
+.. _sphinx-toolbox: https://sphinx-toolbox.readthedocs.io/

--- a/doc/guides.rst
+++ b/doc/guides.rst
@@ -7,5 +7,6 @@ the Confluence Builder extension in a Sphinx-enabled environment.
 .. toctree::
     :maxdepth: 1
 
+    guide-collapse
     guide-math
     guide-ci

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2735,8 +2735,14 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.body.append(self.context.pop())  # acronym
 
     def visit_container(self, node):
-        self.body.append(self._start_tag(node, 'div'))
-        self.context.append(self._end_tag(node))
+        if 'collapse' in node.get('classes', []):
+            self.body.append(self._start_ac_macro(node, 'expand'))
+            self.body.append(self._start_ac_rich_text_body_macro(node))
+            self.context.append(self._end_ac_rich_text_body_macro(node) +
+                self._end_ac_macro(node))
+        else:
+            self.body.append(self._start_tag(node, 'div'))
+            self.context.append(self._end_tag(node))
 
     def depart_container(self, node):
         self.body.append(self.context.pop())  # div

--- a/tests/unit-tests/datasets/collapse/index.rst
+++ b/tests/unit-tests/datasets/collapse/index.rst
@@ -1,0 +1,8 @@
+:orphan:
+
+collapse
+--------
+
+.. container:: collapse
+
+    collapsed paragraph

--- a/tests/unit-tests/test_confluence_collapse.py
+++ b/tests/unit-tests/test_confluence_collapse.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from tests.lib.parse import parse
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+import os
+
+
+class TestConfluenceCollapse(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.dataset = os.path.join(cls.datasets, 'collapse')
+
+    @setup_builder('confluence')
+    def test_storage_confluence_collapse(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            expand_macro = data.find('ac:structured-macro',
+                {'ac:name': 'expand'})
+            self.assertIsNotNone(expand_macro)
+
+            rich_body = expand_macro.find('ac:rich-text-body')
+            self.assertIsNotNone(rich_body)
+
+            text_contents = rich_body.text.strip()
+            self.assertIsNotNone(text_contents)
+            self.assertTrue('collapsed paragraph' in text_contents)


### PR DESCRIPTION
### translator: provide support for collapse-hinted containers

When a document defines a container directive with a `collapse` style, use this as an indication that the content should be wrapped in an expand macro.

### doc: add guide on collapsing content

Provide a guide on information uses the capabilities when wanting to collapse various content.
