### PR TITLE
Support page parent publish overrides

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1587,6 +1587,38 @@ Advanced publishing configuration
 
     See also |confluence_publish_orphan|_.
 
+.. confval:: confluence_parent_override_transform
+
+    .. versionadded:: 2.2
+
+    .. note::
+
+        Using this option may have unexpected results when using certain
+        features of this extension. For example, users with purging
+        enabled may not have pages with parent-ID overrides purged.
+
+    A function to override the specific page to publish a specific document.
+    This option is available for advanced users needing to tailor specific
+    parent pages for individual documents. A provided transform is invoked
+    with the document name and the expected parent page (numerical
+    identifier) the document will be published under. A configuration can
+    tweak the identifier used when publishing. This extension will not check
+    the validity of the identifiers set. If a provided page identifier does
+    not exist or the publishing user does not have access to manipulate the
+    page, the publication will fail with an error provided by Confluence.
+
+    .. code-block:: python
+
+        def my_publish_override(docname, parent_id):
+            if docname == 'special-doc':
+                return 123456
+
+            return parent_id
+
+        confluence_parent_override_transform = my_publish_override
+
+    See also |confluence_parent_page|_.
+
 .. confval:: confluence_request_session_override
 
     .. versionadded:: 1.7

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -135,6 +135,8 @@ def setup(app):
     cm.add_conf('confluence_global_labels')
     # Enablement of configuring root as space's homepage.
     cm.add_conf_bool('confluence_root_homepage')
+    # Translation to override parent page identifier to publish to.
+    cm.add_conf('confluence_parent_override_transform')
     # Parent page's name or identifier to publish documents under.
     cm.add_conf('confluence_parent_page')
     # Perform a dry run of publishing to inspect what publishing will do.

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -510,6 +510,12 @@ class ConfluenceBuilder(Builder):
             uploaded_id = self.publisher.store_page_by_id(title,
                 conf.confluence_publish_root, data)
         else:
+            po_transform = conf.confluence_parent_override_transform
+            if po_transform:
+                new_parent_id = po_transform(docname, parent_id)
+                if new_parent_id:
+                    parent_id = new_parent_id
+
             uploaded_id = self.publisher.store_page(title, data, parent_id)
         self.state.register_upload_id(docname, uploaded_id)
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -446,6 +446,12 @@ The following keys are required:
 
     # ##################################################################
 
+    # confluence_parent_override_transform
+    validator.conf('confluence_parent_override_transform') \
+             .callable_()
+
+    # ##################################################################
+
     try:
         validator.conf('confluence_parent_page').string()
     except ConfluenceConfigurationError:


### PR DESCRIPTION
Adding the option `confluence_parent_override_transform` to allow users to override the specific parent page identifier to use when publishing a document. This is an advanced configuration option for a use case where a single container or hierarchical structure is not desired.

Users can provide a function which accepts a document name and target parent page identifier. The provided identifier will be the expected target for a given document. For no change to a publish target, users can return the same identifier (or `None`). If a new identifier is returned, it will be used instead.

```
def my_publish_override(docname, parent_id):
    if docname == 'special-doc':
        return 123456

    return parent_id

confluence_parent_override_transform = my_publish_override
```

There are most likely limitations when using the override (such as possible issues when also using purging).