### PR TITLE
🐛 respect both confluence_editor and confluence_full_width

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1132,7 +1132,7 @@ reported a success (which can be permitted for anonymous users).
             page['metadata']['properties']['content-appearance-published'] = {
                 'value': content_appearance,
             }
-            
+
         return page
 
     def _update_page(self, page, page_name, data, parent_id=None):

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1133,7 +1133,6 @@ reported a success (which can be permitted for anonymous users).
                 'value': content_appearance,
             }
             
-
         return page
 
     def _update_page(self, page, page_name, data, parent_id=None):

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1121,11 +1121,7 @@ reported a success (which can be permitted for anonymous users).
         }
 
         if self.editor:
-            page['metadata']['properties'] = {
-                'editor': {
-                    'value': self.editor,
-                },
-            }
+            page['metadata']['properties']['editor'] = {'value': self.editor}
 
         if self.config.confluence_full_width is not None:
             if self.config.confluence_full_width:
@@ -1133,11 +1129,10 @@ reported a success (which can be permitted for anonymous users).
             else:
                 content_appearance = 'default'
 
-            page['metadata']['properties'] = {
-                'content-appearance-published': {
-                    'value': content_appearance,
-                },
+            page['metadata']['properties']['content-appearance-published'] = {
+                'value': content_appearance,
             }
+            
 
         return page
 


### PR DESCRIPTION
Previously, if the 'confluence_editor' was set to v2 and 'confluence_full_width' was set, the v2 setting would not be respected since the dictionary containing it in the metadata field was overwritten. Now both settings will be respected in all permutations.