### PR TITLE
translator: correct v2 support tracking for documents

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -59,7 +59,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.numfig_format = config.numfig_format
         self.secnumber_suffix = config.confluence_secnumber_suffix
         self.todo_include_todos = getattr(config, 'todo_include_todos', None)
-        self.v2 = config.confluence_editor == 'v2'
         self._building_footnotes = False
         self._figure_context = []
         self._indent_level = 0
@@ -81,6 +80,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         fw_override = metadata.get('fullWidth')
         if fw_override:
             self.confluence_full_width = (fw_override == 'true')
+
+        # helper to track a v2 editor
+        self.v2 = self.editor == 'v2'
 
     def encode(self, text):
         text = encode_storage_format(text)


### PR DESCRIPTION
When processing individual documents through a translator, a v2 flag is used to help easily indicate if the page is expected to be rendered in a v1 or v2 editor. While the flag worked based on the global configuration setting the editor, if any page-specific overrides are configured in the meta directive, this could cause the flag to be incorrect set for a document.

This commit moves the helper flag to be configured after processing the metadata for a document, ensuring v2 is set considering both the global configuration value and the page-specific override value.