### PR TITLE
translator: support v1 limited-page-width on server/dc

### DIFF
--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -16,6 +16,13 @@ API_REST_BIND_PATH = 'rest/api'
 #       java/com/atlassian/confluence/pages/AbstractPage::isValidTitleLength
 CONFLUENCE_MAX_TITLE_LEN = 255
 
+# maximum width for a non-full-width page (v1; Server/DC)
+#
+# It has been observed that some stock macros would default to a fixed width
+# of "960" (e.g. when using the Widget Connector macro). We will use this as
+# a reference to the max width to ensure no unexpected overflows.
+CONFLUENCE_MAX_WIDTH = 960
+
 # list of supported editors
 EDITORS = [
     'v1',

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -11,6 +11,7 @@ from sphinx.locale import admonitionlabels
 from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceError
 from sphinxcontrib.confluencebuilder.locale import L
+from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_WIDTH
 from sphinxcontrib.confluencebuilder.std.confluence import FALLBACK_HIGHLIGHT_STYLE
 from sphinxcontrib.confluencebuilder.std.confluence import FCMMO
 from sphinxcontrib.confluencebuilder.std.confluence import INDENT
@@ -167,9 +168,13 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         # developed for v2 and newer). To emulate a non-full-width state with
         # a v1 editor, apply a layout around the page contents.
         if not self.v2 and self.builder.config.confluence_full_width is False:
-            data += '<ac:layout>'
-            data += '<ac:layout-section ac:type="fixed-width">'
-            data += '<ac:layout-cell>'
+            if self.builder.cloud:
+                data += '<ac:layout>'
+                data += '<ac:layout-section ac:type="fixed-width">'
+                data += '<ac:layout-cell>'
+            else:
+                max_width = f'{CONFLUENCE_MAX_WIDTH}px'
+                data += f'<div style="max-width: {max_width}; margin: 0 auto;">'
 
         return data
 
@@ -177,9 +182,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         data = ''
 
         if not self.v2 and self.builder.config.confluence_full_width is False:
-            data += '</ac:layout-cell>'
-            data += '</ac:layout-section>'
-            data += '</ac:layout>'
+            if self.builder.cloud:
+                data += '</ac:layout-cell>'
+                data += '</ac:layout-section>'
+                data += '</ac:layout>'
+            else:
+                data += '</div>'
 
         return data
 

--- a/tests/unit-tests/test_config_full_width.py
+++ b/tests/unit-tests/test_config_full_width.py
@@ -25,8 +25,8 @@ class TestConfluenceConfigFullWidth(ConfluenceTestCase):
             self.assertIsNone(layout)
 
     @setup_builder('confluence')
-    def test_storage_config_full_width_v1_disabled(self):
-        """validate full width modifications for v1 editor (disabled)"""
+    def test_storage_config_full_width_v1_disabled_cloud(self):
+        """validate full width modifications for v1 editor (disabled; cloud)"""
         #
         # The use of `confluence_full_width` would typically advise a
         # Confluence instance the layout type on publish. However, this
@@ -36,6 +36,8 @@ class TestConfluenceConfigFullWidth(ConfluenceTestCase):
 
         config = dict(self.config)
         config['confluence_full_width'] = False
+        config['confluence_server_url'] = \
+            'https://sphinxcontrib-confluencebuilder.atlassian.net/wiki/'
 
         out_dir = self.build(self.dataset, config=config)
 
@@ -50,6 +52,26 @@ class TestConfluenceConfigFullWidth(ConfluenceTestCase):
 
             cell = section.find('ac:layout-cell')
             self.assertIsNotNone(cell)
+
+    @setup_builder('confluence')
+    def test_storage_config_full_width_v1_disabled_dc(self):
+        """validate full width modifications for v1 editor (disabled; dc)"""
+        #
+        # See: test_storage_config_full_width_v1_disabled_cloud
+        #
+        # This is a variant for non-Cloud versions, which needs an explicit
+        # max-width hint.
+
+        config = dict(self.config)
+        config['confluence_full_width'] = False
+
+        out_dir = self.build(self.dataset, config=config)
+
+        with parse('index', out_dir) as data:
+            container = data.find('div')
+            self.assertIsNotNone(container)
+            self.assertTrue(container.has_attr('style'))
+            self.assertIn('max-width', container['style'])
 
     @setup_builder('confluence')
     def test_storage_config_full_width_v1_enabled(self):


### PR DESCRIPTION
When adding support for `confluence_full_width` with a v1 editor, the styling used only worked gracefully on Confluence Cloud. For Confluence Server/DC versions, the applied layout does not enforce any maximum width on the contained content.

To improve this feature on Confluence Server/DC, we will use an alternative formatting for page content. Instead, we will opt to using a single div with a maximum width style applied. The maximum width chosen is based on the observed default max-width for macros when using the WYSIWYG editor.