### PR TITLE
Extended publish debugging

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1378,15 +1378,28 @@ Advanced publishing configuration
 .. confval:: confluence_publish_debug
 
     .. versionadded:: 1.8
+    .. versionchanged:: 2.5
 
-    A boolean value to whether or not to print debug requests made to a
-    Confluence instance. This can be helpful for users attempting to debug
-    their connection to a Confluence instance. By default, this option is
-    disabled with a value of ``False``.
+        Switched from boolean to string for setting new debugging options.
+
+    Configures the ability to enable certain debugging messages for requests
+    made to a Confluence instance. This can be helpful for users attempting
+    to debug their connection to a Confluence instance. By default, no
+    debugging is enabled.
+
+    Available options are as follows:
+
+    - ``all``: Enable all debugging options.
+    - ``deprecated``: Log warnings when a deprecated API call is used
+      (*for development purposes*).
+    - ``headers``: Log requests and responses, including their headers.
+    - ``urllib3``: Enable urllib3 library debugging messages.
+
+    An example debugging configuration is as follows:
 
     .. code-block:: python
 
-        confluence_publish_debug = True
+        confluence_publish_debug = 'urllib3'
 
 .. confval:: confluence_publish_delay
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -187,8 +187,8 @@ def setup(app):
     cm.add_conf('confluence_proxy')
     # Subset of documents which are allowed to be published.
     cm.add_conf('confluence_publish_allowlist')
-    # Enable debugging for publish requests.
-    cm.add_conf_bool('confluence_publish_debug')
+    # Configure debugging for publish requests.
+    cm.add_conf('confluence_publish_debug')
     # Duration (in seconds) to delay each API request.
     cm.add_conf('confluence_publish_delay')
     # Subset of documents which are denied to be published.

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -4,6 +4,7 @@
 from sphinxcontrib.confluencebuilder.config.notifications import deprecated
 from sphinxcontrib.confluencebuilder.config.notifications import warnings
 from sphinxcontrib.confluencebuilder.config.validation import ConfigurationValidation
+from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.std.confluence import EDITORS
 from sphinxcontrib.confluencebuilder.util import handle_cli_file_subset
@@ -551,6 +552,28 @@ The value type permitted for this publish list option can either be a list of
 document names or a string pointing to a file containing documents. Document
 names are relative to the documentation's source directory.
 '''.format(msg=e))
+
+    # ##################################################################
+
+    opts = PublishDebug._member_names_  # pylint: disable=no-member
+
+    # confluence_publish_debug
+    try:
+        validator.conf('confluence_publish_debug').bool()  # deprecated
+    except ConfluenceConfigurationError:
+        try:
+            validator.conf('confluence_publish_debug').enum(PublishDebug)
+        except ConfluenceConfigurationError as e:
+            opts = PublishDebug._member_names_  # pylint: disable=no-member
+            raise ConfluenceConfigurationError('''\
+{msg}
+
+The option 'confluence_publish_debug' has been configured to enable publish
+debugging. Accepted values include:
+
+ - all
+ - {opts}
+'''.format(msg=e, opts='\n - '.join(opts)))
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.util import str2bool
 import os
 
@@ -86,6 +87,19 @@ def apply_defaults(builder):
     if conf.confluence_permit_raw_html is None and \
             conf.confluence_adv_permit_raw_html is not None:
         conf.confluence_permit_raw_html = conf.confluence_adv_permit_raw_html
+
+    # ensure confluence_publish_debug is set with its expected enum value
+    publish_debug = conf.confluence_publish_debug
+    if publish_debug is not None and publish_debug is not False:
+        # a boolean-provided publish debug is deprecated, but we will accept
+        # it as its original implementation as an indication to enable
+        # urllib3 logs
+        if publish_debug is True:
+            conf.confluence_publish_debug = PublishDebug.urllib3
+        elif not isinstance(publish_debug, PublishDebug):
+            conf.confluence_publish_debug = PublishDebug[publish_debug.lower()]
+    else:
+        conf.confluence_publish_debug = PublishDebug.none
 
     if conf.confluence_publish_intersphinx is None:
         conf.confluence_publish_intersphinx = True

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -96,3 +96,7 @@ def warnings(validator):
     # confluence_editor assigned to an editor that is not supported
     if config.confluence_editor and config.confluence_editor not in EDITORS:
         logger.warn('confluence_editor configured with an unsupported editor')
+
+    # confluence_publish_debug should be using the new string values
+    if isinstance(config.confluence_publish_debug, bool):
+        logger.warn('confluence_publish_debug using deprecated bool value')

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -202,6 +202,33 @@ class ConfigurationValidation:
 
         return self
 
+    def enum(self, etype):
+        """
+        checks if a configuration is an enumeration type
+
+        After an instance has been set a configuration key (via `conf`), this
+        method can be used to check if the value (if any) configured with this
+        key is an enumeration of type `etype`. If not, a
+        `ConfluenceConfigurationError` exception will be thrown.
+
+        In the event that the configuration is not set (e.g. a value of `None`),
+        this method will have no effect.
+
+        Returns:
+            the validator instance
+        """
+
+        value = self._value()
+
+        if value is not None and not isinstance(value, etype):
+            try:
+                value = etype[value.lower()]
+            except KeyError:
+                raise ConfluenceConfigurationError(
+                    f'{self.key} is not an enumeration ({etype.__name__})')
+
+        return self
+
     def file(self):
         """
         checks if a configuration is a valid file

--- a/sphinxcontrib/confluencebuilder/debug.py
+++ b/sphinxcontrib/confluencebuilder/debug.py
@@ -18,7 +18,9 @@ class PublishDebug(Flag):
 
     # do not perform any logging
     none = auto()
+    # log raw requests/responses in stdout with header data
+    headers = auto()
     # log urllib3-supported debug messages
     urllib3 = auto()
     # enable all logging
-    all = urllib3
+    all = headers | urllib3

--- a/sphinxcontrib/confluencebuilder/debug.py
+++ b/sphinxcontrib/confluencebuilder/debug.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from enum import Flag
+from enum import auto
+
+
+class PublishDebug(Flag):
+    """
+    publishing debugging enumeration
+
+    Defines a series of flags to track support debugging modes when enabling
+    publishing-specific debugging in this extension. Provides an explicit
+    list of supported options (that can be configuration checked), as well
+    as provides an "all" state, allowing easy implementation handling of
+    enabling specific debugging scenarios when all options are enabled.
+    """
+
+    # do not perform any logging
+    none = auto()
+    # log urllib3-supported debug messages
+    urllib3 = auto()
+    # enable all logging
+    all = urllib3

--- a/sphinxcontrib/confluencebuilder/debug.py
+++ b/sphinxcontrib/confluencebuilder/debug.py
@@ -18,9 +18,13 @@ class PublishDebug(Flag):
 
     # do not perform any logging
     none = auto()
+    # logs warnings when confluence reports a deprecated api call
+    deprecated = auto()
     # log raw requests/responses in stdout with header data
     headers = auto()
     # log urllib3-supported debug messages
     urllib3 = auto()
     # enable all logging
     all = headers | urllib3
+    # enable all developer logging
+    developer = deprecated | all

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -8,6 +8,7 @@ See also:
 """
 
 from sphinx.util.logging import skip_warningiserror
+from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadApiError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadServerUrlError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
@@ -41,7 +42,6 @@ class ConfluencePublisher:
         self.cloud = cloud
         self.config = config
         self.append_labels = config.confluence_append_labels
-        self.debug = config.confluence_publish_debug
         self.dryrun = config.confluence_publish_dryrun
         self.notify = not config.confluence_disable_notifications
         self.onlynew = config.confluence_publish_onlynew
@@ -56,7 +56,7 @@ class ConfluencePublisher:
             self.append_labels = True
 
         # if debugging, enable requests (urllib3) logging
-        if self.debug:
+        if PublishDebug.urllib3 in self.config.confluence_publish_debug:
             logging.basicConfig()
             logging.getLogger().setLevel(logging.DEBUG)
             rlog = logging.getLogger('requests.packages.urllib3')

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -377,6 +377,13 @@ class Rest:
                                 math.ceil(delay)))
                     self._reported_large_delay = True
 
+        # check if Confluence reports a `Deprecation` header in the response;
+        # if so, log a message is we have the debug message enabled to help
+        # inform developers that this api call may required updating
+        if PublishDebug.deprecated in self.config.confluence_publish_debug:
+            if rsp.headers.get('Deprecation'):
+                logger.warn(f'(warning) deprecated api call made: {path}')
+
         if rsp.status_code == 401:
             raise ConfluenceAuthenticationFailedUrlError
         if rsp.status_code == 403:

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -9,6 +9,7 @@ from sphinx.util.console import color_terminal
 from sphinx.util.console import nocolor
 from sphinx.util.docutils import docutils_namespace
 from sphinxcontrib.confluencebuilder import util
+from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from threading import Event
 from threading import Lock
 from threading import Thread
@@ -480,8 +481,8 @@ def prepare_conf_publisher():
 
     config = prepare_conf()
 
-    # always enable debug prints from urllib
-    config.confluence_publish_debug = True
+    # always enable debug prints from urllib3
+    config.confluence_publish_debug = PublishDebug.urllib3
 
     # define a timeout to ensure publishing tests do not block
     config.confluence_timeout = 5

--- a/tests/unit-tests/test_config_env.py
+++ b/tests/unit-tests/test_config_env.py
@@ -28,23 +28,23 @@ class TestConfluenceConfigEnvironment(unittest.TestCase):
     def test_config_env_bool(self):
         # default unset
         with prepare_sphinx(self.dataset, config=self.config) as app:
-            self.assertIsNone(app.config.confluence_publish_debug)
+            self.assertIsNone(app.config.confluence_publish_force)
 
         # configure option from environment
-        os.environ['CONFLUENCE_PUBLISH_DEBUG'] = '0'
+        os.environ['CONFLUENCE_PUBLISH_FORCE'] = '0'
         with prepare_sphinx(self.dataset, config=self.config) as app:
-            self.assertFalse(app.config.confluence_publish_debug)
+            self.assertFalse(app.config.confluence_publish_force)
 
-        os.environ['CONFLUENCE_PUBLISH_DEBUG'] = '1'
+        os.environ['CONFLUENCE_PUBLISH_FORCE'] = '1'
         with prepare_sphinx(self.dataset, config=self.config) as app:
-            self.assertTrue(app.config.confluence_publish_debug)
+            self.assertTrue(app.config.confluence_publish_force)
 
         # override the option (taking precedence over environment)
-        self.config['confluence_publish_debug'] = False
+        self.config['confluence_publish_force'] = False
         with prepare_sphinx(self.dataset, config=self.config) as app:
-            self.assertFalse(app.config.confluence_publish_debug)
-        self.assertTrue('CONFLUENCE_PUBLISH_DEBUG' in os.environ)
-        self.assertEqual(os.environ['CONFLUENCE_PUBLISH_DEBUG'], '1')
+            self.assertFalse(app.config.confluence_publish_force)
+        self.assertTrue('CONFLUENCE_PUBLISH_FORCE' in os.environ)
+        self.assertEqual(os.environ['CONFLUENCE_PUBLISH_FORCE'], '1')
 
     def test_config_env_int(self):
         # default unset


### PR DESCRIPTION
### rest: refactor request processing

Adjusting the internals for performing session requests inside the Rest helper class. This is to help prepare the implementation for future work which can help debugging using prepared requests, as well as preparing for adjustments for APIv2, which deviates from the "bind path" used in this implementation.

### config: provide enum-type check

Introduce a configuration check where a value will attempt to map to a specific enumeration type. This is to support future configuration capabilities which will try to map string values to enums.

### switch publish-debug config to be an enum-flag type

Updating the `confluence_publish_debug` option to now accept string values, used to make to specific debugging enumeration flags in the implementation. This is to prepare for additional debugging modes that can be enabled when publishing.

### tests: adjust env bool test to use new option

The unit test used to debug processing a boolean type used the `confluence_publish_debug` option for checks. However, this configuration type is no longer a boolean, so updating the unit test to use a new type (`confluence_publish_force`).

### support request/response header dumps when publishing

Updates the `confluence_publish_debug` option to now accept a new value `headers`, which can be used to dump requests and responses, with their header data, made to a configured Confluence instance.

### support deprecated api warnings when publishing

Updates the `confluence_publish_debug` option to now accept a new value `deprecated`, which can be used by developers to help warn when using API calls that Atlassian has marked as deprecated.

### doc: update new confluence_publish_debug str-options

With updates to `confluence_publish_debug` to accept string values for various debugging modes, updating the documentation to reflect the new values which can be set.