### PR TITLE
introduce permit-raw-html option

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1904,6 +1904,42 @@ Advanced processing configuration
 
     See also |confluence_prev_next_buttons_location|_.
 
+.. confval:: confluence_permit_raw_html
+
+    .. versionadded:: 2.2
+
+    .. caution::
+
+        Using this option is considered unsupported. This extension will
+        allow users to directly publish HTML content defined in a document,
+        but there is no guarantees that the content will render as expected,
+        or even be able to be published to a configured Confluence instance.
+
+    Configure whether to permit the use of raw HTML content in generated
+    documents. While Confluence renders pages through a website, content
+    is stored using a "storage" format, which only supports a subset of HTML.
+    Confluence may filter out or reject the publication of pages with certain
+    HTML content.
+
+    Some documentation may rely on HTML-specific content, and if this HTML
+    content is not too complex, this may be renderable on a Confluence
+    instance. Users wanting to allow this can enable this option to have
+    HTML content directly injected on pages, or even placed inside an
+    HTML-supported macro (if such a macro is available for the target
+    Confluence instance):
+
+    .. code-block:: python
+
+        confluence_permit_raw_html = True
+         (or)
+        confluence_permit_raw_html = 'html'
+
+    Using this option is not supported. Content may be automatically
+    stripped when published into Confluence, content may not render as
+    expected (e.g. styles can be ignored, JavaScript will not function)
+    or Confluence may reject the publication of Confluence document (i.e.
+    failing to upload a page).
+
 .. |confluence_remove_title| replace:: ``confluence_remove_title``
 .. _confluence_remove_title:
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -227,6 +227,8 @@ def setup(app):
     cm.add_conf('confluence_mentions', 'confluence')
     # Inject navigational hints into the documentation.
     cm.add_conf('confluence_navdocs_transform')
+    # Enablement of permitting raw html blocks to be used in storage format.
+    cm.add_conf('confluence_permit_raw_html', 'confluence')
     # Remove a detected title from generated documents.
     cm.add_conf_bool('confluence_remove_title', 'confluence')
 
@@ -241,8 +243,6 @@ def setup(app):
     cm.add_conf('confluence_adv_node_handler')
     # Permit any string value to be provided as the editor.
     cm.add_conf('confluence_adv_permit_editor', 'confluence')
-    # Enablement of permitting raw html blocks to be used in storage format.
-    cm.add_conf_bool('confluence_adv_permit_raw_html', 'confluence')
     # List of optional features/macros/etc. restricted for use.
     cm.add_conf('confluence_adv_restricted', 'confluence')
     # Enablement of tracing processed data.
@@ -253,6 +253,8 @@ def setup(app):
     # (configuration - deprecated)
     # replaced by confluence_cleanup_search_mode
     cm.add_conf_bool('confluence_adv_aggressive_search')
+    # replaced by confluence_permit_raw_html
+    cm.add_conf_bool('confluence_adv_permit_raw_html')
     # replaced by confluence_root_homepage
     cm.add_conf('confluence_master_homepage')
     # replaced by confluence_publish_allowlist

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -474,6 +474,23 @@ confluence_parent_page is not a string or a positive integer''')
 
     # ##################################################################
 
+    # confluence_permit_raw_html
+    try:
+        validator.conf('confluence_permit_raw_html').bool()
+    except ConfluenceConfigurationError:
+        try:
+            validator.conf('confluence_permit_raw_html').string()
+        except ConfluenceConfigurationError:
+            raise ConfluenceConfigurationError('''\
+confluence_permit_raw_html is not a boolean or a string
+
+The option 'confluence_permit_raw_html' has been provided to indicate that
+raw HTML should be published. This value can either be set to `True` or
+configured to the name of a supported macro identifier.
+''')
+
+    # ##################################################################
+
     # confluence_prev_next_buttons_location
     try:
         validator.conf('confluence_prev_next_buttons_location') \

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -73,6 +73,10 @@ def apply_defaults(builder):
     if conf.confluence_page_hierarchy is None:
         conf.confluence_page_hierarchy = True
 
+    if conf.confluence_permit_raw_html is None and \
+            conf.confluence_adv_permit_raw_html is not None:
+        conf.confluence_permit_raw_html = conf.confluence_adv_permit_raw_html
+
     if conf.confluence_publish_intersphinx is None:
         conf.confluence_publish_intersphinx = True
 

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -10,6 +10,8 @@ import mimetypes
 DEPRECATED_CONFIGS = {
     'confluence_adv_aggressive_search':
         'use "confluence_cleanup_search_mode" instead',
+    'confluence_adv_permit_raw_html':
+        'use "confluence_permit_raw_html" instead',
     'confluence_adv_trace_data':
         'to be removed in a future version',
     'confluence_adv_writer_no_section_cap':

--- a/tests/sample-sets/raw-html/conf.py
+++ b/tests/sample-sets/raw-html/conf.py
@@ -1,0 +1,10 @@
+extensions = [
+    'myst_parser',
+    'sphinxcontrib.confluencebuilder',
+]
+
+# Raw injection:
+confluence_permit_raw_html = True
+
+# Using macro:
+# confluence_permit_raw_html = 'html'

--- a/tests/sample-sets/raw-html/index.rst
+++ b/tests/sample-sets/raw-html/index.rst
@@ -1,0 +1,15 @@
+raw-html
+========
+
+.. toctree::
+    :maxdepth: 1
+
+    second
+
+----
+
+Some raw HTML:
+
+.. raw:: html
+
+    <a href="https://www.sphinx-doc.org/">sphinx-doc.org</a>

--- a/tests/sample-sets/raw-html/second.md
+++ b/tests/sample-sets/raw-html/second.md
@@ -1,0 +1,11 @@
+second
+======
+
+Some more HTML in Markdown: 
+
+----
+
+<section id="my-nifty-title">
+<h1>My nifty title</h1>
+<p>Some <strong>text</strong>!</p>
+</section>

--- a/tests/sample-sets/raw-html/tox.ini
+++ b/tests/sample-sets/raw-html/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+package_root={toxinidir}{/}..{/}..{/}..
+
+[testenv]
+deps =
+    myst-parser
+commands =
+    {envpython} -m tests.test_sample {posargs}
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+    TOX_INI_DIR={toxinidir}
+passenv = *
+use_develop = true


### PR DESCRIPTION
The following introduces the option `confluence_permit_raw_html` to allow users to force-publish documents with raw HTML content in them. While the use of this option will be unofficially supported, it is being added solely since users keep requesting such a capability.

We unofficially supported some level of this using an undocumented configuration option `confluence_adv_permit_raw_html`, but instead we have renamed the option to `confluence_permit_raw_html` and have added it into the configuration documentation (for users to easily find).

In addition, we have also tweaked the capability to also accept the name of an HTML macro definition. This can allow users to place raw HTML in a supported HTML macro (if enabled on their Confluence instance). While this option is also still considered unsupported, having this provides the most capability we can provide users who want to manage HTML-based content at their own discretion.