### PR TITLE
publisher: simplify initial connection check

### DIFF
--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -40,32 +40,6 @@ details for more information:
         self.status_code = code
 
 
-class ConfluenceBadSpaceError(ConfluenceError):
-    def __init__(self, space_key, uname, pw_set, token_set, extras):
-        uname_value = uname if uname else '(empty)'
-        pw_value = '<set>' if pw_set else '(empty)'
-        token_value = '<set>' if token_set else '(empty)'
-        super().__init__('''
----
-Invalid Confluence URL detected
-
-The configured Confluence space key does not appear to be valid:
-
-    Space key: {space_key}
-     Username: {uname}
-     Password: {pw}
-        Token: {token}
-
-Ensure the instance is running and inspect that the configured
-Confluence URL is valid. Also ensure authentication options are properly
-set.
-
-Note: Confluence space keys are case-sensitive.{details}
----
-'''.format(space_key=space_key, uname=uname_value, pw=pw_value,
-        token=token_value, details=extras))
-
-
 class ConfluenceBadServerUrlError(ConfluenceError):
     def __init__(self, server_url, ex):
         super().__init__('''

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -193,6 +193,22 @@ class ConfluenceInstanceServer(server_socket.ThreadingMixIn,
         with self.mtx:
             self.put_rsp.append((code, data))
 
+    def reset(self):
+        """
+        reset any pending requests/responses expected
+
+        Provides a call for a tester to reset expected requests or responses
+        for a given instance.
+        """
+
+        with self.mtx:
+            self.del_req = []
+            self.del_rsp = []
+            self.get_req = []
+            self.get_rsp = []
+            self.put_req = []
+            self.put_rsp = []
+
 
 class ConfluenceInstanceRequestHandler(http_server.SimpleHTTPRequestHandler):
     """

--- a/tests/unit-tests/test_publisher_api_bind_path.py
+++ b/tests/unit-tests/test_publisher_api_bind_path.py
@@ -12,13 +12,13 @@ class TestConfluencePublisherApiBindPath(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = prepare_conf_publisher()
+        cls.config.confluence_space_key = 'MOCK'
 
         cls.std_space_connect_rsp = {
-            'size': 1,
-            'results': [{
-                'name': 'Mock Space',
-                'type': 'global',
-            }],
+            'id': 1,
+            'key': 'MOCK',
+            'name': 'Mock Space',
+            'type': 'global',
         }
 
     def test_publisher_api_bind_path_default(self):

--- a/tests/unit-tests/test_publisher_base_id.py
+++ b/tests/unit-tests/test_publisher_base_id.py
@@ -12,13 +12,13 @@ class TestConfluencePublisherBaseId(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = prepare_conf_publisher()
+        cls.config.confluence_space_key = 'MOCK'
 
         cls.std_space_connect_rsp = {
-            'size': 1,
-            'results': [{
-                'name': 'Mock Space',
-                'type': 'global',
-            }],
+            'id': 1,
+            'key': 'MOCK',
+            'name': 'Mock Space',
+            'type': 'global',
         }
 
     def test_publisher_page_base_id_parent_id(self):

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -13,13 +13,13 @@ class TestConfluencePublisherPage(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = prepare_conf_publisher()
+        cls.config.confluence_space_key = 'MOCK'
 
         cls.std_space_connect_rsp = {
-            'size': 1,
-            'results': [{
-                'name': 'Mock Space',
-                'type': 'global',
-            }],
+            'id': 1,
+            'key': 'MOCK',
+            'name': 'Mock Space',
+            'type': 'global',
         }
 
     def test_publisher_page_store_page_id_allow_watch(self):


### PR DESCRIPTION
The following refactors how the initial connection check is performed. The original design introduced back in v0.6 used the "Get spaces" API endpoint to validate access to a space. As the author of this change, I could not recall the specifics of why it was chosen over "Get space" (either an overlooked API call, possible issues observed when testing initial REST support, etc.). At this time, there is no known reason why a switch to the "Get space" API cannot be done. The new call appears to work find for both Cloud and data server versions. Therefore, this commit is making this change.

The switch to the explicit space API endpoint simplifies the publishers logic. We no longer perform a related space key check (back in the day where users may have added the Confluence name instead of space into a legacy `confluence_space_name` option). This removes a special case exception as well, generated for failed searches.

Note that the original and new endpoint switch being made is a deprecated call on Confluence Cloud. This is to be addressed in the future.