### PR TITLE
support sphinxnotes-strike extension

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2931,6 +2931,17 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
     def visit_youtube(self, node):
         self._visit_video(node, 'https://www.youtube.com/watch?v=' + node['id'])
 
+    # -------------------------------------------------------
+    # sphinx -- extension (third party) -- sphinxnotes-strike
+    # -------------------------------------------------------
+
+    def visit_strike_node(self, node):
+        self.body.append(self._start_tag(node, 's'))
+        self.context.append(self._end_tag(node, suffix=''))
+
+    def depart_strike_node(self, node):
+        self.body.append(self.context.pop())  # s
+
     # -------------
     # miscellaneous
     # -------------


### PR DESCRIPTION
Provides partial support when using the sphinxnotes-strike extension. This adds node support to ensure content can be striked; however, there is no immediate way to enable the generation of these nodes in sphinxnotes-strike for the Confluence builder.