### PR TITLE
builder: avoid unchanged page cache checks if we have legacy pages

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -800,14 +800,16 @@ class ConfluenceBuilder(Builder):
                 except OSError as err:
                     self.warn(f'error reading asset {key}: {err}')
 
-            # if we have documents that were not changes (and therefore, not
+            # if we have documents that were not changed (and therefore, not
             # needing to be republished), assume any cached publish page ids
             # are still valid and remove them from the legacy pages list
-            other_docs = self.env.all_docs.keys() - set(self.publish_docnames)
-            for unchanged_doc in other_docs:
-                lpid = self._cache_info.last_page_id(unchanged_doc)
-                if lpid is not None and lpid in self.legacy_pages:
-                    self.legacy_pages.remove(lpid)
+            if self.legacy_pages:
+                all_docnames = self.env.all_docs.keys()
+                other_docnames = all_docnames - set(self.publish_docnames)
+                for unchanged_docname in other_docnames:
+                    lpid = self._cache_info.last_page_id(unchanged_docname)
+                    if lpid is not None and lpid in self.legacy_pages:
+                        self.legacy_pages.remove(lpid)
 
             self.publish_cleanup()
             self.publish_finalize()


### PR DESCRIPTION
Before attempting to cleanup any detected legacy pages from a target Confluence instance, the builder will check to see if any unchanged documents exist (pages that did not trigger an update and we not removed from the internal legacy list), and remove them from the legacy pages list if our cache detects it was already published. However, this logic assumes we have populated a legacy pages list ahead of time, which may not have happened if we are not configured for any cleaning.

This commit adjusts the unchanged pages check to only occur if we have populated a legacy pages list to check on.