### PR TITLE
support page-specific editor/full-width overrides

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -295,6 +295,9 @@ Generic configuration
 
         confluence_editor = 'v1'
 
+    For per-document overrides, please see the ``confluence_metadata``
+    :ref:`directive <confluence_metadata>`.
+
 .. |confluence_header_file| replace:: ``confluence_header_file``
 .. _confluence_header_file:
 
@@ -695,6 +698,9 @@ Publishing configuration
 
     See also |confluence_watch|_.
 
+.. |confluence_full_width| replace:: ``confluence_full_width``
+.. _confluence_full_width:
+
 .. confval:: confluence_full_width
 
     .. versionadded:: 2.0
@@ -710,6 +716,9 @@ Publishing configuration
     .. code-block:: python
 
         confluence_full_width = True
+
+    For per-document overrides, please see the ``confluence_metadata``
+    :ref:`directive <confluence_metadata>`.
 
 .. |confluence_global_labels| replace:: ``confluence_global_labels``
 .. _confluence_global_labels:

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -175,10 +175,40 @@ Common
 .. rst:directive:: confluence_metadata
 
     .. versionadded:: 1.3
+    .. versionchanged:: 2.2 Added ``editor`` and ``full-width`` support.
 
     The ``confluence_metadata`` directive allows a user to define metadata
     information to be added during a publish event. This directive supports the
     following options:
+
+    .. rst:directive:option:: editor: value
+        :type: v1, v2
+
+        Pages are publish with the editor type configured through the
+        ``confluence_editor`` option. However, users can override the editor
+        for a specific page using the ``editor`` metadata option.
+
+        .. code-block:: rst
+
+            .. confluence_metadata::
+                :editor: v2
+
+        See also ``confluence_editor`` (:ref:`ref<confluence_editor>`).
+
+    .. rst:directive:option:: full-width: flag
+        :type: boolean
+
+        Pages are publish with the full-width appearance configured through the
+        ``confluence_full_width`` option. However, users can override the
+        appearance for a specific page using the ``full-width`` metadata
+        option.
+
+        .. code-block:: rst
+
+            .. confluence_metadata::
+                :full-width: false
+
+        See also ``confluence_full_width`` (:ref:`ref<confluence_full_width>`).
 
     .. rst:directive:option:: labels: value
         :type: space separated strings
@@ -192,8 +222,8 @@ Common
             .. confluence_metadata::
                 :labels: label-a label-b
 
-    See also ``confluence_global_labels``
-    (:ref:`ref<confluence_global_labels>`).
+        See also ``confluence_global_labels``
+        (:ref:`ref<confluence_global_labels>`).
 
 .. rst:directive:: confluence_newline
 

--- a/sphinxcontrib/confluencebuilder/directives.py
+++ b/sphinxcontrib/confluencebuilder/directives.py
@@ -15,6 +15,7 @@ from sphinxcontrib.confluencebuilder.nodes import confluence_newline
 from sphinxcontrib.confluencebuilder.nodes import confluence_toc
 from sphinxcontrib.confluencebuilder.nodes import jira
 from sphinxcontrib.confluencebuilder.nodes import jira_issue
+from sphinxcontrib.confluencebuilder.std.confluence import EDITORS
 from uuid import UUID
 
 
@@ -183,6 +184,8 @@ class ConfluenceLatexDirective(Directive):
 class ConfluenceMetadataDirective(Directive):
     has_content = False
     option_spec = {
+        'editor': lambda x: directives.choice(x, EDITORS),
+        'full-width': lambda x: directives.choice(x, ('true', 'false')),
         'labels': string_list,
     }
 

--- a/tests/unit-tests/datasets/metadata/index.rst
+++ b/tests/unit-tests/datasets/metadata/index.rst
@@ -2,4 +2,6 @@ confluence metadata
 -------------------
 
 .. confluence_metadata::
+    :editor: v2
+    :full-width: true
     :labels: tag-a tag-c

--- a/tests/unit-tests/test_confluence_metadata.py
+++ b/tests/unit-tests/test_confluence_metadata.py
@@ -20,15 +20,26 @@ class TestConfluenceMetadata(ConfluenceTestCase):
 
             self.assertTrue(builder_metadata)
             self.assertTrue('index' in builder_metadata)
-            doc_labels = builder_metadata['index']
 
-            self.assertTrue(doc_labels)
-            self.assertTrue('labels' in doc_labels)
+            doc_metadata = builder_metadata['index']
+            self.assertTrue(doc_metadata)
 
-            labels = doc_labels['labels']
+            # verify expected editor override
+            self.assertTrue('editor' in doc_metadata)
+            editor = doc_metadata['editor']
+            self.assertEqual(editor, 'v2')
+
+            # verify expected full-width override
+            self.assertTrue('fullWidth' in doc_metadata)
+            editor = doc_metadata['fullWidth']
+            self.assertEqual(editor, 'true')
+
+            # verify expected labels
+            self.assertTrue('labels' in doc_metadata)
+            labels = doc_metadata['labels']
             self.assertEqual(len(labels), 2)
-            self.assertTrue('tag-a' in labels)
-            self.assertTrue('tag-c' in labels)
+            self.assertIn('tag-a', labels)
+            self.assertIn('tag-c', labels)
 
     @setup_builder('html')
     def test_html_confluence_metadata_directive_ignore(self):

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from collections import defaultdict
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from tests.lib import autocleanup_publisher
 from tests.lib import mock_confluence_instance
@@ -59,10 +60,8 @@ class TestConfluencePublisherPage(unittest.TestCase):
             daemon.register_put_rsp(200, dict(page_fetch_rsp))
 
             # perform page update request
-            data = {
-                'content': 'dummy page data',
-                'labels': [],
-            }
+            data = defaultdict(str)
+            data['content'] = 'dummy page data'
             page_id = publisher.store_page_by_id(
                 'dummy-name', expected_page_id, data)
 
@@ -122,10 +121,8 @@ class TestConfluencePublisherPage(unittest.TestCase):
             daemon.register_delete_rsp(200)
 
             # perform page update request
-            data = {
-                'content': 'dummy page data',
-                'labels': [],
-            }
+            data = defaultdict(str)
+            data['content'] = 'dummy page data'
             page_id = publisher.store_page_by_id(
                 'dummy-name', expected_page_id, data)
 


### PR DESCRIPTION
The following introduces support for a documentation set to provide hints if a specific page should use a specific Confluence editor version as well as whether to override the configured full-width option.