### PR TITLE
Separate third party license

### DIFF
--- a/LICENSE-3RD-PARTY
+++ b/LICENSE-3RD-PARTY
@@ -1,16 +1,26 @@
-Copyright (c) 2012-2023 Sphinx Confluence Builder Contributors (AUTHORS)
+Licenses for incorporated software
+==================================
+
+----------------------------------------------------------------------
+
+Sphinx
+https://github.com/sphinx-doc/sphinx/blob/master/LICENSE.rst
+
+----------------------------------------------------------------------
+
+Copyright (c) 2007-2021 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
 
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -1,6 +1,6 @@
 {#
-:copyright: Copyright Sphinx Confluence Builder Contributors (AUTHORS)
-:license: BSD-2-Clause (LICENSE)
+SPDX-License-Identifier: BSD-2-Clause
+Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 #}
 {% extends "layout.html" %}
 

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -1,6 +1,6 @@
 {#
-:copyright: Copyright Sphinx Confluence Builder Contributors (AUTHORS)
-:license: BSD-2-Clause (LICENSE)
+SPDX-License-Identifier: BSD-2-Clause
+Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 #}
 <p class="logo">
     {%trans%}Jump to{%endtrans%}

--- a/doc/_themes/sphinx13b/layout.html
+++ b/doc/_themes/sphinx13b/layout.html
@@ -1,7 +1,7 @@
 {#
-:copyright: Copyright 2007-2019 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
-:copyright: Copyright Sphinx Confluence Builder Contributors (AUTHORS)
-:license: BSD-2-Clause (LICENSE)
+SPDX-License-Identifier: BSD-2-Clause
+Copyright 2007-2019 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
+Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 #}
 {%- extends "basic/layout.html" %}
 

--- a/doc/_themes/sphinx13b/static/sphinx13b.css
+++ b/doc/_themes/sphinx13b/static/sphinx13b.css
@@ -1,7 +1,7 @@
 /*
-:copyright: Copyright 2007-2019 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
-:copyright: Copyright Sphinx Confluence Builder Contributors (AUTHORS)
-:license: BSD-2-Clause (LICENSE)
+SPDX-License-Identifier: BSD-2-Clause
+Copyright 2007-2019 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
+Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 */
 
 @import url("basic.css");

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,7 +1,5 @@
-"""
-:copyright: Copyright Sphinx Confluence Builder Contributors (AUTHORS)
-:license: BSD-2-Clause (LICENSE)
-"""
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from docutils import nodes
 from sphinx.transforms.post_transforms import SphinxPostTransform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,6 @@ name = 'sphinxcontrib.confluencebuilder'
 include = [
     'AUTHORS',
     'LICENSE',
+    'LICENSE-3RD-PARTY',
     'MANIFEST.in',
 ]


### PR DESCRIPTION
Moves the license text for used Sphinx implementation inside its own license file (`LICENSE-3RD-PARTY`). The goal is to help make it easier to identify third-party-related license information associated to this repository (third-party project name, origin of their license and their license text).