### PR TITLE
Improve anchor links

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -321,15 +321,11 @@ class ConfluenceBuilder(Builder):
                 self.state.register_toctree_depth(
                     docname, toctree.get('maxdepth'))
 
-            # register title targets for references; however, not for v2
-            # editor since internal page links do not support linking
-            # directly to headers, so we will need to still generate anchors
-            # for these headers
-            if self.config.confluence_editor != 'v2':
-                self._register_doctree_title_targets(docname, doctree)
-
             # post-prepare a ready doctree
             self._prepare_doctree_writing(docname, doctree)
+
+            # register title targets for references
+            self._register_doctree_title_targets(docname, doctree)
 
         # register titles for special documents (if needed); if a title is not
         # already set from a placeholder document, configure a default title

--- a/tests/sample-sets/header-links/conf.py
+++ b/tests/sample-sets/header-links/conf.py
@@ -1,0 +1,10 @@
+extensions = [
+    'myst_parser',
+    'sphinxcontrib.confluencebuilder',
+]
+
+myst_enable_extensions = [
+    'colon_fence',
+]
+
+myst_heading_anchors = 7

--- a/tests/sample-sets/header-links/index.rst
+++ b/tests/sample-sets/header-links/index.rst
@@ -1,0 +1,14 @@
+Index
+=====
+
+.. toctree::
+    :maxdepth: 1
+
+    rst-v1-first
+    rst-v1-second
+    rst-v2-first
+    rst-v2-second
+    md-v1-first
+    md-v1-second
+    md-v2-first
+    md-v2-second

--- a/tests/sample-sets/header-links/md-v1-first.md
+++ b/tests/sample-sets/header-links/md-v1-first.md
@@ -1,0 +1,19 @@
+:::{confluence_metadata}
+:editor: v1
+:::
+
+# Markdown v1 First
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris egestas enim ex, quis rhoncus erat vulputate luctus. Donec neque leo, sodales vitae orci sit amet, consectetur congue ipsum. Morbi egestas fermentum nibh pulvinar egestas. Nunc bibendum lobortis orci et tempor. In rhoncus libero ornare est aliquam, id dictum urna ultricies. Donec pretium eros nunc, sit amet ultrices justo blandit in. Aenean vitae blandit ligula. Morbi augue odio, placerat in mi vitae, luctus hendrerit risus. Aliquam in neque mauris. Quisque porta felis nunc, ac porta elit aliquet vitae. Fusce fringilla, ex ac tincidunt pharetra, ligula tellus facilisis purus, semper blandit lectus orci sit amet sapien. Integer sagittis enim purus, a ornare felis malesuada eu. Aenean vel dui bibendum, ornare risus et, commodo velit.
+
+Cras ullamcorper, dui id feugiat sagittis, magna mauris volutpat mi, quis pulvinar ante urna a nisi. Maecenas quam nisl, tempor eu aliquam in, lacinia ut nisi. Maecenas ut sem eu lorem convallis consectetur. Proin ornare purus sit amet aliquam maximus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Duis condimentum fermentum aliquam. Aenean non tempor purus. Aliquam erat volutpat. Ut ac quam at velit viverra hendrerit. Curabitur commodo arcu sed nisi ultrices, eget mollis sapien pellentesque. Vestibulum venenatis, mauris at aliquet malesuada, tortor arcu ultricies lorem, non mollis nisi erat sed elit. Suspendisse potenti. Cras vitae dolor vel sem porta congue. Donec vehicula eros ut magna finibus semper. Phasellus a consequat massa.
+
+Nam placerat faucibus tellus, a volutpat nibh imperdiet at. Aenean egestas, tellus at commodo mollis, nibh lacus porta tellus, eget commodo erat massa ac orci. Proin at eros eu velit gravida aliquam. Phasellus vel feugiat augue. Proin tristique iaculis lobortis. Integer id bibendum ante. Duis lacinia sodales libero, at euismod quam eleifend id. Vestibulum laoreet dolor vitae scelerisque dignissim.
+
+## Markdown v1 First sub-heading
+
+Aenean rhoncus magna metus. Aenean malesuada leo sed orci ultrices pulvinar in ut eros. Etiam a fringilla arcu, vitae vehicula eros. Suspendisse potenti. Proin dignissim risus ut vulputate imperdiet. Praesent quis placerat velit, eu pellentesque ante. Integer sed pretium risus, at hendrerit urna. Proin consequat gravida nunc vitae euismod. Curabitur ut massa at nulla molestie auctor. Phasellus euismod euismod dictum. Nulla volutpat purus eu sapien maximus, nec euismod tortor finibus.
+
+Maecenas posuere nunc nec maximus scelerisque. Cras viverra scelerisque pulvinar. Phasellus posuere tristique dui eget rhoncus. Fusce ultricies posuere pharetra. Quisque finibus diam dolor, in consequat nisl pellentesque in. Morbi sodales nulla ut tempor congue. Nulla congue vehicula eros eu pellentesque. In sollicitudin ullamcorper lacinia. Pellentesque suscipit ante in sollicitudin pulvinar. Nulla tellus nibh, molestie nec massa nec, varius sodales ex.
+
+Nunc eget enim a nisi pretium imperdiet. Proin auctor euismod porttitor. Sed molestie imperdiet erat. Nam ut nisl porttitor nibh scelerisque vehicula. Proin pharetra, dui nec finibus posuere, nunc ex fringilla massa, sit amet interdum purus purus vitae sem. Morbi vitae enim gravida, aliquam eros nec, malesuada eros. Proin tristique sodales fermentum. Donec tristique condimentum nulla a pretium. Cras rutrum feugiat venenatis. Ut interdum vitae justo in rutrum. Etiam rutrum eleifend nulla ullamcorper consequat.

--- a/tests/sample-sets/header-links/md-v1-second.md
+++ b/tests/sample-sets/header-links/md-v1-second.md
@@ -1,0 +1,47 @@
+:::{confluence_metadata}
+:editor: v1
+:::
+
+# Markdown v1 Second
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce lacinia scelerisque bibendum. Suspendisse in ligula sit amet ipsum eleifend tempus. In congue augue sed elit tincidunt congue. Curabitur ut nisl quis mauris dictum dictum. Donec volutpat purus purus, eget dapibus odio facilisis id. Aliquam sit amet tincidunt lacus. Vestibulum nec neque id dui rhoncus euismod. Nunc ornare ipsum et semper hendrerit. Cras eget mi ultrices, mollis nulla a, dignissim elit. Ut pharetra ultricies vestibulum. Suspendisse ex lorem, dictum et congue in, pharetra vitae mi.
+
+Sed mollis mauris tortor, quis consectetur ex tristique ut. Nulla eu nisl vitae odio fringilla faucibus. Etiam vestibulum vehicula mollis. Maecenas lacinia tempor consectetur. Aliquam sed tempor purus. Suspendisse ex dui, venenatis et tortor vel, mollis laoreet tellus. Fusce eu porttitor ante. Sed maximus odio nisi, nec commodo turpis faucibus sit amet. Maecenas et maximus tellus. Vivamus eget pellentesque velit. In in ex mauris. Ut vestibulum facilisis pulvinar. Suspendisse fringilla non est ornare sagittis. Donec sagittis rhoncus eros, et imperdiet leo. Maecenas elementum fermentum turpis nec porta.
+
+Duis quam magna, rhoncus id erat ut, placerat eleifend est. Donec eget tellus felis. In ac enim gravida, consectetur metus in, dapibus ligula. Donec consequat augue efficitur vulputate ultrices. Sed scelerisque tortor ex, sit amet imperdiet elit tincidunt commodo. Aenean ac mi suscipit, tincidunt neque id, tincidunt turpis. Fusce aliquam aliquet nisl a porta. Nam aliquam nibh eget metus mollis posuere.
+
+## Markdown v1 Second sub-heading
+
+Praesent ullamcorper quis elit maximus ultricies. Suspendisse id sagittis mauris. Aliquam mattis, augue eget laoreet lacinia, enim sapien ultrices lacus, vel gravida elit nisl et neque. Praesent venenatis imperdiet varius. Curabitur efficitur, ligula at vestibulum tempus, ligula quam tempus ex, quis semper ipsum velit quis dui. Proin ac augue ultrices, egestas felis ut, euismod mi. Sed sed ipsum in mi cursus fermentum. Integer nec risus non felis imperdiet iaculis. Sed euismod gravida metus id ullamcorper. Quisque varius risus non ligula porta mollis. Duis consectetur tortor eu congue laoreet. Aenean eu nulla non tortor ultrices mollis quis ut purus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+
+Sed a sodales ipsum, quis efficitur leo. Aliquam vitae rutrum lacus, vitae eleifend enim. Duis vestibulum eget enim in bibendum. Morbi sagittis varius justo. Fusce semper aliquam massa, et iaculis sem lacinia semper. Morbi ullamcorper nisl auctor iaculis finibus. Praesent accumsan non turpis a venenatis. Donec tincidunt tortor quis auctor ultrices. In sit amet tempus justo. Ut commodo eros eget convallis auctor. Vivamus euismod ipsum est, et maximus tellus dapibus et. Suspendisse aliquet sit amet lectus ut rutrum. Suspendisse potenti. Maecenas ultrices dignissim consectetur.
+
+Donec blandit, nisi sit amet imperdiet tempor, felis lectus semper justo, et varius sem mauris id sapien. Quisque tincidunt leo laoreet ante tempus, in dictum nisl pellentesque. Sed eu ultricies magna. Aenean purus massa, scelerisque vitae aliquam eu, lobortis a urna. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris vel molestie nisi. Praesent euismod interdum arcu, molestie tristique odio scelerisque eu. Proin at porta dui, eget dignissim diam. Phasellus nec malesuada orci, sit amet semper nulla. Nullam varius ultricies risus, mollis efficitur dui.
+
+## Markdown v1 Second sub-heading [(jump above)](#markdown-v1-second-sub-heading)
+
+:::{note}
+The link in the above header should jump to the first sub-header above.
+:::
+
+In pulvinar aliquet consequat. Phasellus aliquet fermentum lectus eu tempor. Vivamus aliquet, risus nec auctor imperdiet, orci mauris pellentesque eros, eget viverra tellus urna sed lectus. Donec a sem eget turpis volutpat venenatis id a enim. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec sit amet finibus purus. In id hendrerit est, ac mollis dolor. Nam sodales a libero sed dapibus. Vestibulum sit amet sagittis urna, ut ornare lectus. Proin mattis dui id nulla consequat, ac tempor dolor fermentum. Ut finibus sem augue, vel luctus libero imperdiet non. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut sed tellus non sapien imperdiet laoreet. Aliquam vestibulum nulla a sagittis luctus. Donec finibus rutrum risus.
+
+Aliquam erat volutpat. Aenean sit amet ligula sed odio mollis efficitur. Nulla pharetra imperdiet dui quis eleifend. Nunc pretium nulla vitae nibh suscipit pulvinar. Nunc in fermentum orci. Praesent vitae sapien facilisis nisi elementum scelerisque sit amet et velit. In dictum nulla turpis, a laoreet diam rutrum a. Nullam in fringilla sapien. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec lacus massa, fringilla ut neque ac, euismod tempor augue. Nam cursus, mauris at eleifend semper, dui massa tincidunt nunc, eu gravida lorem tellus quis lacus. Curabitur suscipit ipsum vitae dignissim semper. Aenean eget ultrices metus. Cras vel elementum orci. Curabitur ut justo non purus tempus consequat. Nulla eros quam, ultrices et diam vitae, porta tempor leo.
+
+---
+
+This should link to the top of this page: [](#markdown-v1-second)
+
+This should link to the sub-heading on this page: [](#markdown-v1-second-sub-heading)
+
+This should link to the second sub-heading on this page: [](#markdown-v1-second-sub-heading-jump-above)
+
+This should link to the top of the second page (v1): [**link text**](./md-v1-first.md#markdown-v1-first)
+
+This should link to the second page's (v1) sub-heading: [**link text**](./md-v1-first.md#markdown-v1-first-sub-heading)
+
+---
+
+This should link to the top of the second page (v2): [**link text**](./md-v2-first.md#markdown-v2-first)
+
+This should link to the second page's (v2) sub-heading: [**link text**](./md-v2-first.md#markdown-v2-first-sub-heading)

--- a/tests/sample-sets/header-links/md-v2-first.md
+++ b/tests/sample-sets/header-links/md-v2-first.md
@@ -1,0 +1,19 @@
+:::{confluence_metadata}
+:editor: v2
+:::
+
+# Markdown v2 First
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris egestas enim ex, quis rhoncus erat vulputate luctus. Donec neque leo, sodales vitae orci sit amet, consectetur congue ipsum. Morbi egestas fermentum nibh pulvinar egestas. Nunc bibendum lobortis orci et tempor. In rhoncus libero ornare est aliquam, id dictum urna ultricies. Donec pretium eros nunc, sit amet ultrices justo blandit in. Aenean vitae blandit ligula. Morbi augue odio, placerat in mi vitae, luctus hendrerit risus. Aliquam in neque mauris. Quisque porta felis nunc, ac porta elit aliquet vitae. Fusce fringilla, ex ac tincidunt pharetra, ligula tellus facilisis purus, semper blandit lectus orci sit amet sapien. Integer sagittis enim purus, a ornare felis malesuada eu. Aenean vel dui bibendum, ornare risus et, commodo velit.
+
+Cras ullamcorper, dui id feugiat sagittis, magna mauris volutpat mi, quis pulvinar ante urna a nisi. Maecenas quam nisl, tempor eu aliquam in, lacinia ut nisi. Maecenas ut sem eu lorem convallis consectetur. Proin ornare purus sit amet aliquam maximus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Duis condimentum fermentum aliquam. Aenean non tempor purus. Aliquam erat volutpat. Ut ac quam at velit viverra hendrerit. Curabitur commodo arcu sed nisi ultrices, eget mollis sapien pellentesque. Vestibulum venenatis, mauris at aliquet malesuada, tortor arcu ultricies lorem, non mollis nisi erat sed elit. Suspendisse potenti. Cras vitae dolor vel sem porta congue. Donec vehicula eros ut magna finibus semper. Phasellus a consequat massa.
+
+Nam placerat faucibus tellus, a volutpat nibh imperdiet at. Aenean egestas, tellus at commodo mollis, nibh lacus porta tellus, eget commodo erat massa ac orci. Proin at eros eu velit gravida aliquam. Phasellus vel feugiat augue. Proin tristique iaculis lobortis. Integer id bibendum ante. Duis lacinia sodales libero, at euismod quam eleifend id. Vestibulum laoreet dolor vitae scelerisque dignissim.
+
+## Markdown v2 First sub-heading
+
+Aenean rhoncus magna metus. Aenean malesuada leo sed orci ultrices pulvinar in ut eros. Etiam a fringilla arcu, vitae vehicula eros. Suspendisse potenti. Proin dignissim risus ut vulputate imperdiet. Praesent quis placerat velit, eu pellentesque ante. Integer sed pretium risus, at hendrerit urna. Proin consequat gravida nunc vitae euismod. Curabitur ut massa at nulla molestie auctor. Phasellus euismod euismod dictum. Nulla volutpat purus eu sapien maximus, nec euismod tortor finibus.
+
+Maecenas posuere nunc nec maximus scelerisque. Cras viverra scelerisque pulvinar. Phasellus posuere tristique dui eget rhoncus. Fusce ultricies posuere pharetra. Quisque finibus diam dolor, in consequat nisl pellentesque in. Morbi sodales nulla ut tempor congue. Nulla congue vehicula eros eu pellentesque. In sollicitudin ullamcorper lacinia. Pellentesque suscipit ante in sollicitudin pulvinar. Nulla tellus nibh, molestie nec massa nec, varius sodales ex.
+
+Nunc eget enim a nisi pretium imperdiet. Proin auctor euismod porttitor. Sed molestie imperdiet erat. Nam ut nisl porttitor nibh scelerisque vehicula. Proin pharetra, dui nec finibus posuere, nunc ex fringilla massa, sit amet interdum purus purus vitae sem. Morbi vitae enim gravida, aliquam eros nec, malesuada eros. Proin tristique sodales fermentum. Donec tristique condimentum nulla a pretium. Cras rutrum feugiat venenatis. Ut interdum vitae justo in rutrum. Etiam rutrum eleifend nulla ullamcorper consequat.

--- a/tests/sample-sets/header-links/md-v2-second.md
+++ b/tests/sample-sets/header-links/md-v2-second.md
@@ -1,0 +1,47 @@
+:::{confluence_metadata}
+:editor: v2
+:::
+
+# Markdown v2 Second
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce lacinia scelerisque bibendum. Suspendisse in ligula sit amet ipsum eleifend tempus. In congue augue sed elit tincidunt congue. Curabitur ut nisl quis mauris dictum dictum. Donec volutpat purus purus, eget dapibus odio facilisis id. Aliquam sit amet tincidunt lacus. Vestibulum nec neque id dui rhoncus euismod. Nunc ornare ipsum et semper hendrerit. Cras eget mi ultrices, mollis nulla a, dignissim elit. Ut pharetra ultricies vestibulum. Suspendisse ex lorem, dictum et congue in, pharetra vitae mi.
+
+Sed mollis mauris tortor, quis consectetur ex tristique ut. Nulla eu nisl vitae odio fringilla faucibus. Etiam vestibulum vehicula mollis. Maecenas lacinia tempor consectetur. Aliquam sed tempor purus. Suspendisse ex dui, venenatis et tortor vel, mollis laoreet tellus. Fusce eu porttitor ante. Sed maximus odio nisi, nec commodo turpis faucibus sit amet. Maecenas et maximus tellus. Vivamus eget pellentesque velit. In in ex mauris. Ut vestibulum facilisis pulvinar. Suspendisse fringilla non est ornare sagittis. Donec sagittis rhoncus eros, et imperdiet leo. Maecenas elementum fermentum turpis nec porta.
+
+Duis quam magna, rhoncus id erat ut, placerat eleifend est. Donec eget tellus felis. In ac enim gravida, consectetur metus in, dapibus ligula. Donec consequat augue efficitur vulputate ultrices. Sed scelerisque tortor ex, sit amet imperdiet elit tincidunt commodo. Aenean ac mi suscipit, tincidunt neque id, tincidunt turpis. Fusce aliquam aliquet nisl a porta. Nam aliquam nibh eget metus mollis posuere.
+
+## Markdown v2 Second sub-heading
+
+Praesent ullamcorper quis elit maximus ultricies. Suspendisse id sagittis mauris. Aliquam mattis, augue eget laoreet lacinia, enim sapien ultrices lacus, vel gravida elit nisl et neque. Praesent venenatis imperdiet varius. Curabitur efficitur, ligula at vestibulum tempus, ligula quam tempus ex, quis semper ipsum velit quis dui. Proin ac augue ultrices, egestas felis ut, euismod mi. Sed sed ipsum in mi cursus fermentum. Integer nec risus non felis imperdiet iaculis. Sed euismod gravida metus id ullamcorper. Quisque varius risus non ligula porta mollis. Duis consectetur tortor eu congue laoreet. Aenean eu nulla non tortor ultrices mollis quis ut purus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.
+
+Sed a sodales ipsum, quis efficitur leo. Aliquam vitae rutrum lacus, vitae eleifend enim. Duis vestibulum eget enim in bibendum. Morbi sagittis varius justo. Fusce semper aliquam massa, et iaculis sem lacinia semper. Morbi ullamcorper nisl auctor iaculis finibus. Praesent accumsan non turpis a venenatis. Donec tincidunt tortor quis auctor ultrices. In sit amet tempus justo. Ut commodo eros eget convallis auctor. Vivamus euismod ipsum est, et maximus tellus dapibus et. Suspendisse aliquet sit amet lectus ut rutrum. Suspendisse potenti. Maecenas ultrices dignissim consectetur.
+
+Donec blandit, nisi sit amet imperdiet tempor, felis lectus semper justo, et varius sem mauris id sapien. Quisque tincidunt leo laoreet ante tempus, in dictum nisl pellentesque. Sed eu ultricies magna. Aenean purus massa, scelerisque vitae aliquam eu, lobortis a urna. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris vel molestie nisi. Praesent euismod interdum arcu, molestie tristique odio scelerisque eu. Proin at porta dui, eget dignissim diam. Phasellus nec malesuada orci, sit amet semper nulla. Nullam varius ultricies risus, mollis efficitur dui.
+
+## Markdown v2 Second sub-heading [(jump above)](#markdown-v2-second-sub-heading)
+
+:::{note}
+The link in the above header should jump to the first sub-header above.
+:::
+
+In pulvinar aliquet consequat. Phasellus aliquet fermentum lectus eu tempor. Vivamus aliquet, risus nec auctor imperdiet, orci mauris pellentesque eros, eget viverra tellus urna sed lectus. Donec a sem eget turpis volutpat venenatis id a enim. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Donec sit amet finibus purus. In id hendrerit est, ac mollis dolor. Nam sodales a libero sed dapibus. Vestibulum sit amet sagittis urna, ut ornare lectus. Proin mattis dui id nulla consequat, ac tempor dolor fermentum. Ut finibus sem augue, vel luctus libero imperdiet non. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Ut sed tellus non sapien imperdiet laoreet. Aliquam vestibulum nulla a sagittis luctus. Donec finibus rutrum risus.
+
+Aliquam erat volutpat. Aenean sit amet ligula sed odio mollis efficitur. Nulla pharetra imperdiet dui quis eleifend. Nunc pretium nulla vitae nibh suscipit pulvinar. Nunc in fermentum orci. Praesent vitae sapien facilisis nisi elementum scelerisque sit amet et velit. In dictum nulla turpis, a laoreet diam rutrum a. Nullam in fringilla sapien. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec lacus massa, fringilla ut neque ac, euismod tempor augue. Nam cursus, mauris at eleifend semper, dui massa tincidunt nunc, eu gravida lorem tellus quis lacus. Curabitur suscipit ipsum vitae dignissim semper. Aenean eget ultrices metus. Cras vel elementum orci. Curabitur ut justo non purus tempus consequat. Nulla eros quam, ultrices et diam vitae, porta tempor leo.
+
+---
+
+This should link to the top of this page: [](#markdown-v2-second)
+
+This should link to the sub-heading on this page: [](#markdown-v2-second-sub-heading)
+
+This should link to the second sub-heading on this page: [](#markdown-v2-second-sub-heading-jump-above)
+
+This should link to the top of the second page (v2): [**link text**](./md-v2-first.md#markdown-v2-first)
+
+This should link to the second page's (v2) sub-heading: [**link text**](./md-v2-first.md#markdown-v2-first-sub-heading)
+
+---
+
+This should link to the top of the second page (v1): [**link text**](./md-v1-first.md#markdown-v1-first)
+
+This should link to the second page's (v1) sub-heading: [**link text**](./md-v1-first.md#markdown-v1-first-sub-heading)

--- a/tests/sample-sets/header-links/rst-v1-first.rst
+++ b/tests/sample-sets/header-links/rst-v1-first.rst
@@ -1,0 +1,90 @@
+.. confluence_metadata::
+    :editor: v1
+
+.. _main-rst-v1:
+
+reStructuredText v1 First 
+=========================
+
+Fusce dignissim, sapien sit amet lobortis congue, magna augue efficitur justo, at ultricies leo mi vitae sapien. Nam iaculis orci quis ullamcorper faucibus. Mauris a enim justo. Sed efficitur leo non volutpat volutpat. Curabitur pretium euismod tellus, vitae volutpat augue ultrices vitae. Sed euismod eleifend orci consectetur consectetur. Quisque in placerat lacus. Ut faucibus eleifend lectus, sit amet lacinia dolor elementum sit amet. Maecenas pellentesque ligula eu metus sollicitudin, sit amet imperdiet eros venenatis. Donec a neque eleifend elit pretium venenatis feugiat ac eros. Aliquam nec magna eros. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Quisque cursus aliquam arcu quis ullamcorper. Curabitur auctor mollis quam, eu porttitor mi interdum vel. Proin nec massa tortor.
+
+Donec neque turpis, maximus quis pretium a, varius at leo. Nulla facilisi. Sed et diam non odio tincidunt ultricies vel vel nisi. Phasellus quis egestas felis, nec pulvinar justo. Quisque nec urna congue, mollis nisi ac, sodales enim. In faucibus, nunc ac venenatis mattis, sem nunc malesuada augue, vitae venenatis sem diam sit amet ligula. In dapibus tortor nec velit placerat congue. Cras eget eros felis. Aenean blandit sollicitudin commodo. Maecenas sed odio in lorem auctor aliquam. Donec eu risus id nulla convallis pellentesque. Pellentesque volutpat eros nec nunc semper, non eleifend tellus dictum.
+
+Donec quis tincidunt augue, at accumsan eros. Nunc arcu massa, aliquam et mauris sit amet, fringilla molestie dui. Duis quis pretium ligula. Aenean auctor malesuada arcu sed semper. Maecenas pulvinar pulvinar mauris at lobortis. Integer tincidunt tortor non molestie accumsan. Fusce non molestie neque, molestie pharetra ipsum. Ut sapien lorem, faucibus sit amet est id, rutrum egestas metus. Integer sollicitudin dui a tellus pulvinar, nec ultrices lorem dictum.
+
+----
+
+.. create a local contents tab to ensure links to page headers work (and back)
+
+.. contents::
+    :local:
+
+.. note::
+
+    The above link should be able to jump to the header below.
+
+----
+
+Mauris accumsan suscipit purus sed suscipit. Donec vestibulum cursus tincidunt. Nulla facilisi. Suspendisse potenti. Duis fermentum imperdiet cursus. In finibus placerat accumsan. Quisque arcu dolor, sollicitudin in mi vel, malesuada mattis quam. Phasellus auctor faucibus ante, nec elementum odio consequat a.
+
+Duis placerat enim viverra magna ullamcorper, sed pellentesque arcu faucibus. Duis vulputate convallis felis at blandit. Curabitur rhoncus arcu nec dolor pharetra, in porta diam vehicula. Aenean molestie eget nisl ut laoreet. Sed gravida ex vel tortor finibus mollis. Nam in elit non lectus tempus mattis. Maecenas quis urna sed massa bibendum venenatis volutpat ut odio. Cras eget egestas purus. Integer cursus hendrerit dolor. Morbi finibus, nisi vulputate sagittis faucibus, sem dolor gravida nisl, auctor laoreet magna neque a velit. Sed efficitur eros vitae ultricies tincidunt.
+
+Phasellus fringilla pretium sem sed semper. Vestibulum elementum sodales diam sed tempor. Sed in tellus elit. Donec eu bibendum dui. Nullam tempor nisi at libero vestibulum vulputate. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nullam id imperdiet magna, sed imperdiet sem. Integer vitae nisi rhoncus lorem gravida suscipit. Mauris ut erat faucibus, vestibulum sem a, elementum dui.
+
+----
+
+.. a sub-header with a reference
+
+.. _main-rst-v1-extra:
+
+An Extra Header
+---------------
+
+.. note::
+
+    The above header should be able to jump to the local contents tree above.
+
+Fusce id sem tellus. Maecenas ac neque et dolor laoreet tincidunt. Nunc mollis id nunc ut consectetur. Aenean ipsum turpis, condimentum at elementum tempor, malesuada sit amet eros. Maecenas eu massa vitae orci condimentum auctor. Integer et imperdiet lorem. In malesuada nibh sed orci commodo, eget porta odio convallis. Morbi vel augue lectus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris condimentum sem ac augue rutrum, non rutrum ligula tempus.
+
+Proin placerat consequat diam in laoreet. Praesent efficitur egestas velit, id varius velit mattis vel. Etiam lobortis justo ut blandit consequat. Donec nec dapibus eros. Duis luctus euismod erat, eu rhoncus enim. Donec fermentum odio id diam faucibus dignissim. In aliquam lacinia convallis. Aenean pulvinar, libero vel rhoncus venenatis, lectus dolor aliquam felis, at viverra velit quam sit amet est.
+
+Pellentesque id eros eleifend, consequat dolor non, convallis mauris. Aliquam sit amet felis sit amet urna finibus aliquam nec et erat. Nulla gravida euismod ultricies. Sed ac iaculis lectus, tempor vehicula massa. Nullam laoreet sem vel porta placerat. Praesent sit amet orci mauris. Ut feugiat maximus nibh, quis dapibus nibh. Vestibulum condimentum nulla non rutrum bibendum.
+
+----
+
+.. an anchor to content mid-way which is not a header
+
+.. _main-rst-v1-subcontent:
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Suspendisse potenti. Nunc in efficitur tellus, quis semper ligula. Etiam ac consequat augue. Mauris ut rutrum ante. Aliquam sit amet tincidunt mi. Phasellus augue dolor, tempor at elit at, venenatis scelerisque massa. Sed arcu libero, sodales ut odio a, placerat sollicitudin est. Duis semper risus ac velit varius fringilla. In gravida ultricies mauris, nec venenatis purus semper faucibus.
+
+Praesent in consectetur lorem. Donec nunc dui, pulvinar non fringilla in, feugiat vitae sapien. Vestibulum at varius dolor, non vehicula purus. In volutpat feugiat quam a pretium. Proin accumsan sodales neque, vel auctor metus tempus ut. Sed eget justo at mi dignissim ultrices. Morbi sagittis aliquam enim, quis interdum augue placerat id. Aenean commodo turpis sed magna dignissim efficitur. Mauris in neque sed purus porttitor aliquam id ut augue.
+
+Vivamus iaculis, sapien ac blandit faucibus, mauris felis sodales enim, et facilisis libero ante sed nisi. Ut luctus aliquam mauris, et auctor magna consequat consequat. Nunc sem mauris, iaculis in elementum ut, volutpat a purus. Aenean tincidunt mauris ac pulvinar convallis. Vivamus sed consectetur nulla. Aliquam ut ex vitae turpis scelerisque porta. Curabitur vestibulum arcu id nunc dapibus lobortis. Aliquam sed ante sed est luctus venenatis vitae nec ipsum. Cras ultrices, lorem nec rutrum convallis, ante leo molestie nibh, sit amet ultrices justo lacus blandit lorem. Pellentesque in magna vel felis vehicula semper. Phasellus auctor, risus eu congue aliquet, ex nulla dapibus felis, ut placerat orci massa et eros. Duis bibendum ac sem ut euismod. Pellentesque vitae ultrices turpis. In hac habitasse platea dictumst.
+
+.. a sub-header with the same name as above
+
+.. _main-rst-v1-extra2:
+
+An Extra Header
+---------------
+
+.. note::
+
+    The above header should be able to jump to the local contents tree above.
+
+Cras hendrerit tincidunt nulla, nec rutrum libero bibendum nec. Suspendisse potenti. Mauris quis ante malesuada, bibendum lacus ac, condimentum nunc. Vestibulum quis placerat est. Morbi efficitur mi lectus, congue mollis purus sagittis id. Nam lobortis turpis in velit posuere, nec viverra magna feugiat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ut sodales lorem. Curabitur pretium nulla a est placerat aliquet.
+
+Vivamus pulvinar rhoncus malesuada. Sed luctus, est quis hendrerit consectetur, leo purus vehicula sem, id hendrerit diam nunc sit amet lacus. Donec maximus, risus vestibulum rutrum ullamcorper, urna lectus laoreet lacus, ornare volutpat metus tellus id ligula. In iaculis malesuada urna ut placerat. Morbi tincidunt blandit nulla elementum lacinia. Sed lacus arcu, blandit sed tempus a, iaculis et magna. Mauris venenatis commodo diam ut posuere. Pellentesque vel nulla in ipsum sagittis gravida quis sed dui.
+
+Pellentesque commodo eu metus eu tempor. Sed sodales tincidunt tortor, eu condimentum massa porttitor ut. Vestibulum a enim eu mauris consequat ornare viverra sit amet metus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nullam eget leo vitae neque efficitur ornare a et quam. Vivamus cursus sem nec odio condimentum feugiat. Proin consequat eleifend est non gravida. Phasellus quis fermentum eros. Aliquam fringilla risus sed urna laoreet porttitor. Morbi rhoncus justo justo, ac molestie mauris fringilla id. Etiam vulputate pretium nunc, vitae aliquam ex ornare nec. Vestibulum congue lacus ac dictum bibendum. Phasellus eu diam non erat vestibulum dictum. Sed porta ultricies risus, vitae gravida est facilisis ac. Fusce sit amet est ut metus pretium congue.
+
+----
+
+Link to the very top of this page: :ref:`main-rst-v1`
+
+Link to the sub-header on this page: :ref:`main-rst-v1-extra`
+
+Link mid-way in the content section: :ref:`content <main-rst-v1-subcontent>`
+
+Link to the second sub-header on this page: :ref:`main-rst-v1-extra2`

--- a/tests/sample-sets/header-links/rst-v1-second.rst
+++ b/tests/sample-sets/header-links/rst-v1-second.rst
@@ -1,0 +1,31 @@
+.. confluence_metadata::
+    :editor: v1
+
+reStructuredText v1 Second 
+==========================
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam convallis mi nec libero mattis, vel placerat nibh vulputate. Suspendisse cursus tristique metus, non commodo ex consequat elementum. Etiam rutrum ultrices magna. In lacinia sem quis orci luctus, vitae ultricies arcu feugiat. Aliquam sit amet massa libero. Nam sapien nisl, hendrerit at urna at, aliquet porta sapien. Sed feugiat ante at orci tempor rhoncus vitae ut sapien. Praesent est dolor, scelerisque eu lobortis vitae, tempor in erat. Nunc venenatis orci sit amet nisl accumsan, ac euismod libero elementum. Cras id urna eu libero facilisis vestibulum. Fusce quis nisl vitae sem suscipit dapibus.
+
+Cras pharetra purus vitae rhoncus vestibulum. In bibendum convallis ligula, in eleifend mi sodales quis. Maecenas diam leo, sodales eu orci in, malesuada tincidunt sapien. Mauris fringilla magna in nunc interdum, quis ultrices neque malesuada. Nullam id eros dolor. Suspendisse bibendum est vitae ligula tincidunt, id ornare ipsum suscipit. Integer tristique, tortor sit amet tincidunt porta, ante leo porttitor dui, eu fringilla urna leo et nibh. Quisque mollis augue eu lectus consectetur, a lobortis nisl consectetur. Integer vitae finibus justo. Etiam vehicula id nulla non pellentesque. Vestibulum malesuada ligula nulla, et fringilla ante efficitur at. Nunc vel rhoncus ligula.
+
+Nulla suscipit quam sit amet mi luctus, eu venenatis neque consectetur. Donec placerat interdum mi et tincidunt. Pellentesque eu laoreet velit. Interdum et malesuada fames ac ante ipsum primis in faucibus. Etiam pellentesque, lacus et aliquet aliquam, mi lacus congue quam, eget mollis ipsum sapien in mi. Sed et varius libero. Aenean eget arcu metus. Donec pretium, dui a posuere ullamcorper, massa ex semper ligula, quis eleifend quam mauris eu turpis. Proin consequat viverra lacus, sed scelerisque nisl tincidunt pulvinar. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Curabitur tincidunt risus nunc. Sed suscipit vitae dui nec commodo. Mauris malesuada quam vel ante lobortis rutrum. Sed porttitor pulvinar turpis, sit amet blandit est bibendum ac.
+
+----
+
+Link to the very top of the main page (v1): :ref:`main-rst-v1`
+
+Link to the sub-header on the main page (v1): :ref:`main-rst-v1-extra`
+
+Link mid-way in the content section on the main page (v1): :ref:`content <main-rst-v1-subcontent>`
+
+Link to the second sub-header on the main page (v1): :ref:`main-rst-v1-extra2`
+
+----
+
+Link to the very top of the main page (v2): :ref:`main-rst-v2`
+
+Link to the sub-header on the main page (v2): :ref:`main-rst-v2-extra`
+
+Link mid-way in the content section on the main page (v2): :ref:`content <main-rst-v2-subcontent>`
+
+Link to the second sub-header on the main page (v2): :ref:`main-rst-v2-extra2`

--- a/tests/sample-sets/header-links/rst-v2-first.rst
+++ b/tests/sample-sets/header-links/rst-v2-first.rst
@@ -1,0 +1,90 @@
+.. confluence_metadata::
+    :editor: v2
+
+.. _main-rst-v2:
+
+reStructuredText v2 First 
+=========================
+
+Fusce dignissim, sapien sit amet lobortis congue, magna augue efficitur justo, at ultricies leo mi vitae sapien. Nam iaculis orci quis ullamcorper faucibus. Mauris a enim justo. Sed efficitur leo non volutpat volutpat. Curabitur pretium euismod tellus, vitae volutpat augue ultrices vitae. Sed euismod eleifend orci consectetur consectetur. Quisque in placerat lacus. Ut faucibus eleifend lectus, sit amet lacinia dolor elementum sit amet. Maecenas pellentesque ligula eu metus sollicitudin, sit amet imperdiet eros venenatis. Donec a neque eleifend elit pretium venenatis feugiat ac eros. Aliquam nec magna eros. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Quisque cursus aliquam arcu quis ullamcorper. Curabitur auctor mollis quam, eu porttitor mi interdum vel. Proin nec massa tortor.
+
+Donec neque turpis, maximus quis pretium a, varius at leo. Nulla facilisi. Sed et diam non odio tincidunt ultricies vel vel nisi. Phasellus quis egestas felis, nec pulvinar justo. Quisque nec urna congue, mollis nisi ac, sodales enim. In faucibus, nunc ac venenatis mattis, sem nunc malesuada augue, vitae venenatis sem diam sit amet ligula. In dapibus tortor nec velit placerat congue. Cras eget eros felis. Aenean blandit sollicitudin commodo. Maecenas sed odio in lorem auctor aliquam. Donec eu risus id nulla convallis pellentesque. Pellentesque volutpat eros nec nunc semper, non eleifend tellus dictum.
+
+Donec quis tincidunt augue, at accumsan eros. Nunc arcu massa, aliquam et mauris sit amet, fringilla molestie dui. Duis quis pretium ligula. Aenean auctor malesuada arcu sed semper. Maecenas pulvinar pulvinar mauris at lobortis. Integer tincidunt tortor non molestie accumsan. Fusce non molestie neque, molestie pharetra ipsum. Ut sapien lorem, faucibus sit amet est id, rutrum egestas metus. Integer sollicitudin dui a tellus pulvinar, nec ultrices lorem dictum.
+
+----
+
+.. create a local contents tab to ensure links to page headers work (and back)
+
+.. contents::
+    :local:
+
+.. note::
+
+    The above link should be able to jump to the header below.
+
+----
+
+Mauris accumsan suscipit purus sed suscipit. Donec vestibulum cursus tincidunt. Nulla facilisi. Suspendisse potenti. Duis fermentum imperdiet cursus. In finibus placerat accumsan. Quisque arcu dolor, sollicitudin in mi vel, malesuada mattis quam. Phasellus auctor faucibus ante, nec elementum odio consequat a.
+
+Duis placerat enim viverra magna ullamcorper, sed pellentesque arcu faucibus. Duis vulputate convallis felis at blandit. Curabitur rhoncus arcu nec dolor pharetra, in porta diam vehicula. Aenean molestie eget nisl ut laoreet. Sed gravida ex vel tortor finibus mollis. Nam in elit non lectus tempus mattis. Maecenas quis urna sed massa bibendum venenatis volutpat ut odio. Cras eget egestas purus. Integer cursus hendrerit dolor. Morbi finibus, nisi vulputate sagittis faucibus, sem dolor gravida nisl, auctor laoreet magna neque a velit. Sed efficitur eros vitae ultricies tincidunt.
+
+Phasellus fringilla pretium sem sed semper. Vestibulum elementum sodales diam sed tempor. Sed in tellus elit. Donec eu bibendum dui. Nullam tempor nisi at libero vestibulum vulputate. Interdum et malesuada fames ac ante ipsum primis in faucibus. Nullam id imperdiet magna, sed imperdiet sem. Integer vitae nisi rhoncus lorem gravida suscipit. Mauris ut erat faucibus, vestibulum sem a, elementum dui.
+
+----
+
+.. a sub-header with a reference
+
+.. _main-rst-v2-extra:
+
+An Extra Header
+---------------
+
+.. note::
+
+    The above header should be able to jump to the local contents tree above.
+
+Fusce id sem tellus. Maecenas ac neque et dolor laoreet tincidunt. Nunc mollis id nunc ut consectetur. Aenean ipsum turpis, condimentum at elementum tempor, malesuada sit amet eros. Maecenas eu massa vitae orci condimentum auctor. Integer et imperdiet lorem. In malesuada nibh sed orci commodo, eget porta odio convallis. Morbi vel augue lectus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris condimentum sem ac augue rutrum, non rutrum ligula tempus.
+
+Proin placerat consequat diam in laoreet. Praesent efficitur egestas velit, id varius velit mattis vel. Etiam lobortis justo ut blandit consequat. Donec nec dapibus eros. Duis luctus euismod erat, eu rhoncus enim. Donec fermentum odio id diam faucibus dignissim. In aliquam lacinia convallis. Aenean pulvinar, libero vel rhoncus venenatis, lectus dolor aliquam felis, at viverra velit quam sit amet est.
+
+Pellentesque id eros eleifend, consequat dolor non, convallis mauris. Aliquam sit amet felis sit amet urna finibus aliquam nec et erat. Nulla gravida euismod ultricies. Sed ac iaculis lectus, tempor vehicula massa. Nullam laoreet sem vel porta placerat. Praesent sit amet orci mauris. Ut feugiat maximus nibh, quis dapibus nibh. Vestibulum condimentum nulla non rutrum bibendum.
+
+----
+
+.. an anchor to content mid-way which is not a header
+
+.. _main-rst-v2-subcontent:
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Suspendisse potenti. Nunc in efficitur tellus, quis semper ligula. Etiam ac consequat augue. Mauris ut rutrum ante. Aliquam sit amet tincidunt mi. Phasellus augue dolor, tempor at elit at, venenatis scelerisque massa. Sed arcu libero, sodales ut odio a, placerat sollicitudin est. Duis semper risus ac velit varius fringilla. In gravida ultricies mauris, nec venenatis purus semper faucibus.
+
+Praesent in consectetur lorem. Donec nunc dui, pulvinar non fringilla in, feugiat vitae sapien. Vestibulum at varius dolor, non vehicula purus. In volutpat feugiat quam a pretium. Proin accumsan sodales neque, vel auctor metus tempus ut. Sed eget justo at mi dignissim ultrices. Morbi sagittis aliquam enim, quis interdum augue placerat id. Aenean commodo turpis sed magna dignissim efficitur. Mauris in neque sed purus porttitor aliquam id ut augue.
+
+Vivamus iaculis, sapien ac blandit faucibus, mauris felis sodales enim, et facilisis libero ante sed nisi. Ut luctus aliquam mauris, et auctor magna consequat consequat. Nunc sem mauris, iaculis in elementum ut, volutpat a purus. Aenean tincidunt mauris ac pulvinar convallis. Vivamus sed consectetur nulla. Aliquam ut ex vitae turpis scelerisque porta. Curabitur vestibulum arcu id nunc dapibus lobortis. Aliquam sed ante sed est luctus venenatis vitae nec ipsum. Cras ultrices, lorem nec rutrum convallis, ante leo molestie nibh, sit amet ultrices justo lacus blandit lorem. Pellentesque in magna vel felis vehicula semper. Phasellus auctor, risus eu congue aliquet, ex nulla dapibus felis, ut placerat orci massa et eros. Duis bibendum ac sem ut euismod. Pellentesque vitae ultrices turpis. In hac habitasse platea dictumst.
+
+.. a sub-header with the same name as above
+
+.. _main-rst-v2-extra2:
+
+An Extra Header
+---------------
+
+.. note::
+
+    The above header should be able to jump to the local contents tree above.
+
+Cras hendrerit tincidunt nulla, nec rutrum libero bibendum nec. Suspendisse potenti. Mauris quis ante malesuada, bibendum lacus ac, condimentum nunc. Vestibulum quis placerat est. Morbi efficitur mi lectus, congue mollis purus sagittis id. Nam lobortis turpis in velit posuere, nec viverra magna feugiat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum ut sodales lorem. Curabitur pretium nulla a est placerat aliquet.
+
+Vivamus pulvinar rhoncus malesuada. Sed luctus, est quis hendrerit consectetur, leo purus vehicula sem, id hendrerit diam nunc sit amet lacus. Donec maximus, risus vestibulum rutrum ullamcorper, urna lectus laoreet lacus, ornare volutpat metus tellus id ligula. In iaculis malesuada urna ut placerat. Morbi tincidunt blandit nulla elementum lacinia. Sed lacus arcu, blandit sed tempus a, iaculis et magna. Mauris venenatis commodo diam ut posuere. Pellentesque vel nulla in ipsum sagittis gravida quis sed dui.
+
+Pellentesque commodo eu metus eu tempor. Sed sodales tincidunt tortor, eu condimentum massa porttitor ut. Vestibulum a enim eu mauris consequat ornare viverra sit amet metus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Nullam eget leo vitae neque efficitur ornare a et quam. Vivamus cursus sem nec odio condimentum feugiat. Proin consequat eleifend est non gravida. Phasellus quis fermentum eros. Aliquam fringilla risus sed urna laoreet porttitor. Morbi rhoncus justo justo, ac molestie mauris fringilla id. Etiam vulputate pretium nunc, vitae aliquam ex ornare nec. Vestibulum congue lacus ac dictum bibendum. Phasellus eu diam non erat vestibulum dictum. Sed porta ultricies risus, vitae gravida est facilisis ac. Fusce sit amet est ut metus pretium congue.
+
+----
+
+Link to the very top of this page: :ref:`main-rst-v2`
+
+Link to the sub-header on this page: :ref:`main-rst-v2-extra`
+
+Link mid-way in the content section: :ref:`content <main-rst-v2-subcontent>`
+
+Link to the second sub-header on this page: :ref:`main-rst-v2-extra2`

--- a/tests/sample-sets/header-links/rst-v2-second.rst
+++ b/tests/sample-sets/header-links/rst-v2-second.rst
@@ -1,0 +1,31 @@
+.. confluence_metadata::
+    :editor: v2
+
+reStructuredText v2 Second 
+==========================
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam convallis mi nec libero mattis, vel placerat nibh vulputate. Suspendisse cursus tristique metus, non commodo ex consequat elementum. Etiam rutrum ultrices magna. In lacinia sem quis orci luctus, vitae ultricies arcu feugiat. Aliquam sit amet massa libero. Nam sapien nisl, hendrerit at urna at, aliquet porta sapien. Sed feugiat ante at orci tempor rhoncus vitae ut sapien. Praesent est dolor, scelerisque eu lobortis vitae, tempor in erat. Nunc venenatis orci sit amet nisl accumsan, ac euismod libero elementum. Cras id urna eu libero facilisis vestibulum. Fusce quis nisl vitae sem suscipit dapibus.
+
+Cras pharetra purus vitae rhoncus vestibulum. In bibendum convallis ligula, in eleifend mi sodales quis. Maecenas diam leo, sodales eu orci in, malesuada tincidunt sapien. Mauris fringilla magna in nunc interdum, quis ultrices neque malesuada. Nullam id eros dolor. Suspendisse bibendum est vitae ligula tincidunt, id ornare ipsum suscipit. Integer tristique, tortor sit amet tincidunt porta, ante leo porttitor dui, eu fringilla urna leo et nibh. Quisque mollis augue eu lectus consectetur, a lobortis nisl consectetur. Integer vitae finibus justo. Etiam vehicula id nulla non pellentesque. Vestibulum malesuada ligula nulla, et fringilla ante efficitur at. Nunc vel rhoncus ligula.
+
+Nulla suscipit quam sit amet mi luctus, eu venenatis neque consectetur. Donec placerat interdum mi et tincidunt. Pellentesque eu laoreet velit. Interdum et malesuada fames ac ante ipsum primis in faucibus. Etiam pellentesque, lacus et aliquet aliquam, mi lacus congue quam, eget mollis ipsum sapien in mi. Sed et varius libero. Aenean eget arcu metus. Donec pretium, dui a posuere ullamcorper, massa ex semper ligula, quis eleifend quam mauris eu turpis. Proin consequat viverra lacus, sed scelerisque nisl tincidunt pulvinar. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Curabitur tincidunt risus nunc. Sed suscipit vitae dui nec commodo. Mauris malesuada quam vel ante lobortis rutrum. Sed porttitor pulvinar turpis, sit amet blandit est bibendum ac.
+
+----
+
+Link to the very top of the main page (v1): :ref:`main-rst-v1`
+
+Link to the sub-header on the main page (v1): :ref:`main-rst-v1-extra`
+
+Link mid-way in the content section on the main page (v1): :ref:`content <main-rst-v1-subcontent>`
+
+Link to the second sub-header on the main page (v1): :ref:`main-rst-v1-extra2`
+
+----
+
+Link to the very top of the main page (v2): :ref:`main-rst-v2`
+
+Link to the sub-header on the main page (v2): :ref:`main-rst-v2-extra`
+
+Link mid-way in the content section on the main page (v2): :ref:`content <main-rst-v2-subcontent>`
+
+Link to the second sub-header on the main page (v2): :ref:`main-rst-v2-extra2`

--- a/tests/sample-sets/header-links/tox.ini
+++ b/tests/sample-sets/header-links/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+package_root={toxinidir}{/}..{/}..{/}..
+
+[testenv]
+deps =
+    myst-parser
+commands =
+    {envpython} -m tests.test_sample {posargs}
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+    TOX_INI_DIR={toxinidir}
+passenv = *
+use_develop = true

--- a/tests/unit-tests/test_rst_targets.py
+++ b/tests/unit-tests/test_rst_targets.py
@@ -4,6 +4,7 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
+from tests.lib.testcase import setup_editor
 import os
 
 
@@ -35,3 +36,23 @@ class TestConfluenceRstTargets(ConfluenceTestCase):
 
             trailing_data = anchor_tag.nextSibling.strip()
             self.assertEqual(trailing_data, 'inline target example.')
+
+    @setup_builder('confluence')
+    @setup_editor('v2')
+    def test_storage_rst_targets_v2(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            # sanity check anchor creation
+            anchor_tag = data.find('ac:structured-macro')
+            self.assertIsNotNone(anchor_tag)
+            self.assertTrue(anchor_tag.has_attr('ac:name'))
+            self.assertEqual(anchor_tag['ac:name'], 'anchor')
+
+            anchor_param = anchor_tag.find('ac:parameter', recursive=False)
+            self.assertIsNotNone(anchor_param)
+            self.assertEqual(anchor_param.text, 'inline-target')
+
+            # before text
+            before_data = anchor_tag.previousSibling.strip()
+            self.assertEqual(before_data, 'An')


### PR DESCRIPTION
The following provides a somewhat major rewrite on the creation of anchors and how pages can link to these anchors. There has been some limitations with linking to anchors when support for the v2 editor was added. Ideally, pages will generate an `ac:link` macro and specify anchors to target. However, testing showed that anchor links would not always work with these macros since the macro expected anchors to be prefixed with a page's name, which is not the case for v2 pages.

This commit attempts to fix these by building compatible anchor links on pages no matter what editor version is configured for a page. This extension now calculates expected targets for each document no matter the editor (with an appropriate target expected for auto-generates identifiers). When anchors are now added to a v2 page, we generate additional anchors on a page that include a page-prefix, allowing any `ac:link` macros to have an appropriate target to jump to (either the old compatible link; or if sometime in the future, the new non-prefixed link).

In addition, we also inject MyST slug-generated anchor points, to be flexible for links created with the MyST-parser extension.

Note that there are still some limitations with anchors in the v2 editor. For example, anchors with parenthesis are silently dropped in publish storage formatted documents. At this time, a support request has been made with Atlassian to investigate this issue (JST-937603).