### PR TITLE
Validation set cleanup

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -33,6 +33,7 @@ class TestConfluenceValidation(unittest.TestCase):
         cls.config = prepare_conf()
         cls.config['extensions'].append('sphinx.ext.ifconfig')
         cls.config['confluence_disable_notifications'] = True
+        cls.config['confluence_full_width'] = False
         cls.config['confluence_page_hierarchy'] = True
         cls.config['confluence_page_generation_notice'] = True
         cls.config['confluence_parent_page'] = None

--- a/tests/validation-sets/base/index.rst
+++ b/tests/validation-sets/base/index.rst
@@ -1,3 +1,6 @@
+.. confluence_metadata::
+    :full-width: true
+
 |test_key|
 ==========
 

--- a/tests/validation-sets/base/index.rst
+++ b/tests/validation-sets/base/index.rst
@@ -19,11 +19,18 @@ as well as show possible limitations.
     <br /></ac:layout-cell></ac:layout-section>
     <ac:layout-section ac:type="two_equal"><ac:layout-cell>
 
+.. Unable to link images to document pages (unsupported by Sphinx/docutils),
+   but to improve user experience, we create a dummy reference so that when
+   clicking on the images, it doesn't do anything (instead of having Confluence
+   zoom into the image).
+.. _dummy:
+
 :doc:`editor_v1`
 ----------------
 
 .. image:: left.png
    :align: center
+   :target: `dummy`_
    :width: 130px
 
 - Largest compatibility with Sphinx's features.
@@ -40,6 +47,7 @@ as well as show possible limitations.
 
 .. image:: right.png
    :align: center
+   :target: `dummy`_
    :width: 130px
 
 - Confluence's newer editor is more stylish.


### PR DESCRIPTION
### validation: default to collapsed width for validation pages

Adjust the widths for validation pages to be collapsed width by default. This makes all v1 pages render in the smaller-width environment, providing a similar look to the v2 pages.

Although, we place an exception for the leading page based on how we present the editor choice and custom widths for images used.

### validation: apply dummy target for base page images

When rendering images on the base page for both editors, users will typically click on the images to jump to an editor selection, instead of the header link. This causes the images to expand ~ where users then unexpand then click on the header links.

While ideally users can click on these images to jump to the respective editor document pages, Sphinx/docutils does not support processing document links in the image's `target` option.

To deal with this scenario, we inject a custom reference link on the current page. This then suppresses the zooming of the images and "consuming" the click event.