### PR TITLE
validation: remove comment on production lists and code lines

### DIFF
--- a/tests/validation-sets/sphinx/production-list.rst
+++ b/tests/validation-sets/sphinx/production-list.rst
@@ -1,16 +1,6 @@
 Production list
 ===============
 
-.. only:: confluence_storage
-
-    .. ifconfig:: confluence_editor == 'v2'
-
-        .. attention::
-
-            Limitations using the Fabric (``v2``) editor:
-
-            - Confluence does not support disabling code lines.
-
 Sphinx defines a `production list`_. Example markup is as follows:
 
 .. code-block:: none


### PR DESCRIPTION
It appears that Confluence's use of `pre` tags no longer injects code lines for the content. This means rendered production lists no longer have the undesired code lines. Removing this limitation notice.