### PR TITLE
Support Sphinx 6.2.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,31 +37,30 @@ jobs:
     strategy:
       matrix:
         include:
-            - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.7", toxenv:  py37-sphinx53, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx51, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx53, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx60, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx61, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx51, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx62, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx53, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx60, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx61, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx51, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx62, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx53, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx60, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx61, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx51, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx62, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx52, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx53, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx60, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx61, cache: ~/.cache/pip }
-            - { os:   macos-latest, python: "3.11", toxenv: py311-sphinx61, cache: ~/Library/Caches/pip }
-            - { os: windows-latest, python: "3.11", toxenv: py311-sphinx61, cache: ~\AppData\Local\pip\Cache }
+            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx62, cache: ~/.cache/pip }
+            - { os:   macos-latest, python: "3.11", toxenv: py311-sphinx62, cache: ~/Library/Caches/pip }
+            - { os: windows-latest, python: "3.11", toxenv: py311-sphinx62, cache: ~\AppData\Local\pip\Cache }
             - { os:  ubuntu-latest, python: "3.11", toxenv:         flake8, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv:         pylint, cache: ~/.cache/pip }
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,17 +2,17 @@
 envlist =
     flake8
     pylint
-    py{37}-sphinx{51,52,53}
-    py{38,39,310,311}-sphinx{51,52,53,60,61}
+    py{37}-sphinx{52,53}
+    py{38,39,310,311}-sphinx{52,53,60,61,62}
 
 [testenv]
 deps =
     -r{toxinidir}/requirements_dev.txt
-    sphinx51: sphinx>=5.1,<5.2
     sphinx52: sphinx>=5.2,<5.3
     sphinx53: sphinx>=5.3,<5.4
     sphinx60: sphinx>=6.0,<6.1
     sphinx61: sphinx>=6.1,<6.2
+    sphinx62: sphinx>=6.2,<6.3
 commands =
     {envpython} -m tests {posargs}
 setenv =


### PR DESCRIPTION
With the release of Sphinx 6.2.0, updating tox and CI to test against this version.

- tox: adjust for new sphinx versions (v6.2.x)
- workflows: adjust for new sphinx versions (v6.2.x)