### PR TITLE
config: flexible boolean processing from int value

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -52,7 +52,7 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if isinstance(value, str):
+            if isinstance(value, str) or isinstance(value, int):
                 try:
                     str2bool(value)
                 except ValueError:

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -378,7 +378,7 @@ def str2bool(value):
         ``ValueError`` is raised if the string value is not an accepted string
     """
 
-    value = value.lower()
+    value = str(value).lower()
     if value in ['y', 'yes', 't', 'true', 'on', '1']:
         return True
     elif value in ['n', 'no', 'f', 'false', 'off', '0']:

--- a/tests/unit-tests/test_util_str2bool.py
+++ b/tests/unit-tests/test_util_str2bool.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from sphinxcontrib.confluencebuilder.util import str2bool
+import unittest
+
+
+class TestConfluenceUtilStr2Bool(unittest.TestCase):
+    def test_util_str2bool_invalid(self):
+        with self.assertRaises(ValueError):
+            str2bool(None)
+
+        with self.assertRaises(ValueError):
+            str2bool(2)
+
+        with self.assertRaises(ValueError):
+            str2bool({})
+
+    def test_util_str2bool_true(self):
+        self.assertTrue(str2bool('on'))
+        self.assertTrue(str2bool('ON'))
+        self.assertTrue(str2bool('true'))
+        self.assertTrue(str2bool('TRUE'))
+        self.assertTrue(str2bool('yes'))
+        self.assertTrue(str2bool('YES'))
+        self.assertTrue(str2bool('1'))
+        self.assertTrue(str2bool(1))
+
+    def test_util_str2bool_false(self):
+        self.assertFalse(str2bool('false'))
+        self.assertFalse(str2bool('FALSE'))
+        self.assertFalse(str2bool('no'))
+        self.assertFalse(str2bool('NO'))
+        self.assertFalse(str2bool('off'))
+        self.assertFalse(str2bool('OFF'))
+        self.assertFalse(str2bool('0'))
+        self.assertFalse(str2bool(0))


### PR DESCRIPTION
For a boolean configuration entry, accept an integer representation of 0/1 to be used to represent a false/true state. This extension already accepted these values as string value, and allowing their integer variant should make things more flexible for users (if they desire).
