### PR TITLE
translator: skip creating link body for non-inlined cards

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2518,9 +2518,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._start_tag(node, 'ac:link', **attribs))
             self.body.append(self._start_tag(node, 'ri:page',
                 suffix=self.nl, empty=True, **{'ri:content-title': doctitle}))
-            self.body.append(self._start_ac_link_body(node))
-            self.body.append(node.astext())
-            self.body.append(self._end_ac_link_body(node))
             self.body.append(self._end_tag(node, suffix=''))
         else:
             self.warn('unable to build link to document card due to '


### PR DESCRIPTION
Non-inlined cards do not have any node text, which creates a link body that is empty. While Confluence will ignore/remove the empty body on publication, there is no need to add this into prepared pages; cleaning up.