### PR TITLE
support csv width hints in v2 editor

### DIFF
--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -7,6 +7,13 @@ import os
 # confluence trailing bind path for rest api
 API_REST_BIND_PATH = 'rest/api'
 
+# default width for a table (v2 editor)
+#
+# It has been observed that when attempting to fix specific column widths on
+# a table in the v2 editor, Confluence applies a default data width of 760 on
+# the table.
+CONFLUENCE_DEFAULT_V2_TABLE_WIDTH = 760
+
 # maximum length for a confluence page title
 #
 # The maximum length of a Confluence page is set to 255. This is a Confluence-

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -12,6 +12,7 @@ from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceError
 from sphinxcontrib.confluencebuilder.locale import L
 from sphinxcontrib.confluencebuilder.nodes import confluence_parameters_fetch as PARAMS
+from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_WIDTH
 from sphinxcontrib.confluencebuilder.std.confluence import FALLBACK_HIGHLIGHT_STYLE
 from sphinxcontrib.confluencebuilder.std.confluence import FCMMO
@@ -1055,6 +1056,14 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         table_classes = node.get('classes', [])
         attribs = {}
+
+        # For v2 editor, if we have given explicit widths for columns in the
+        # table (e.g. CSV table), we need to apply a data table width or the
+        # editor will ignore the column-specific widths. If widths are
+        # detected, apply the default table width observed when using the v2
+        # editor.
+        if self.v2 and 'colwidths-given' in table_classes:
+            attribs['data-table-width'] = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 
         # [sphinxcontrib-needs]
         # force needs tables to a maximum width

--- a/tests/validation-sets/restructuredtext/csv-table.rst
+++ b/tests/validation-sets/restructuredtext/csv-table.rst
@@ -1,16 +1,6 @@
 CSV Table
 =========
 
-.. only:: confluence_storage
-
-    .. ifconfig:: confluence_editor == 'v2'
-
-        .. attention::
-
-            Limitations using the Fabric (``v2``) editor:
-
-            - Confluence does not support customizing column widths.
-
 reStructuredText defines a `csv-table`_. Example markup is as follows:
 
 .. code-block:: none


### PR DESCRIPTION
When using CSV tables with width hints, the v2 editor looks to ignore the percentages applied on the column tags. However, if we provide an explicit data width value on the table, percentages are taken into consideration.

This commit tweaks the tables in v2 editor so that if column widths are detected, we apply the default width typically given to a table in the v2 editor to help allow column hints to work.