### PR TITLE
workflows: expand/tweak test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       matrix:
         include:
+            # test each python/sphinx pair supported
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx61, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx62, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx70, cache: ~/.cache/pip }
@@ -56,13 +57,21 @@ jobs:
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx70, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx71, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx72, cache: ~/.cache/pip }
-            - { os:   macos-latest, python: "3.11", toxenv: py311-sphinx72, cache: ~/Library/Caches/pip }
-            - { os: windows-latest, python: "3.11", toxenv: py311-sphinx72, cache: ~\AppData\Local\pip\Cache }
+            - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx61, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx62, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx70, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx71, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx72, cache: ~/.cache/pip }
+
+            # other OSes
+            #  - test against all other supported OSes, using most recent interpreter/sphinx
             - { os:   macos-latest, python: "3.12", toxenv: py312-sphinx72, cache: ~/Library/Caches/pip }
             - { os: windows-latest, python: "3.12", toxenv: py312-sphinx72, cache: ~\AppData\Local\pip\Cache }
-            - { os:  ubuntu-latest, python: "3.11", toxenv:         flake8, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.11", toxenv:         pylint, cache: ~/.cache/pip }
+
+            # linting
+            #  - any OS, using most recent interpreter
+            - { os: ubuntu-latest, python: "3.12", toxenv: flake8, cache: ~/.cache/pip }
+            - { os: ubuntu-latest, python: "3.12", toxenv: pylint, cache: ~/.cache/pip }
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Updating the build workflow to ensure each supported Sphinx version under Python 3.12 is tested.

In addition, this commit drops the the OSX/Windows tests on Python 3.11 since (ideally) the Python 3.12 tests should be enough; and bumping the linting tests to run on the most recent version of Python.