### PR TITLE
pyproject.toml: add missing files in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,10 @@ sphinx-build-confluence = 'sphinxcontrib.confluencebuilder.__main__:main'
 
 [tool.flit.module]
 name = 'sphinxcontrib.confluencebuilder'
+
+[tool.flit.sdist]
+include = [
+    'AUTHORS',
+    'LICENSE',
+    'MANIFEST.in',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ maintainers = [
 ]
 requires-python = '>=3.7'
 readme = 'README.rst'
-license = {text = 'BSD-2-Clause'}
 classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Console',


### PR DESCRIPTION
The most recent release (v2.1) generated a source distribution package that did not include a license file (reported by @maresb). This was a result of an incomplete switch from setuptools to flit. Correcting this by listing `LICENSE` as a file to include in the source distribution (as well as other desired files).

Also, the use of a desired SPDX license definition does not appear to be the proper usage of the license text field (PEP-621). It also looks that the use of this key as a table is to be deprecated (PEP-639). To remove a possible incorrect license entry and not update the value to a soon-to-be deprecated value, dropping its usage.

See also #805.