### PR TITLE
Fix missing LICENSE in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
 ]
 requires-python = '>=3.7'
 readme = 'README.rst'
-license = {text = 'BSD-2-Clause'}
+license = {file = 'LICENSE'}
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',


### PR DESCRIPTION
The latest [release on PyPI](https://pypi.org/project/sphinxcontrib-confluencebuilder/2.1.0/#files) is missing the `LICENSE` file. Unless I'm mistaken, this is because Flit expects the filename to be specified as the `file` argument under `license`. (The `text` argument is meant for the full license text, not the license identifier.)

I'm repackaging this for conda-forge, and this issue was caught by the infrastructure we have to make sure that all  the licenses are in order.