### PR TITLE
.github: renaming the confluence publish check workflow

### DIFF
--- a/.github/workflows/confluence-publish-check.yml
+++ b/.github/workflows/confluence-publish-check.yml
@@ -4,7 +4,7 @@
 #  sphinxcontrib-confluencebuilder -- Development Space
 #  https://sphinxcontrib-confluencebuilder.atlassian.net/wiki/spaces/DEVELOP
 
-name: Publish Check
+name: Confluence Publish Check
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ on:
       python:
         description: 'Python interpreter'
         required: true
-        default: '3.9'
+        default: '3.12'
       space:
         description: 'Space'
         default: 'DEVELOP'


### PR DESCRIPTION
This commit renames the original "validate/publish" workflow to a Confluence publishing workflow. This is to make it clear that this is specific to publishing test results to a Confluence instance and not related to publishing to PyPI.