### PR TITLE
translator: ensure v2 header flag is defined

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -61,6 +61,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self._needs_navnode_spacing = False
         self._reference_context = []
         self._thead_context = []
+        self._v2_header_added = False
         self.colspecs = []
         self._tocdepth = self.state.toctree_depth(self.docname)
 


### PR DESCRIPTION
Internally, the storage translator uses a `_v2_header_added` flag to track header usage. An issue with this implementation is that if no Confluence header is used, no page generation and no source links; the flag value may not be defined when it may be used in some link checks. To correct this, ensure the flag is initialized in the translation's constructor.