### PR TITLE
config: correct config type for publish-force option

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -190,7 +190,7 @@ def setup(app):
     # Subset of documents which are denied to be published.
     cm.add_conf('confluence_publish_denylist')
     # Whether to check for changes on remote before publishing.
-    cm.add_conf('confluence_publish_force')
+    cm.add_conf_bool('confluence_publish_force')
     # Disable adding `rest/api` to REST requests.
     cm.add_conf_bool('confluence_publish_disable_api_prefix')
     # Header(s) to use for Confluence REST interaction.


### PR DESCRIPTION
The `confluence_publish_force` configuration option is a boolean type; however, the option was added using `add_conf` instead of `add_conf_bool`. Correcting.