### PR TITLE
allow empty legacy pages set for new root content

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -537,7 +537,7 @@ class ConfluenceBuilder(Builder):
         if self.post_cleanup and self.legacy_pages is None:
             if conf.confluence_publish_root:
                 baseid = conf.confluence_publish_root
-            elif conf.confluence_cleanup_from_root and self.root_doc_page_id:
+            elif conf.confluence_cleanup_from_root:
                 baseid = self.root_doc_page_id
             else:
                 baseid = self.parent_id


### PR DESCRIPTION
When determining legacy pages when purging, the base identifier used is either the parent container or a configured root page. When configured to purge from root and the root page does not yet exist, this can give a misrepresentation of what legacy pages are detected when a parent page is also configured.

This commit changes this by force using the detected root page as the cleanup root. And if the cleanup root does not exist, a `None` root will result in an empty legacy pages set (which is expected).