### PR TITLE
Support relative publish list

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -191,7 +191,7 @@ class ConfluenceBuilder(Builder):
             if value is None:
                 return None
 
-            value = handle_cli_file_subset(config, option, value)
+            value = handle_cli_file_subset(self, option, value)
             if value is None:
                 return None
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -532,7 +532,7 @@ navigational buttons onto generated pages. Accepted values include 'bottom',
 
         # if provided a file via command line, treat as a list
         def conf_translate(value):
-            return handle_cli_file_subset(config, option, value)
+            return handle_cli_file_subset(builder, option, value)
         value = conf_translate(value)
 
         try:

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -303,7 +303,7 @@ def getpass2(prompt='Password: '):
         return getpass.getpass(prompt=prompt)
 
 
-def handle_cli_file_subset(config, option, value):
+def handle_cli_file_subset(builder, option, value):
     """
     process a file subset entry based on a cli-provided value
 
@@ -313,7 +313,7 @@ def handle_cli_file_subset(config, option, value):
     this is a string, it is most likely a list of files from the command line.
 
     Args:
-        config: the sphinx configuration
+        builder: the confluence builder
         option: the key associated to this configuration value
         value: the configuration value
 
@@ -321,14 +321,22 @@ def handle_cli_file_subset(config, option, value):
         the resolved configuration value
     """
 
-    if option in config['overrides'] and isinstance(value, str):
+    if option in builder.config['overrides'] and isinstance(value, str):
         if not value:
             # an empty command line subset is an "unset" request
             # (and not an empty list); if no values are detected,
             # return `None`
             return None
-        elif not os.path.isfile(value):
-            value = value.split(',')
+        else:
+            if os.path.isabs(value):
+                target_file = value
+            else:
+                target_file = os.path.join(builder.env.srcdir, value)
+
+            if os.path.isfile(target_file):
+                value = target_file
+            else:
+                value = value.split(',')
 
     return value
 

--- a/tests/unit-tests/test_config_publish_list.py
+++ b/tests/unit-tests/test_config_publish_list.py
@@ -67,11 +67,23 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
             call('folder/page-b', ANY),
         ], any_order=True)
 
-    def test_config_publishlist_allow_list_file_default(self):
+    def test_config_publishlist_allow_list_file_default_abs(self):
         publish_list = os.path.join(self.dataset, 'publish-list-default')
 
         config = dict(self.config)
         config['confluence_publish_allowlist'] = publish_list
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('page-a', ANY),
+            call('folder/page-b', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_allow_list_file_default_relative(self):
+        config = dict(self.config)
+        config['confluence_publish_allowlist'] = 'publish-list-default'
 
         with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
             self.build(self.dataset, config=config)
@@ -186,11 +198,22 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
             call('folder/page-b', ANY),
         ], any_order=True)
 
-    def test_config_publishlist_deny_list_file_default(self):
+    def test_config_publishlist_deny_list_file_default_abs(self):
         publish_list = os.path.join(self.dataset, 'publish-list-default')
 
         config = dict(self.config)
         config['confluence_publish_denylist'] = publish_list
+
+        with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
+            self.build(self.dataset, config=config)
+
+        mm.assert_has_calls([
+            call('index', ANY),
+        ], any_order=True)
+
+    def test_config_publishlist_deny_list_file_default_relative(self):
+        config = dict(self.config)
+        config['confluence_publish_denylist'] = 'publish-list-default'
 
         with patch.object(ConfluenceBuilder, 'publish_doc') as mm:
             self.build(self.dataset, config=config)


### PR DESCRIPTION
When a relative path publish list is provided in a configuration, look for the file from within the source directory (which is the expected location when this feature was introduced). This should prevent issues when invoking a Sphinx build from outside a project's source directory.