### PR TITLE
support publishing only pages needing updates

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1446,6 +1446,24 @@ Advanced publishing configuration
     See also
     :ref:`Confluence Spaces and Unique Page Names <confluence_unique_page_names>`.
 
+.. confval:: confluence_publish_force
+
+    .. versionadded:: 2.1
+
+    A boolean value on whether or not to force publish page updates even if
+    no changes are detected on the Confluence instance. When a page is
+    published by this extension, a hash of the page will be stored on the
+    Confluence page. This hash can be referred to later by hosts using this
+    extension, by query the hash and comparing it against a locally prepared
+    page update. If hashes match, no attempt will be made to update the
+    specific page. If users are experience issues with this check, they may
+    force publishing by configuring this option to ``True``. By default, this
+    option is disabled with a value of ``False``.
+
+    .. code-block:: python
+
+        confluence_publish_force = True
+
 .. confval:: confluence_publish_intersphinx
 
     .. versionadded:: 1.9

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -189,6 +189,8 @@ def setup(app):
     cm.add_conf('confluence_publish_delay')
     # Subset of documents which are denied to be published.
     cm.add_conf('confluence_publish_denylist')
+    # Whether to check for changes on remote before publishing.
+    cm.add_conf('confluence_publish_force')
     # Disable adding `rest/api` to REST requests.
     cm.add_conf_bool('confluence_publish_disable_api_prefix')
     # Header(s) to use for Confluence REST interaction.

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -23,6 +23,22 @@ class ConfluenceUtil:
     """
 
     @staticmethod
+    def hash(data):
+        """
+        generate a hash of the provided string
+
+        Calculate a hash for a string. When publishing Confluence pages, hashes
+        can be used to check if pages needs to be uploaded again.
+
+        Args:
+            data: the raw string
+
+        Returns:
+            the hash
+        """
+        return sha256(data.encode()).hexdigest()
+
+    @staticmethod
     def hash_asset(asset):
         """
         generate a hash of the provided asset


### PR DESCRIPTION
The following attempts to bring support for publishing pages which only need to be updated. Pages are now published with a properly value of the hash value of a page's contents used by this extension. When a future publish event occurs, this hash is used to compare against newer pages. If the hashes match, no new publish attempt will be made for the page.

---

Originally, attempts were made to try to compare the raw contents of pages to determine if a publish event should occur. Investigation showed a series of issues preventing this from gracefully working:

- Confluence may optimize/tweak the storage format provided (e.g. removing or adding closing tags).
- Confluence would inject attributes in macros ('ri:version-at-save'; which can be filtered out, but there may be other attributes to consider).
- Encoded HTML values provided are presented as uncoded on fetch, making comparisons less ideal; especially when the encoded values are hacks in order for Confluence to properly form content.
