### PR TITLE
Resolve relative CA file for requests

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -171,7 +171,7 @@ certificate/key-pair, or a 2-tuple of the certificate and key.
         for cert in cert_files:
             if cert and not os.path.isfile(os.path.join(env.srcdir, cert)):
                 raise ConfluenceConfigurationError('''\
-confluence_ca_cert missing certificate file
+confluence_client_cert missing certificate file
 
 The option 'confluence_client_cert' has been provided to find a client
 certificate file from a relative location, but the certificate could not be

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -2,6 +2,7 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from sphinxcontrib.confluencebuilder.util import str2bool
+import os
 
 
 # configures the default editor to publication
@@ -30,6 +31,7 @@ def apply_defaults(builder):
 
     conf = builder.config
     config_manager = builder.app.config_manager_
+    env = builder.env
 
     if conf.confluence_add_secnumbers is None:
         conf.confluence_add_secnumbers = True
@@ -39,6 +41,14 @@ def apply_defaults(builder):
 
     if conf.confluence_adv_restricted is None:
         conf.confluence_adv_restricted = []
+
+    if conf.confluence_ca_cert and not os.path.isabs(conf.confluence_ca_cert):
+        # if the ca path is not an absolute path, the path is a relative
+        # path based on the source directory (i.e. passed configuration
+        # checks); resolve the file here before it eventually gets provided
+        # to Requests
+        conf.confluence_ca_cert = os.path.join(
+            env.srcdir, conf.confluence_ca_cert)
 
     if conf.confluence_cleanup_search_mode is None:
         # the default is `search`, since on Confluence Server/DC; the `direct`

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -354,7 +354,7 @@ class ConfigurationValidation:
             if not isinstance(value, str) or not os.path.exists(
                     os.path.join(self.env.srcdir, value)):
                 raise ConfluenceConfigurationError(
-                    '%s is not a file' % self.key)
+                    '%s is not a path' % self.key)
 
         return self
 


### PR DESCRIPTION
When this extension performs a configuration check for a CA certificate, the check will pass if either the absolute path exists or that a relative path based on the project's source directory exists. However, after checking if the file exists, it passes the raw file into Requests which may not be able to resolve a relative path. To prevent issues, always determine the absolute path of the CA file/directory before providing it to Requests.