### PR TITLE
Use pathlib (Part 1)

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
-from os import path
+from pathlib import Path
 from sphinx.util import docutils
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.config import handle_config_inited
@@ -58,9 +58,9 @@ def setup(app):
     app.add_builder(SingleConfluenceBuilder)
 
     # register this extension's locale
-    package_dir = path.abspath(path.dirname(__file__))
-    locale_dir = path.join(package_dir, 'locale')
-    app.add_message_catalog(MESSAGE_CATALOG_NAME, locale_dir)
+    package_dir = Path(__file__).parent.resolve()
+    locale_dir = package_dir / 'locale'
+    app.add_message_catalog(MESSAGE_CATALOG_NAME, str(locale_dir))
 
     # ##########################################################################
 

--- a/sphinxcontrib/confluencebuilder/env.py
+++ b/sphinxcontrib/confluencebuilder/env.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
 import json
-import os
 
 
 # base filename for cache information
@@ -21,16 +21,14 @@ ENV_CACHE_PUBLISH = ENV_CACHE_BASENAME + 'publish'
 
 class ConfluenceCacheInfo:
     def __init__(self, builder):
-        outdir = builder.outdir
-
         self.builder = builder
         self.env = builder.env
         self._active_dochash = {}
         self._active_hash = None
         self._active_pids = {}
-        self._cache_cfg_file = os.path.join(outdir, ENV_CACHE_CONFIG)
-        self._cache_hash_file = os.path.join(outdir, ENV_CACHE_DOCHASH)
-        self._cache_publish_file = os.path.join(outdir, ENV_CACHE_PUBLISH)
+        self._cache_cfg_file = builder.out_dir / ENV_CACHE_CONFIG
+        self._cache_hash_file = builder.out_dir / ENV_CACHE_DOCHASH
+        self._cache_publish_file = builder.out_dir / ENV_CACHE_PUBLISH
         self._cached_dochash = {}
         self._cached_hash = None
         self._cached_pids = {}
@@ -76,13 +74,13 @@ class ConfluenceCacheInfo:
 
         # if there is not output file, considered outdated
         dst_filename = self.builder.file_transform(docname)
-        dst_file = os.path.join(self.builder.outdir, dst_filename)
-        if not os.path.exists(dst_file):
+        dst_file = self.builder.out_dir / dst_filename
+        if not dst_file.is_file():
             return True
 
         # if there is not source file (removed document), considered outdated
-        src_file = self.env.doc2path(docname)
-        if not os.path.exists(src_file):
+        src_file = Path(self.env.doc2path(docname))
+        if not src_file.is_file():
             return True
 
         # check if the hashes do not match; if not, this document is outdated
@@ -173,7 +171,7 @@ class ConfluenceCacheInfo:
         """
 
         try:
-            with open(self._cache_cfg_file, encoding='utf-8') as f:
+            with self._cache_cfg_file.open(encoding='utf-8') as f:
                 self._cached_hash = json.load(f).get('hash')
         except FileNotFoundError:
             pass
@@ -181,7 +179,7 @@ class ConfluenceCacheInfo:
             self.builder.warn('failed to load cache (config): ' + e)
 
         try:
-            with open(self._cache_hash_file, encoding='utf-8') as f:
+            with self._cache_hash_file.open(encoding='utf-8') as f:
                 self._cached_dochash = json.load(f)
         except FileNotFoundError:
             pass
@@ -189,7 +187,7 @@ class ConfluenceCacheInfo:
             self.builder.warn('failed to load cache (hashes): ' + e)
 
         try:
-            with open(self._cache_publish_file, encoding='utf-8') as f:
+            with self._cache_publish_file.open(encoding='utf-8') as f:
                 self._cached_pids = json.load(f)
         except FileNotFoundError:
             pass
@@ -213,19 +211,19 @@ class ConfluenceCacheInfo:
         new_dochashs.update(self._active_dochash)
 
         try:
-            with open(self._cache_cfg_file, 'w', encoding='utf-8') as f:
+            with self._cache_cfg_file.open('w', encoding='utf-8') as f:
                 json.dump(new_cfg, f)
         except OSError as e:
             self.builder.warn('failed to save cache (config): ' + e)
 
         try:
-            with open(self._cache_hash_file, 'w', encoding='utf-8') as f:
+            with self._cache_hash_file.open('w', encoding='utf-8') as f:
                 json.dump(new_dochashs, f)
         except OSError as e:
             self.builder.warn('failed to save cache (hashes): ' + e)
 
         try:
-            with open(self._cache_publish_file, 'w', encoding='utf-8') as f:
+            with self._cache_publish_file.open('w', encoding='utf-8') as f:
                 json.dump(self._active_pids, f)
         except OSError as e:
             self.builder.warn('failed to save cache (pids): ' + e)

--- a/sphinxcontrib/confluencebuilder/intersphinx.py
+++ b/sphinxcontrib/confluencebuilder/intersphinx.py
@@ -2,7 +2,6 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 # Copyright 2007-2020 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 
-from os import path
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 import re
 import requests
@@ -32,7 +31,8 @@ def build_intersphinx(builder):
     else:
         pages_part = 'pages/viewpage.action?pageId={}'
 
-    with open(path.join(builder.outdir, INVENTORY_FILENAME), 'wb') as f:
+    inventory_db = builder.out_dir / INVENTORY_FILENAME
+    with inventory_db.open('wb') as f:
         # header
         f.write((
             '# Sphinx inventory version 2\n'

--- a/sphinxcontrib/confluencebuilder/svg.py
+++ b/sphinxcontrib/confluencebuilder/svg.py
@@ -3,12 +3,10 @@
 
 from hashlib import sha256
 from sphinx.util.images import guess_mimetype
-from sphinx.util.osutil import ensuredir
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.util import convert_length
 from sphinxcontrib.confluencebuilder.util import extract_length
 from sphinxcontrib.confluencebuilder.util import find_env_abspath
-import os
 import xml.etree.ElementTree as xml_et
 
 
@@ -194,23 +192,23 @@ def confluence_supported_svg(builder, node):
         return
 
     fname = sha256(svg_data).hexdigest() + '.svg'
-    outfn = os.path.join(builder.outdir, builder.imagedir, 'svgs', fname)
+    out_file = builder.out_dir / builder.imagedir / 'svgs' / fname
 
     # write the new svg file (if needed)
-    if not os.path.isfile(outfn):
+    if not out_file.is_file():
         logger.verbose('generating compatible svg of: %s' % uri)
-        logger.verbose('generating compatible svg to: %s' % outfn)
+        logger.verbose(f'generating compatible svg to: {out_file}')
 
-        ensuredir(os.path.dirname(outfn))
+        out_file.parent.mkdir(parents=True, exist_ok=True)
         try:
-            with open(outfn, 'wb') as f:
+            with out_file.open('wb') as f:
                 f.write(svg_data)
         except (IOError, OSError) as err:
             builder.warn('error writing svg: %s' % err)
             return
 
     # replace the required node attributes
-    node['uri'] = outfn
+    node['uri'] = str(out_file)
 
     if 'height' in node:
         del node['height']

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -2,7 +2,6 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from docutils import nodes
-from os import path
 from sphinx.util.math import wrap_displaymath
 from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger
@@ -136,7 +135,7 @@ def prepare_math_images(builder, doctree):
 
             new_node = nodes.image(
                 candidates={'?'},
-                uri=path.join(builder.outdir, mf),
+                uri=str(builder.out_dir / mf),
                 **node.attributes)
 
             if depth is not None:

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from tests.lib import enable_sphinx_info
 import argparse
 import fnmatch
-import os
 import sys
 import unittest
 
@@ -50,8 +50,8 @@ def main():
         unittest.TestCase.shortDescription = lambda _: None
 
     # discover unit tests
-    test_base = os.path.dirname(os.path.realpath(__file__))
-    unit_tests_dir = os.path.join(test_base, 'unit-tests')
+    test_base = Path(__file__).parent.resolve()
+    unit_tests_dir = test_base / 'unit-tests'
     unit_tests = loader.discover(unit_tests_dir)
 
     # check if a unit test name was provided

--- a/tests/lib/parse.py
+++ b/tests/lib/parse.py
@@ -3,7 +3,7 @@
 
 from bs4 import BeautifulSoup
 from contextlib import contextmanager
-import os
+from pathlib import Path
 
 
 @contextmanager
@@ -24,12 +24,12 @@ def parse(filename, dirname=None):
         the parsed output
     """
     if dirname:
-        target = os.path.join(dirname, filename)
+        target = Path(dirname) / filename
     else:
-        target = filename
+        target = Path(filename)
 
-    target += '.conf'
+    target = target.parent / (target.name + '.conf')
 
-    with open(target, encoding='utf-8') as fp:
+    with target.open(encoding='utf-8') as fp:
         soup = BeautifulSoup(fp, 'html.parser')
         yield soup

--- a/tests/lib/testcase.py
+++ b/tests/lib/testcase.py
@@ -2,10 +2,10 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from functools import wraps
+from pathlib import Path
 from tests.lib import build_sphinx
 from tests.lib import prepare_conf
 from tests.lib import prepare_sphinx
-import os
 import unittest
 
 # default builder to test against
@@ -42,13 +42,12 @@ class ConfluenceTestCase(unittest.TestCase):
         cls.config = prepare_conf()
 
         # provide a reference to common directories
-        lib_dir = os.path.dirname(os.path.realpath(__file__))
-        tests_dir = os.path.join(lib_dir, os.pardir)
-        unit_tests_dir = os.path.join(tests_dir, 'unit-tests')
+        lib_dir = Path(__file__).parent.resolve()
+        unit_tests_dir = lib_dir.parent / 'unit-tests'
 
-        cls.assets_dir = os.path.join(unit_tests_dir, 'assets')
-        cls.datasets = os.path.join(unit_tests_dir, 'datasets')
-        cls.templates_dir = os.path.join(unit_tests_dir, 'templates')
+        cls.assets_dir = unit_tests_dir / 'assets'
+        cls.datasets = unit_tests_dir / 'datasets'
+        cls.templates_dir = unit_tests_dir / 'templates'
 
     def build(self, *args, **kwargs):
         """

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from tests.lib import build_sphinx
 from tests.lib import enable_sphinx_info
 from tests.lib import prepare_dirs
@@ -40,16 +41,16 @@ def main():
         print('[sample] (error) missing tox ini environment variable')
         return 1
 
-    sample_base = os.environ['TOX_INI_DIR']
-    sample_set_dir = os.path.dirname(sample_base)
-    sample_name = os.path.basename(sample_base)
+    sample_base = Path(os.environ['TOX_INI_DIR'])
+    sample_set_dir = sample_base.parent
+    sample_name = sample_base.name
     container = 'sample-' + sample_name
     if args.builder:
         container += '-' + args.builder
 
     # check if there is a sub-folder the documentation will be found under
     if 'SAMPLE_DIR' in os.environ:
-        sample_dir = os.path.join(sample_base, os.environ['SAMPLE_DIR'])
+        sample_dir = sample_base / os.environ['SAMPLE_DIR']
     else:
         sample_dir = sample_base
 
@@ -57,9 +58,9 @@ def main():
 
     # extract any shared confguration values and inject them into the
     # define list
-    shared_config = os.path.join(sample_set_dir, 'config.py')
-    if os.path.isfile(shared_config):
-        with open(shared_config, encoding='utf-8') as f:
+    shared_config = sample_set_dir / 'config.py'
+    if shared_config.is_file():
+        with shared_config.open(encoding='utf-8') as f:
             data = f.read()
 
         ast_data = ast.parse(data, filename=shared_config)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadApiError
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from tests.lib import build_sphinx
@@ -13,9 +14,8 @@ import sys
 
 
 def process_sandbox(target_sandbox, builder=None, defines=None):
-    test_dir = os.path.dirname(os.path.realpath(__file__))
-    base_dir = os.path.join(test_dir, os.pardir)
-    sandbox_dir = os.path.join(base_dir, target_sandbox)
+    test_dir = Path(__file__).parent.resolve()
+    sandbox_dir = test_dir.parent / target_sandbox
 
     container = 'sandbox-test'
     if builder:
@@ -27,12 +27,11 @@ def process_sandbox(target_sandbox, builder=None, defines=None):
 
 
 def process_raw_upload(target_sandbox):
-    test_dir = os.path.dirname(os.path.realpath(__file__))
-    base_dir = os.path.join(test_dir, os.pardir)
-    sandbox_dir = os.path.join(base_dir, target_sandbox)
-    raw_file = os.path.join(sandbox_dir, 'raw.conf')
+    test_dir = Path(__file__).parent.resolve()
+    sandbox_dir = test_dir.parent / target_sandbox
+    raw_file = sandbox_dir / 'raw.conf'
 
-    if not os.path.exists(raw_file):
+    if not raw_file.is_file():
         print('[sandbox] missing file', raw_file)
         return
 
@@ -47,7 +46,7 @@ def process_raw_upload(target_sandbox):
                 'labels': [],
             }
 
-            with open(raw_file, 'r', encoding='utf-8') as f:
+            with raw_file.open(encoding='utf-8') as f:
                 data['content'] = f.read()
 
             print('[sandbox] publishing page...')

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from tests.lib import build_sphinx
 from tests.lib import enable_sphinx_info
@@ -93,11 +94,11 @@ class TestConfluenceValidation(unittest.TestCase):
 """.format(cls.test_key, cls.test_desc)
 
         # find validate-sets base folder
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.datasets = os.path.join(test_dir, 'validation-sets')
+        test_dir = Path(__file__).parent.resolve()
+        cls.datasets = test_dir / 'validation-sets'
 
         # setup base structure
-        dataset = os.path.join(cls.datasets, 'base')
+        dataset = cls.datasets / 'base'
         doc_dir = prepare_dirs('validation-set-base')
 
         config = cls.config.clone()
@@ -178,7 +179,7 @@ class TestConfluenceValidation(unittest.TestCase):
         config = self._prepare_editor(editor)
         config['confluence_sourcelink']['container'] += 'restructuredtext/'
 
-        dataset = os.path.join(self.datasets, 'restructuredtext')
+        dataset = self.datasets / 'restructuredtext'
         doc_dir = prepare_dirs('validation-set-restructuredtext-' + editor)
 
         # inject a navdoc to the header/footer start page
@@ -206,7 +207,7 @@ class TestConfluenceValidation(unittest.TestCase):
         config = self._prepare_editor(editor)
         config['confluence_sourcelink']['container'] += 'sphinx/'
 
-        dataset = os.path.join(self.datasets, 'sphinx')
+        dataset = self.datasets / 'sphinx'
         doc_dir = prepare_dirs('validation-set-sphinx-' + editor)
 
         # inject a navdoc to the header/footer start page
@@ -235,7 +236,7 @@ class TestConfluenceValidation(unittest.TestCase):
         config['confluence_sourcelink']['container'] += 'markdown/'
         config['extensions'].append('myst_parser')
 
-        dataset = os.path.join(self.datasets, 'markdown')
+        dataset = self.datasets / 'markdown'
         doc_dir = prepare_dirs('validation-set-markdown-' + editor)
 
         # inject a navdoc to the header/footer start page
@@ -277,7 +278,7 @@ class TestConfluenceValidation(unittest.TestCase):
         else:
             config['graphviz_output_format'] = 'svg'
 
-        dataset = os.path.join(self.datasets, 'extensions')
+        dataset = self.datasets / 'extensions'
         doc_dir = prepare_dirs('validation-set-extensions-' + editor)
 
         # inject a navdoc to the header/footer start page
@@ -296,9 +297,9 @@ class TestConfluenceValidation(unittest.TestCase):
             return docnames
         config['confluence_navdocs_transform'] = navdocs_transform
 
-        dataset = os.path.join(self.datasets, 'extensions')
+        dataset = self.datasets / 'extensions'
         doc_dir = prepare_dirs('validation-set-extensions')
-        sys.path.insert(0, os.path.join(dataset, 'src'))
+        sys.path.insert(0, str(dataset / 'src'))
 
         build_sphinx(dataset, config=config, out_dir=doc_dir)
 

--- a/tests/unit-tests/test_cache.py
+++ b/tests/unit-tests/test_cache.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.util import temp_dir
 from tests.lib import prepare_dirs
 from tests.lib.testcase import ConfluenceTestCase
-import os
 
 
 class TestCache(ConfluenceTestCase):
@@ -15,7 +15,7 @@ class TestCache(ConfluenceTestCase):
         # Confluence-specific configuration flags that a rebuild is needed.
 
         config = dict(self.config)
-        dataset = os.path.join(self.datasets, 'minimal')
+        dataset = self.datasets / 'minimal'
         out_dir = prepare_dirs()
         src_docs = []
 
@@ -90,15 +90,16 @@ class TestCache(ConfluenceTestCase):
 
             return []
 
-        def write_doc(fname, data):
+        def write_doc(file, data):
             try:
-                with open(fname, 'w') as f:
+                with file.open('w') as f:
                     f.write(data)
             except OSError:
                 pass
 
         with temp_dir() as src_dir:
-            index_file = os.path.join(src_dir, 'index.rst')
+            src_dir = Path(src_dir)
+            index_file = src_dir / 'index.rst'
             write_doc(index_file, '''\
 index
 =====
@@ -106,7 +107,7 @@ index
 content
 ''')
 
-            second_file = os.path.join(src_dir, 'second.rst')
+            second_file = src_dir / 'second.rst'
             write_doc(second_file, '''\
 :orphan:
 

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from requests.auth import AuthBase
 from requests.auth import HTTPDigestAuth
 from sphinx.environment import BuildEnvironment
@@ -12,17 +13,16 @@ from tests.lib import mock_getpass
 from tests.lib import mock_input
 from tests.lib import prepare_conf
 from tests.lib import prepare_sphinx
-import os
 import unittest
 
 
 class TestConfluenceConfigChecks(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(cls.test_dir, 'datasets', 'common')
-        cls.dummy_exists = os.path.join(cls.test_dir, 'assets', 'dummy')
-        cls.dummy_missing = os.path.join(cls.test_dir, 'assets', 'missing')
+        cls.test_dir = Path(__file__).parent.resolve()
+        cls.dataset = cls.test_dir / 'datasets' / 'common'
+        cls.dummy_exists = cls.test_dir / 'assets' / 'dummy'
+        cls.dummy_missing = cls.test_dir / 'assets' / 'missing'
 
         cls.minimal_config = {'extensions': EXT_NAME}
 
@@ -188,9 +188,9 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_ca_cert(self):
-        valid_cert_dir = self.test_dir
-        valid_cert_file = self.dummy_exists
-        missing_cert = self.dummy_missing
+        valid_cert_dir = str(self.test_dir)
+        valid_cert_file = str(self.dummy_exists)
+        missing_cert = str(self.dummy_missing)
 
         self.config['confluence_ca_cert'] = valid_cert_dir
         self._try_config()
@@ -203,8 +203,8 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_client_cert(self):
-        valid_cert = self.dummy_exists
-        missing_cert = self.dummy_missing
+        valid_cert = str(self.dummy_exists)
+        missing_cert = str(self.dummy_missing)
 
         self.config['confluence_client_cert'] = valid_cert
         self._try_config()
@@ -350,8 +350,8 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_footer_file(self):
-        valid_footer = self.dummy_exists
-        missing_footer = self.dummy_missing
+        valid_footer = str(self.dummy_exists)
+        missing_footer = str(self.dummy_missing)
 
         self.config['confluence_footer_file'] = valid_footer
         self._try_config()
@@ -373,8 +373,8 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_header_file(self):
-        valid_header = self.dummy_exists
-        missing_header = self.dummy_missing
+        valid_header = str(self.dummy_exists)
+        missing_header = str(self.dummy_missing)
 
         self.config['confluence_header_file'] = valid_header
         self._try_config()
@@ -636,11 +636,11 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_publish_list(self):
-        dataset = os.path.join(self.test_dir, 'datasets', 'publish-set')
-        assets_dir = os.path.join(self.test_dir, 'assets')
-        invalid_list = os.path.join(assets_dir, 'sample-invalid-publish-list')
+        dataset = self.test_dir / 'datasets' / 'publish-set'
+        assets_dir = self.test_dir / 'assets'
+        invalid_list = assets_dir / 'sample-invalid-publish-list'
         missing_list = self.dummy_missing
-        valid_list = os.path.join(assets_dir, 'sample-valid-publish-list')
+        valid_list = assets_dir / 'sample-valid-publish-list'
 
         options = [
             'confluence_publish_allowlist',
@@ -670,8 +670,8 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config(dataset=dataset)
 
             # file with a valid document list
-            self.assertTrue(os.path.isfile(valid_list))
-            self.config[option] = valid_list
+            self.assertTrue(valid_list.is_file())
+            self.config[option] = str(valid_list)
             self._try_config(dataset=dataset)
 
             # list with invalid content
@@ -690,14 +690,14 @@ class TestConfluenceConfigChecks(unittest.TestCase):
                 self._try_config(dataset=dataset)
 
             # file with invalid document list
-            self.assertTrue(os.path.isfile(invalid_list))
-            self.config[option] = invalid_list
+            self.assertTrue(invalid_list.is_file())
+            self.config[option] = str(invalid_list)
             with self.assertRaises(ConfluenceConfigurationError):
                 self._try_config(dataset=dataset)
 
             # missing file
-            self.assertFalse(os.path.isfile(missing_list))
-            self.config[option] = missing_list
+            self.assertFalse(missing_list.is_file())
+            self.config[option] = str(missing_list)
             with self.assertRaises(ConfluenceConfigurationError):
                 self._try_config(dataset=dataset)
 

--- a/tests/unit-tests/test_config_env.py
+++ b/tests/unit-tests/test_config_env.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from tests.lib import prepare_conf
 from tests.lib import prepare_sphinx
 import os
@@ -10,8 +11,8 @@ import unittest
 class TestConfluenceConfigEnvironment(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        cls.dataset = os.path.join(test_dir, 'datasets', 'common')
+        test_dir = Path(__file__).parent.resolve()
+        cls.dataset = test_dir / 'datasets' / 'common'
 
     def run(self, result=None):
         # unique configuration each run to avoid copying it in each test

--- a/tests/unit-tests/test_config_full_width.py
+++ b/tests/unit-tests/test_config_full_width.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceConfigFullWidth(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceConfigFullWidth(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'common')
+        cls.dataset = cls.datasets / 'common'
 
     @setup_builder('confluence')
     def test_storage_config_full_width_v1_default(self):

--- a/tests/unit-tests/test_config_header_footer.py
+++ b/tests/unit-tests/test_config_header_footer.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
@@ -12,15 +11,15 @@ class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'header-footer')
+        cls.dataset = cls.datasets / 'header-footer'
 
     @setup_builder('confluence')
     def test_storage_config_headerfooter_absolute(self):
         config = dict(self.config)
-        footer_tpl = os.path.join(self.templates_dir, 'sample-footer.tpl')
-        header_tpl = os.path.join(self.templates_dir, 'sample-header.tpl')
-        config['confluence_footer_file'] = footer_tpl
-        config['confluence_header_file'] = header_tpl
+        footer_tpl = self.templates_dir / 'sample-footer.tpl'
+        header_tpl = self.templates_dir / 'sample-header.tpl'
+        config['confluence_footer_file'] = str(footer_tpl)
+        config['confluence_header_file'] = str(header_tpl)
 
         out_dir = self.build(self.dataset, config=config)
 

--- a/tests/unit-tests/test_config_hierarchy.py
+++ b/tests/unit-tests/test_config_hierarchy.py
@@ -3,7 +3,6 @@
 
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from tests.lib.testcase import ConfluenceTestCase
-import os
 
 
 class TestConfluenceHierarchy(ConfluenceTestCase):
@@ -11,7 +10,7 @@ class TestConfluenceHierarchy(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'hierarchy')
+        cls.dataset = cls.datasets / 'hierarchy'
 
     def test_config_hierarchy_parent_registration_default(self):
         ConfluenceState.reset()

--- a/tests/unit-tests/test_config_orphan.py
+++ b/tests/unit-tests/test_config_orphan.py
@@ -7,7 +7,6 @@ from tests.lib.testcase import ConfluenceTestCase
 from unittest.mock import ANY
 from unittest.mock import call
 from unittest.mock import patch
-import os
 
 
 class TestConfluenceConfigOrphan(ConfluenceTestCase):
@@ -15,7 +14,7 @@ class TestConfluenceConfigOrphan(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'orphan')
+        cls.dataset = cls.datasets / 'orphan'
 
         cls.config['confluence_publish'] = True
         cls.config['confluence_server_url'] = 'https://dummy.example.com/'

--- a/tests/unit-tests/test_config_postfix_formatting.py
+++ b/tests/unit-tests/test_config_postfix_formatting.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
-import os
 from sphinxcontrib.confluencebuilder.exceptions import \
     ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
@@ -99,7 +98,7 @@ class TestRegisterTitle(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.config['root_doc'] = 'index'
-        cls.dataset = os.path.join(cls.datasets, 'postfix_formatting')
+        cls.dataset = cls.datasets / 'postfix_formatting'
 
     @setup_builder('confluence')
     def test_postfix_hash_fixing_name_conflict(self):

--- a/tests/unit-tests/test_config_prev_next.py
+++ b/tests/unit-tests/test_config_prev_next.py
@@ -2,7 +2,6 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from tests.lib.testcase import ConfluenceTestCase
-import os
 
 
 class TestConfluenceConfigPrevNext(ConfluenceTestCase):
@@ -10,7 +9,7 @@ class TestConfluenceConfigPrevNext(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'prevnext')
+        cls.dataset = cls.datasets / 'prevnext'
 
     def test_config_prevnext_bottom(self):
         config = dict(self.config)
@@ -53,11 +52,11 @@ class TestConfluenceConfigPrevNext(ConfluenceTestCase):
         self._character_check('final',  out_dir, {'←': 1, '→': 0})
 
     def _character_check(self, name, output, expected):
-        test_path = os.path.join(output, name + '.conf')
-        self.assertTrue(os.path.exists(test_path),
+        test_path = output / (name + '.conf')
+        self.assertTrue(test_path.is_file(),
             f'missing output file: {test_path}')
 
-        with open(test_path, encoding='utf8') as test_file:
+        with test_path.open(encoding='utf8') as test_file:
             data = ''.join([o.strip() + '\n' for o in test_file.readlines()])
             for char, count in expected.items():
                 found = data.count(char)

--- a/tests/unit-tests/test_config_publish_list.py
+++ b/tests/unit-tests/test_config_publish_list.py
@@ -7,7 +7,6 @@ from tests.lib.testcase import ConfluenceTestCase
 from unittest.mock import ANY
 from unittest.mock import call
 from unittest.mock import patch
-import os
 
 
 class TestConfluenceConfigPublishList(ConfluenceTestCase):
@@ -15,7 +14,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'publish-list')
+        cls.dataset = cls.datasets / 'publish-list'
 
         cls.config['confluence_publish'] = True
         cls.config['confluence_server_url'] = 'https://dummy.example.com/'
@@ -68,7 +67,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
         ], any_order=True)
 
     def test_config_publishlist_allow_list_file_default_abs(self):
-        publish_list = os.path.join(self.dataset, 'publish-list-default')
+        publish_list = str(self.dataset / 'publish-list-default')
 
         config = dict(self.config)
         config['confluence_publish_allowlist'] = publish_list
@@ -94,7 +93,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
         ], any_order=True)
 
     def test_config_publishlist_allow_list_file_empty(self):
-        publish_list = os.path.join(self.dataset, 'publish-list-empty')
+        publish_list = str(self.dataset / 'publish-list-empty')
 
         config = dict(self.config)
         config['confluence_publish_allowlist'] = publish_list
@@ -199,7 +198,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
         ], any_order=True)
 
     def test_config_publishlist_deny_list_file_default_abs(self):
-        publish_list = os.path.join(self.dataset, 'publish-list-default')
+        publish_list = str(self.dataset / 'publish-list-default')
 
         config = dict(self.config)
         config['confluence_publish_denylist'] = publish_list
@@ -223,7 +222,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
         ], any_order=True)
 
     def test_config_publishlist_deny_list_file_empty(self):
-        publish_list = os.path.join(self.dataset, 'publish-list-empty')
+        publish_list = str(self.dataset / 'publish-list-empty')
 
         config = dict(self.config)
         config['confluence_publish_denylist'] = publish_list

--- a/tests/unit-tests/test_config_sourcelink.py
+++ b/tests/unit-tests/test_config_sourcelink.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceConfigSourceLink(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceConfigSourceLink(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'minimal')
+        cls.dataset = cls.datasets / 'minimal'
 
     @setup_builder('confluence')
     def test_storage_sourcelink_custom_text(self):

--- a/tests/unit-tests/test_config_titlefix.py
+++ b/tests/unit-tests/test_config_titlefix.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceConfigTitlefix(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceConfigTitlefix(ConfluenceTestCase):
         super().setUpClass()
 
         cls.config['root_doc'] = 'titlefix'
-        cls.dataset = os.path.join(cls.datasets, 'titlefix')
+        cls.dataset = cls.datasets / 'titlefix'
 
     @setup_builder('confluence')
     def test_storage_config_titlefix_none(self):

--- a/tests/unit-tests/test_confluence_code_params.py
+++ b/tests/unit-tests/test_confluence_code_params.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceCodeParams(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceCodeParams(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'code-block-params')
+        cls.dataset = cls.datasets / 'code-block-params'
 
     @setup_builder('confluence')
     def test_storage_confluence_code_params_collapse(self):

--- a/tests/unit-tests/test_confluence_collapse.py
+++ b/tests/unit-tests/test_confluence_collapse.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceCollapse(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceCollapse(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'collapse')
+        cls.dataset = cls.datasets / 'collapse'
 
     @setup_builder('confluence')
     def test_storage_confluence_collapse(self):

--- a/tests/unit-tests/test_confluence_doc.py
+++ b/tests/unit-tests/test_confluence_doc.py
@@ -5,7 +5,6 @@ from sphinx.errors import SphinxWarning
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceDoc(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceDoc(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'confluence-doc')
+        cls.dataset = cls.datasets / 'confluence-doc'
 
     @setup_builder('html')
     def test_html_confluence_doc_ignore(self):
@@ -99,18 +98,18 @@ class TestConfluenceDoc(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_confluence_doc_invalid_doc(self):
-        dataset = self.dataset + '-invalid-doc'
+        dataset = self.dataset.parent / (self.dataset.name + '-invalid-doc')
         with self.assertRaises(SphinxWarning):
             self.build(dataset)
 
     @setup_builder('confluence')
     def test_storage_confluence_doc_invalid_layout(self):
-        dataset = self.dataset + '-invalid-layout'
+        dataset = self.dataset.parent / (self.dataset.name + '-invalid-layout')
         with self.assertRaises(SphinxWarning):
             self.build(dataset)
 
     @setup_builder('confluence')
     def test_storage_confluence_doc_invalid_width(self):
-        dataset = self.dataset + '-invalid-width'
+        dataset = self.dataset.parent / (self.dataset.name + '-invalid-width')
         with self.assertRaises(SphinxWarning):
             self.build(dataset)

--- a/tests/unit-tests/test_confluence_emoticon.py
+++ b/tests/unit-tests/test_confluence_emoticon.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceEmoticon(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceEmoticon(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'emoticon')
+        cls.dataset = cls.datasets / 'emoticon'
 
     @setup_builder('html')
     def test_html_confluence_emoticon_role_ignore(self):

--- a/tests/unit-tests/test_confluence_excerpt.py
+++ b/tests/unit-tests/test_confluence_excerpt.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceExcerpt(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceExcerpt(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'excerpt')
+        cls.dataset = cls.datasets / 'excerpt'
 
     @setup_builder('confluence')
     def test_storage_confluence_excerpt_directive_expected(self):

--- a/tests/unit-tests/test_confluence_expand.py
+++ b/tests/unit-tests/test_confluence_expand.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceExpand(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceExpand(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'expand')
+        cls.dataset = cls.datasets / 'expand'
 
     @setup_builder('confluence')
     def test_storage_confluence_expand_directive_expected(self):

--- a/tests/unit-tests/test_confluence_jira.py
+++ b/tests/unit-tests/test_confluence_jira.py
@@ -5,7 +5,6 @@ from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 from sphinx.errors import SphinxWarning
-import os
 
 
 class TestConfluenceJira(ConfluenceTestCase):
@@ -13,54 +12,54 @@ class TestConfluenceJira(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.container = os.path.join(cls.datasets, 'jira')
+        cls.container = cls.datasets / 'jira'
 
     def test_confluence_jira_directive_bad_sid(self):
-        dataset = os.path.join(self.container, 'bad-sid')
+        dataset = self.container / 'bad-sid'
 
         with self.assertRaises(SphinxWarning):
             self.build(dataset)
 
     def test_confluence_jira_directive_conflicting_server_id(self):
-        dataset = os.path.join(self.container, 'conflicting-server-id')
+        dataset = self.container / 'conflicting-server-id'
 
         with self.assertRaises(SphinxWarning):
             self.build(dataset)
 
     def test_confluence_jira_directive_conflicting_server_name(self):
-        dataset = os.path.join(self.container, 'conflicting-server-name')
+        dataset = self.container / 'conflicting-server-name'
 
         with self.assertRaises(SphinxWarning):
             self.build(dataset)
 
     def test_confluence_jira_directive_missing_server_entry(self):
-        dataset = os.path.join(self.container, 'missing-server-entry')
+        dataset = self.container / 'missing-server-entry'
 
         with self.assertRaises(SphinxWarning):
             self.build(dataset)
 
     def test_confluence_jira_directive_missing_server_id(self):
-        dataset = os.path.join(self.container, 'missing-server-id')
+        dataset = self.container / 'missing-server-id'
 
         with self.assertRaises(SphinxWarning):
             self.build(dataset)
 
     def test_confluence_jira_directive_missing_server_name(self):
-        dataset = os.path.join(self.container, 'missing-server-name')
+        dataset = self.container / 'missing-server-name'
 
         with self.assertRaises(SphinxWarning):
             self.build(dataset)
 
     @setup_builder('html')
     def test_html_confluence_jira_directive_ignore(self):
-        dataset = os.path.join(self.container, 'valid')
+        dataset = self.container / 'valid'
 
         # build attempt should not throw an exception/error
         self.build(dataset, relax=True)
 
     @setup_builder('confluence')
     def test_storage_confluence_jira_directive_expected(self):
-        dataset = os.path.join(self.container, 'valid')
+        dataset = self.container / 'valid'
 
         config = dict(self.config)
         config['confluence_jira_servers'] = {
@@ -130,7 +129,7 @@ class TestConfluenceJira(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_confluence_jira_role_default_expected(self):
-        dataset = os.path.join(self.container, 'valid-role')
+        dataset = self.container / 'valid-role'
 
         out_dir = self.build(dataset)
 
@@ -151,7 +150,7 @@ class TestConfluenceJira(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_confluence_jira_substitution_expected(self):
-        dataset = os.path.join(self.container, 'valid-substitution')
+        dataset = self.container / 'valid-substitution'
 
         out_dir = self.build(dataset)
 

--- a/tests/unit-tests/test_confluence_link.py
+++ b/tests/unit-tests/test_confluence_link.py
@@ -5,7 +5,6 @@ from sphinx.errors import SphinxWarning
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceLink(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceLink(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'confluence-link')
+        cls.dataset = cls.datasets / 'confluence-link'
 
     @setup_builder('html')
     def test_html_confluence_link_ignore(self):
@@ -84,12 +83,12 @@ class TestConfluenceLink(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_confluence_link_invalid_layout(self):
-        dataset = self.dataset + '-invalid-layout'
+        dataset = self.dataset.parent / (self.dataset.name + '-invalid-layout')
         with self.assertRaises(SphinxWarning):
             self.build(dataset)
 
     @setup_builder('confluence')
     def test_storage_confluence_link_invalid_width(self):
-        dataset = self.dataset + '-invalid-width'
+        dataset = self.dataset.parent / (self.dataset.name + '-invalid-width')
         with self.assertRaises(SphinxWarning):
             self.build(dataset)

--- a/tests/unit-tests/test_confluence_mentions.py
+++ b/tests/unit-tests/test_confluence_mentions.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceMentions(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceMentions(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'mentions')
+        cls.dataset = cls.datasets / 'mentions'
 
     @setup_builder('html')
     def test_html_confluence_mention_role_ignore(self):

--- a/tests/unit-tests/test_confluence_metadata.py
+++ b/tests/unit-tests/test_confluence_metadata.py
@@ -3,7 +3,6 @@
 
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceMetadata(ConfluenceTestCase):
@@ -11,7 +10,7 @@ class TestConfluenceMetadata(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'metadata')
+        cls.dataset = cls.datasets / 'metadata'
 
     def test_confluence_metadata_directive_expected(self):
         with self.prepare(self.dataset) as app:

--- a/tests/unit-tests/test_confluence_newline.py
+++ b/tests/unit-tests/test_confluence_newline.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceNewline(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceNewline(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'newline')
+        cls.dataset = cls.datasets / 'newline'
 
     @setup_builder('confluence')
     def test_storage_confluence_newline_directive_expected(self):

--- a/tests/unit-tests/test_confluence_status.py
+++ b/tests/unit-tests/test_confluence_status.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceStatus(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceStatus(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'status')
+        cls.dataset = cls.datasets / 'status'
 
     @setup_builder('html')
     def test_html_confluence_status_role_ignore(self):

--- a/tests/unit-tests/test_confluence_strikethough.py
+++ b/tests/unit-tests/test_confluence_strikethough.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceStrikethrough(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceStrikethrough(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'strikethrough')
+        cls.dataset = cls.datasets / 'strikethrough'
 
     @setup_builder('confluence')
     def test_html_confluence_strikethrough(self):

--- a/tests/unit-tests/test_confluence_toc.py
+++ b/tests/unit-tests/test_confluence_toc.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceToc(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceToc(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'confluence-toc')
+        cls.dataset = cls.datasets / 'confluence-toc'
 
     @setup_builder('html')
     def test_html_confluence_toc_directive_ignore(self):

--- a/tests/unit-tests/test_extension.py
+++ b/tests/unit-tests/test_extension.py
@@ -3,12 +3,11 @@
 
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib import EXT_NAME
-import os
 
 
 class TestConfluenceExtension(ConfluenceTestCase):
     def test_extension_registration(self):
-        mock_ds = os.path.join(self.datasets, 'common')
+        mock_ds = self.datasets / 'common'
 
         with self.prepare(mock_ds) as app:
             if hasattr(app, 'extensions'):

--- a/tests/unit-tests/test_legacy_pages.py
+++ b/tests/unit-tests/test_legacy_pages.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.util import temp_dir
 from tests.lib import prepare_dirs
 from tests.lib.testcase import ConfluenceTestCase
 from unittest.mock import patch
-import os
 
 
 class TestConfluenceLegacyPages(ConfluenceTestCase):
@@ -39,10 +39,11 @@ class TestConfluenceLegacyPages(ConfluenceTestCase):
         out_dir = prepare_dirs()
 
         with temp_dir() as src_dir:
-            conf_file = os.path.join(src_dir, 'conf.py')
+            src_dir = Path(src_dir)
+            conf_file = src_dir / 'conf.py'
             write_doc(conf_file, '')
 
-            index_file = os.path.join(src_dir, 'index.rst')
+            index_file = src_dir / 'index.rst'
             write_doc(index_file, '''\
 index
 =====
@@ -53,7 +54,7 @@ index
     third
 ''')
 
-            second_file = os.path.join(src_dir, 'second.rst')
+            second_file = src_dir / 'second.rst'
             write_doc(second_file, '''\
 second
 ======
@@ -61,7 +62,7 @@ second
 content
 ''')
 
-            third_file = os.path.join(src_dir, 'third.rst')
+            third_file = src_dir / 'third.rst'
             write_doc(third_file, '''\
 third
 =====
@@ -86,7 +87,7 @@ content
             self.assertEqual(len(publisher.removed), 0)
 
             # remove the second file; update the index to drop the entry
-            os.remove(second_file)
+            second_file.unlink()
 
             write_doc(index_file, '''\
 index
@@ -166,9 +167,9 @@ class MockedPublisher:
         return 0
 
 
-def write_doc(fname, data):
+def write_doc(file, data):
     try:
-        with open(fname, 'w') as f:
+        with file.open('w') as f:
             f.write(data)
     except OSError:
         pass

--- a/tests/unit-tests/test_rst_admonitions.py
+++ b/tests/unit-tests/test_rst_admonitions.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstAdmonitions(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstAdmonitions(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'admonitions')
+        cls.dataset = cls.datasets / 'rst' / 'admonitions'
 
     @setup_builder('confluence')
     def test_storage_rst_admonitions(self):

--- a/tests/unit-tests/test_rst_attribution.py
+++ b/tests/unit-tests/test_rst_attribution.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstAttribution(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstAttribution(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'attribution')
+        cls.dataset = cls.datasets / 'rst' / 'attribution'
 
     @setup_builder('confluence')
     def test_storage_rst_attribution(self):

--- a/tests/unit-tests/test_rst_bibliographic.py
+++ b/tests/unit-tests/test_rst_bibliographic.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstBibliographic(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstBibliographic(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'bibliographic')
+        cls.dataset = cls.datasets / 'rst' / 'bibliographic'
 
     @setup_builder('confluence')
     def test_storage_rst_bibliographic_defaults(self):

--- a/tests/unit-tests/test_rst_block_quotes.py
+++ b/tests/unit-tests/test_rst_block_quotes.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstBlockQuotes(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstBlockQuotes(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'block-quotes')
+        cls.dataset = cls.datasets / 'rst' / 'block-quotes'
 
     @setup_builder('confluence')
     def test_storage_rst_block_quotes(self):

--- a/tests/unit-tests/test_rst_citations.py
+++ b/tests/unit-tests/test_rst_citations.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstCitations(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstCitations(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'citations')
+        cls.dataset = cls.datasets / 'rst' / 'citations'
 
     @setup_builder('confluence')
     def test_storage_rst_citations(self):

--- a/tests/unit-tests/test_rst_contents.py
+++ b/tests/unit-tests/test_rst_contents.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 import re
 
 
@@ -13,7 +12,7 @@ class TestConfluenceRstContents(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'contents')
+        cls.dataset = cls.datasets / 'rst' / 'contents'
 
         cls.expected_header_text = [
             'section',

--- a/tests/unit-tests/test_rst_definition_lists.py
+++ b/tests/unit-tests/test_rst_definition_lists.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstDefinitionLists(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstDefinitionLists(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'definition-lists')
+        cls.dataset = cls.datasets / 'rst' / 'definition-lists'
 
     @setup_builder('confluence')
     def test_storage_rst_definition_lists(self):

--- a/tests/unit-tests/test_rst_epigraph.py
+++ b/tests/unit-tests/test_rst_epigraph.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstEpigraph(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstEpigraph(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'epigraph')
+        cls.dataset = cls.datasets / 'rst' / 'epigraph'
 
     @setup_builder('confluence')
     def test_storage_rst_epigraph(self):

--- a/tests/unit-tests/test_rst_figure.py
+++ b/tests/unit-tests/test_rst_figure.py
@@ -6,7 +6,6 @@ from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 from tests.lib.testcase import setup_editor
-import os
 
 
 class TestConfluenceRstFigure(ConfluenceTestCase):
@@ -14,7 +13,7 @@ class TestConfluenceRstFigure(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'figure')
+        cls.dataset = cls.datasets / 'rst' / 'figure'
 
     @setup_builder('confluence')
     def test_storage_rst_figure_defaults(self):
@@ -170,7 +169,7 @@ class TestConfluenceRstFigure(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_rst_figure_caption_default(self):
-        dataset = os.path.join(self.datasets, 'rst', 'figure-caption')
+        dataset = self.datasets / 'rst' / 'figure-caption'
         out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
@@ -199,7 +198,7 @@ class TestConfluenceRstFigure(ConfluenceTestCase):
     @setup_builder('confluence')
     @setup_editor('v2')
     def test_storage_rst_figure_caption_v2(self):
-        dataset = os.path.join(self.datasets, 'rst', 'figure-caption')
+        dataset = self.datasets / 'rst' / 'figure-caption'
         out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:

--- a/tests/unit-tests/test_rst_footnotes.py
+++ b/tests/unit-tests/test_rst_footnotes.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstFootnotes(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstFootnotes(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'footnotes')
+        cls.dataset = cls.datasets / 'rst' / 'footnotes'
 
     @setup_builder('confluence')
     def test_storage_rst_footnotes(self):

--- a/tests/unit-tests/test_rst_headings.py
+++ b/tests/unit-tests/test_rst_headings.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstHeadings(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstHeadings(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'headings')
+        cls.dataset = cls.datasets / 'rst' / 'headings'
 
     @setup_builder('confluence')
     def test_storage_rst_headings_default(self):

--- a/tests/unit-tests/test_rst_highlights.py
+++ b/tests/unit-tests/test_rst_highlights.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstHighlights(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstHighlights(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'highlights')
+        cls.dataset = cls.datasets / 'rst' / 'highlights'
 
     @setup_builder('confluence')
     def test_storage_rst_highlights(self):

--- a/tests/unit-tests/test_rst_image.py
+++ b/tests/unit-tests/test_rst_image.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstImage(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstImage(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'image')
+        cls.dataset = cls.datasets / 'rst' / 'image'
 
     @setup_builder('confluence')
     def test_storage_rst_image_defaults(self):

--- a/tests/unit-tests/test_rst_list_table.py
+++ b/tests/unit-tests/test_rst_list_table.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstListTable(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstListTable(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'list-table')
+        cls.dataset = cls.datasets / 'rst' / 'list-table'
 
     @setup_builder('confluence')
     def test_storage_rst_listtable(self):

--- a/tests/unit-tests/test_rst_lists.py
+++ b/tests/unit-tests/test_rst_lists.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstLists(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstLists(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'lists')
+        cls.dataset = cls.datasets / 'rst' / 'lists'
 
     @setup_builder('confluence')
     def test_storage_rst_lists(self):

--- a/tests/unit-tests/test_rst_literal.py
+++ b/tests/unit-tests/test_rst_literal.py
@@ -5,7 +5,6 @@ from bs4 import CData
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstLiteral(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceRstLiteral(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'literal')
+        cls.dataset = cls.datasets / 'rst' / 'literal'
 
     @setup_builder('confluence')
     def test_storage_rst_literal_blocks(self):

--- a/tests/unit-tests/test_rst_markup.py
+++ b/tests/unit-tests/test_rst_markup.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstMarkup(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstMarkup(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'markup')
+        cls.dataset = cls.datasets / 'rst' / 'markup'
 
     @setup_builder('confluence')
     def test_storage_rst_markup(self):

--- a/tests/unit-tests/test_rst_option_lists.py
+++ b/tests/unit-tests/test_rst_option_lists.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstOptionLists(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstOptionLists(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'option-lists')
+        cls.dataset = cls.datasets / 'rst' / 'option-lists'
 
     @setup_builder('confluence')
     def test_storage_rst_option_lists(self):

--- a/tests/unit-tests/test_rst_parsed_literal.py
+++ b/tests/unit-tests/test_rst_parsed_literal.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstParsedLiteral(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstParsedLiteral(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'parsed-literal')
+        cls.dataset = cls.datasets / 'rst' / 'parsed-literal'
 
     @setup_builder('confluence')
     def test_storage_rst_parsedliteral_defaults(self):

--- a/tests/unit-tests/test_rst_pull_quote.py
+++ b/tests/unit-tests/test_rst_pull_quote.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'pull-quote')
+        cls.dataset = cls.datasets / 'rst' / 'pull-quote'
 
     @setup_builder('confluence')
     def test_storage_rst_pull_quote(self):

--- a/tests/unit-tests/test_rst_raw.py
+++ b/tests/unit-tests/test_rst_raw.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstRaw(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstRaw(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'raw-storage')
+        cls.dataset = cls.datasets / 'rst' / 'raw-storage'
 
     @setup_builder('confluence')
     def test_storage_rst_raw_default(self):

--- a/tests/unit-tests/test_rst_references.py
+++ b/tests/unit-tests/test_rst_references.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstReferences(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceRstReferences(ConfluenceTestCase):
         super().setUpClass()
 
         cls.config['root_doc'] = 'references'
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'references')
+        cls.dataset = cls.datasets / 'rst' / 'references'
 
     @setup_builder('confluence')
     def test_storage_rst_references(self):

--- a/tests/unit-tests/test_rst_tables.py
+++ b/tests/unit-tests/test_rst_tables.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstTables(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstTables(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'tables')
+        cls.dataset = cls.datasets / 'rst' / 'tables'
 
     @setup_builder('confluence')
     def test_storage_rst_tables_defaults(self):

--- a/tests/unit-tests/test_rst_targets.py
+++ b/tests/unit-tests/test_rst_targets.py
@@ -5,7 +5,6 @@ from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 from tests.lib.testcase import setup_editor
-import os
 
 
 class TestConfluenceRstTargets(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceRstTargets(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'targets')
+        cls.dataset = cls.datasets / 'rst' / 'targets'
 
     @setup_builder('confluence')
     def test_storage_rst_targets_defaults(self):

--- a/tests/unit-tests/test_rst_transitions.py
+++ b/tests/unit-tests/test_rst_transitions.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceRstTransitions(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceRstTransitions(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'rst', 'transitions')
+        cls.dataset = cls.datasets / 'rst' / 'transitions'
 
     @setup_builder('confluence')
     def test_storage_rst_transitions_default(self):

--- a/tests/unit-tests/test_sdoc_genindex.py
+++ b/tests/unit-tests/test_sdoc_genindex.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestSdocGenindex(ConfluenceTestCase):
@@ -12,23 +11,23 @@ class TestSdocGenindex(ConfluenceTestCase):
     def test_storage_sdoc_genindex_default_missing_confluence(self):
         """validate genindex is not added by default (confluence)"""
 
-        dataset = os.path.join(self.datasets, 'minimal')
+        dataset = self.datasets / 'minimal'
 
         out_dir = self.build(dataset)
 
-        fname_check = os.path.join(out_dir, 'genindex.conf')
-        self.assertFalse(os.path.exists(fname_check))
+        fname_check = out_dir / 'genindex.conf'
+        self.assertFalse(fname_check.is_file())
 
     @setup_builder('singleconfluence')
     def test_storage_sdoc_genindex_default_missing_singleconfluence(self):
         """validate genindex is not added by default (singleconfluence)"""
 
-        dataset = os.path.join(self.datasets, 'minimal')
+        dataset = self.datasets / 'minimal'
 
         out_dir = self.build(dataset)
 
-        fname_check = os.path.join(out_dir, 'genindex.conf')
-        self.assertFalse(os.path.exists(fname_check))
+        fname_check = out_dir / 'genindex.conf'
+        self.assertFalse(fname_check.is_file())
 
     @setup_builder('confluence')
     def test_storage_sdoc_genindex_explicit_disabled(self):
@@ -39,7 +38,7 @@ class TestSdocGenindex(ConfluenceTestCase):
         # option explicitly, the original genindex document should not be
         # touched.
 
-        dataset = os.path.join(self.datasets, 'sdoc', 'genindex-placeholder')
+        dataset = self.datasets / 'sdoc' / 'genindex-placeholder'
         config = dict(self.config)
         config['confluence_use_index'] = False
 
@@ -57,7 +56,7 @@ class TestSdocGenindex(ConfluenceTestCase):
         # Ensures the extension adds a "genindex" document; even if its not in a
         # documentation set's toctree.
 
-        dataset = os.path.join(self.datasets, 'sdoc', 'genindex')
+        dataset = self.datasets / 'sdoc' / 'genindex'
         config = dict(self.config)
         config['confluence_use_index'] = True
 
@@ -85,9 +84,9 @@ class TestSdocGenindex(ConfluenceTestCase):
         # Ensures that when the extension adds a "genindex" document; any custom
         # defined header/footer data is also injected into the document.
 
-        dataset = os.path.join(self.datasets, 'sdoc', 'genindex')
-        footer_tpl = os.path.join(self.templates_dir, 'sample-footer.tpl')
-        header_tpl = os.path.join(self.templates_dir, 'sample-header.tpl')
+        dataset = self.datasets / 'sdoc' / 'genindex'
+        footer_tpl = str(self.templates_dir / 'sample-footer.tpl')
+        header_tpl = str(self.templates_dir / 'sample-header.tpl')
 
         config = dict(self.config)
         config['confluence_use_index'] = True
@@ -110,7 +109,7 @@ class TestSdocGenindex(ConfluenceTestCase):
         # If a "genindex" document is found in the documentation set's toctree,
         # the document should be generated.
 
-        dataset = os.path.join(self.datasets, 'sdoc', 'genindex-placeholder')
+        dataset = self.datasets / 'sdoc' / 'genindex-placeholder'
 
         out_dir = self.build(dataset)
 

--- a/tests/unit-tests/test_sdoc_modindex.py
+++ b/tests/unit-tests/test_sdoc_modindex.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestSdocModindex(ConfluenceTestCase):
@@ -12,23 +11,23 @@ class TestSdocModindex(ConfluenceTestCase):
     def test_sdoc_modindex_default_missing_confluence(self):
         """validate modindex is not added by default (storage)"""
 
-        dataset = os.path.join(self.datasets, 'minimal')
+        dataset = self.datasets / 'minimal'
 
         out_dir = self.build(dataset)
 
-        fname_check = os.path.join(out_dir, 'py-modindex.conf')
-        self.assertFalse(os.path.exists(fname_check))
+        fname_check = out_dir / 'py-modindex.conf'
+        self.assertFalse(fname_check.is_file())
 
     @setup_builder('singleconfluence')
     def test_sdoc_modindex_default_missing_singleconfluence(self):
         """validate modindex is not added by default (storage)"""
 
-        dataset = os.path.join(self.datasets, 'minimal')
+        dataset = self.datasets / 'minimal'
 
         out_dir = self.build(dataset)
 
-        fname_check = os.path.join(out_dir, 'py-modindex.conf')
-        self.assertFalse(os.path.exists(fname_check))
+        fname_check = out_dir / 'py-modindex.conf'
+        self.assertFalse(fname_check.is_file())
 
     @setup_builder('confluence')
     def test_storage_sdoc_modindex_enabled(self):
@@ -37,7 +36,7 @@ class TestSdocModindex(ConfluenceTestCase):
         # Ensures the extension adds a "py-modindex" document when the domain
         # indices option is assigned to include the domain type.
 
-        dataset = os.path.join(self.datasets, 'sdoc', 'py-modindex')
+        dataset = self.datasets / 'sdoc' / 'py-modindex'
         config = dict(self.config)
         config['confluence_domain_indices'] = [
             'py-modindex',
@@ -67,7 +66,7 @@ class TestSdocModindex(ConfluenceTestCase):
         # Ensures the extension adds a "py-modindex" document when the domain
         # indices option is assigned to a `True` value.
 
-        dataset = os.path.join(self.datasets, 'sdoc', 'py-modindex')
+        dataset = self.datasets / 'sdoc' / 'py-modindex'
         config = dict(self.config)
         config['confluence_domain_indices'] = True
 
@@ -95,9 +94,9 @@ class TestSdocModindex(ConfluenceTestCase):
         # Ensures that when the extension adds a "modindex" document; any custom
         # defined header/footer data is also injected into the document.
 
-        dataset = os.path.join(self.datasets, 'sdoc', 'py-modindex')
-        footer_tpl = os.path.join(self.templates_dir, 'sample-footer.tpl')
-        header_tpl = os.path.join(self.templates_dir, 'sample-header.tpl')
+        dataset = self.datasets / 'sdoc' / 'py-modindex'
+        footer_tpl = str(self.templates_dir / 'sample-footer.tpl')
+        header_tpl = str(self.templates_dir / 'sample-header.tpl')
 
         config = dict(self.config)
         config['confluence_domain_indices'] = True

--- a/tests/unit-tests/test_sdoc_search.py
+++ b/tests/unit-tests/test_sdoc_search.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestSdocSearch(ConfluenceTestCase):
@@ -12,12 +11,12 @@ class TestSdocSearch(ConfluenceTestCase):
     def test_storage_sdoc_search_default_missing(self):
         """validate search is not added by default (storage)"""
 
-        dataset = os.path.join(self.datasets, 'minimal')
+        dataset = self.datasets / 'minimal'
 
         out_dir = self.build(dataset)
 
-        fname_check = os.path.join(out_dir, 'search.conf')
-        self.assertFalse(os.path.exists(fname_check))
+        fname_check = out_dir / 'search.conf'
+        self.assertFalse(fname_check.is_file())
 
     @setup_builder('confluence')
     def test_storage_sdoc_search_explicit_disabled(self):
@@ -27,7 +26,7 @@ class TestSdocSearch(ConfluenceTestCase):
         # automatically generate its contents, by disabling the search option
         # explicitly, the original search document should not be touched.
 
-        dataset = os.path.join(self.datasets, 'sdoc', 'search-placeholder')
+        dataset = self.datasets / 'sdoc' / 'search-placeholder'
         config = dict(self.config)
         config['confluence_include_search'] = False
 
@@ -45,7 +44,7 @@ class TestSdocSearch(ConfluenceTestCase):
         # Ensures the extension adds a "search" document; even if its not in a
         # documentation set's toctree.
 
-        dataset = os.path.join(self.datasets, 'minimal')
+        dataset = self.datasets / 'minimal'
         config = dict(self.config)
         config['confluence_include_search'] = True
 
@@ -63,9 +62,9 @@ class TestSdocSearch(ConfluenceTestCase):
         # Ensures that when the extension adds a "search" document; any custom
         # defined header/footer data is also injected into the document.
 
-        dataset = os.path.join(self.datasets, 'minimal')
-        footer_tpl = os.path.join(self.templates_dir, 'sample-footer.tpl')
-        header_tpl = os.path.join(self.templates_dir, 'sample-header.tpl')
+        dataset = self.datasets / 'minimal'
+        footer_tpl = str(self.templates_dir / 'sample-footer.tpl')
+        header_tpl = str(self.templates_dir / 'sample-header.tpl')
 
         config = dict(self.config)
         config['confluence_include_search'] = True
@@ -88,7 +87,7 @@ class TestSdocSearch(ConfluenceTestCase):
         # If a "search" document is found in the documentation set's toctree,
         # the document should be generated.
 
-        dataset = os.path.join(self.datasets, 'sdoc', 'search-placeholder')
+        dataset = self.datasets / 'sdoc' / 'search-placeholder'
 
         out_dir = self.build(dataset)
 

--- a/tests/unit-tests/test_shared_asset.py
+++ b/tests/unit-tests/test_shared_asset.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSharedAsset(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceSharedAsset(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'shared-asset')
+        cls.dataset = cls.datasets / 'shared-asset'
 
     @setup_builder('confluence')
     def test_storage_sharedasset_defaults(self):

--- a/tests/unit-tests/test_singlepage_assets.py
+++ b/tests/unit-tests/test_singlepage_assets.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSinglepageAssets(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceSinglepageAssets(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'shared-asset')
+        cls.dataset = cls.datasets / 'shared-asset'
 
     @setup_builder('singleconfluence')
     def test_storage_singlepage_asset_defaults(self):

--- a/tests/unit-tests/test_singlepage_docref.py
+++ b/tests/unit-tests/test_singlepage_docref.py
@@ -4,13 +4,12 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSinglepageToctree(ConfluenceTestCase):
     @setup_builder('singleconfluence')
     def test_storage_singlepage_docref_pageref(self):
-        dataset = os.path.join(self.datasets, 'singlepage-docref')
+        dataset = self.datasets / 'singlepage-docref'
 
         out_dir = self.build(dataset)
 
@@ -29,7 +28,7 @@ class TestConfluenceSinglepageToctree(ConfluenceTestCase):
 
     @setup_builder('singleconfluence')
     def test_storage_singlepage_docref_index_no_title(self):
-        dataset = os.path.join(self.datasets, 'singlepage-docref')
+        dataset = self.datasets / 'singlepage-docref'
 
         out_dir = self.build(dataset)
 
@@ -48,7 +47,7 @@ class TestConfluenceSinglepageToctree(ConfluenceTestCase):
         config = dict(self.config)
         config['confluence_remove_title'] = False
 
-        dataset = os.path.join(self.datasets, 'singlepage-docref')
+        dataset = self.datasets / 'singlepage-docref'
 
         out_dir = self.build(dataset, config=config)
 

--- a/tests/unit-tests/test_singlepage_toctree.py
+++ b/tests/unit-tests/test_singlepage_toctree.py
@@ -4,13 +4,12 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSinglepageToctree(ConfluenceTestCase):
     @setup_builder('singleconfluence')
     def test_storage_singlepage_toctree_default(self):
-        dataset = os.path.join(self.datasets, 'toctree-default')
+        dataset = self.datasets / 'toctree-default'
 
         out_dir = self.build(dataset)
 
@@ -72,7 +71,7 @@ class TestConfluenceSinglepageToctree(ConfluenceTestCase):
 
     @setup_builder('singleconfluence')
     def test_storage_singlepage_toctree_numbered(self):
-        dataset = os.path.join(self.datasets, 'toctree-numbered')
+        dataset = self.datasets / 'toctree-numbered'
 
         out_dir = self.build(dataset)
 

--- a/tests/unit-tests/test_sphinx_alignment.py
+++ b/tests/unit-tests/test_sphinx_alignment.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxAlignment(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceSphinxAlignment(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'alignment')
+        cls.dataset = cls.datasets / 'alignment'
 
     @setup_builder('confluence')
     def test_storage_sphinx_alignment_center(self):

--- a/tests/unit-tests/test_sphinx_codeblock.py
+++ b/tests/unit-tests/test_sphinx_codeblock.py
@@ -5,7 +5,6 @@ from bs4 import CData
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxCodeblock(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceSphinxCodeblock(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'code-block')
+        cls.dataset = cls.datasets / 'code-block'
 
     @setup_builder('confluence')
     def test_storage_sphinx_codeblock_caption(self):
@@ -121,7 +120,7 @@ class TestConfluenceSphinxCodeblock(ConfluenceTestCase):
     @setup_builder('confluence')
     def test_storage_sphinx_codeblock_theme_override(self):
         expected_theme = 'Eclipse'
-        dataset = os.path.join(self.datasets, 'code-block-theme')
+        dataset = self.datasets / 'code-block-theme'
         out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:

--- a/tests/unit-tests/test_sphinx_codeblock_highlight.py
+++ b/tests/unit-tests/test_sphinx_codeblock_highlight.py
@@ -5,7 +5,6 @@ from sphinx.errors import SphinxWarning
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'code-block')
+        cls.dataset = cls.datasets / 'code-block'
 
     @setup_builder('confluence')
     def test_storage_sphinx_codeblock_highlight_default(self):
@@ -35,7 +34,7 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_codeblock_highlight_fallback_default(self):
-        dataset = os.path.join(self.datasets, 'code-block-fallback')
+        dataset = self.datasets / 'code-block-fallback'
 
         # check that a fallback language generates a warning
         with self.assertRaises(SphinxWarning):
@@ -43,7 +42,7 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_codeblock_highlight_fallback_handle(self):
-        dataset = os.path.join(self.datasets, 'code-block-fallback')
+        dataset = self.datasets / 'code-block-fallback'
 
         # run in relaxed mode, to ensure a fallback language is applied
         out_dir = self.build(dataset, relax=True)
@@ -135,7 +134,7 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_codeblock_highlight_suppress_warning(self):
-        dataset = os.path.join(self.datasets, 'code-block-fallback')
+        dataset = self.datasets / 'code-block-fallback'
 
         # configure to suppress the generated warning
         config = dict(self.config)

--- a/tests/unit-tests/test_sphinx_deprecated.py
+++ b/tests/unit-tests/test_sphinx_deprecated.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxDeprecated(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceSphinxDeprecated(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'deprecated')
+        cls.dataset = cls.datasets / 'deprecated'
 
     @setup_builder('confluence')
     def test_storage_sphinx_deprecated_defaults(self):

--- a/tests/unit-tests/test_sphinx_domains.py
+++ b/tests/unit-tests/test_sphinx_domains.py
@@ -5,7 +5,6 @@ from sphinx.locale import _
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxDomains(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceSphinxDomains(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'domains')
+        cls.dataset = cls.datasets / 'domains'
 
     @setup_builder('confluence')
     def test_storage_sphinx_domain_c(self):

--- a/tests/unit-tests/test_sphinx_download.py
+++ b/tests/unit-tests/test_sphinx_download.py
@@ -5,7 +5,6 @@ from bs4 import CData
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxDownload(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceSphinxDownload(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'download')
+        cls.dataset = cls.datasets / 'download'
 
     @setup_builder('confluence')
     def test_storage_sphinx_download_defaults(self):

--- a/tests/unit-tests/test_sphinx_glossary.py
+++ b/tests/unit-tests/test_sphinx_glossary.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxDomains(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceSphinxDomains(ConfluenceTestCase):
         super().setUpClass()
 
         cls.config['root_doc'] = 'glossary'
-        cls.dataset = os.path.join(cls.datasets, 'glossary')
+        cls.dataset = cls.datasets / 'glossary'
 
     @setup_builder('confluence')
     def test_storage_sphinx_glossary_defaults(self):

--- a/tests/unit-tests/test_sphinx_image_candidate.py
+++ b/tests/unit-tests/test_sphinx_image_candidate.py
@@ -7,7 +7,6 @@ from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 from tests.lib import prepare_dirs
 import mimetypes
-import os
 import shutil
 import sys
 
@@ -15,7 +14,7 @@ import sys
 class TestConfluenceSphinxImageCandidate(ConfluenceTestCase):
     @setup_builder('confluence')
     def test_storage_sphinx_image_candidate(self):
-        sample_img = os.path.join(self.assets_dir, 'test.png')
+        sample_img = self.assets_dir / 'test.png'
 
         for mime_type in SUPPORTED_IMAGE_TYPES:
             ext = mimetypes.guess_extension(mime_type)
@@ -38,14 +37,14 @@ class TestConfluenceSphinxImageCandidate(ConfluenceTestCase):
             #     image is needed as the contents can be parsed through sphinx
             #     to see if its a real image before considering it to be a
             #     candidate
-            os.makedirs(doc_dir)
+            doc_dir.mkdir(parents=True, exist_ok=True)
 
-            index_file = os.path.join(doc_dir, 'index.rst')
-            with open(index_file, 'w') as f:
+            index_file = doc_dir / 'index.rst'
+            with index_file.open('w') as f:
                 f.write('.. image:: candidate.*')
 
             img_filename = 'candidate' + ext
-            dummy_img_file = os.path.join(doc_dir, img_filename)
+            dummy_img_file = doc_dir / img_filename
             shutil.copyfile(sample_img, dummy_img_file)
 
             # build and check

--- a/tests/unit-tests/test_sphinx_manpage.py
+++ b/tests/unit-tests/test_sphinx_manpage.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxManpage(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceSphinxManpage(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'manpage')
+        cls.dataset = cls.datasets / 'manpage'
 
     @setup_builder('confluence')
     def test_storage_sphinx_manpage_config(self):

--- a/tests/unit-tests/test_sphinx_productionlist.py
+++ b/tests/unit-tests/test_sphinx_productionlist.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxProductionList(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceSphinxProductionList(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'production-list')
+        cls.dataset = cls.datasets / 'production-list'
 
     @setup_builder('confluence')
     def test_storage_sphinx_productionlist_defaults(self):

--- a/tests/unit-tests/test_sphinx_toctree.py
+++ b/tests/unit-tests/test_sphinx_toctree.py
@@ -4,13 +4,12 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxToctree(ConfluenceTestCase):
     @setup_builder('confluence')
     def test_storage_sphinx_toctree_caption(self):
-        dataset = os.path.join(self.datasets, 'toctree-caption')
+        dataset = self.datasets / 'toctree-caption'
         out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
@@ -23,7 +22,7 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_toctree_default(self):
-        dataset = os.path.join(self.datasets, 'toctree-default')
+        dataset = self.datasets / 'toctree-default'
 
         out_dir = self.build(dataset)
 
@@ -69,7 +68,7 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_toctree_hidden(self):
-        dataset = os.path.join(self.datasets, 'toctree-hidden')
+        dataset = self.datasets / 'toctree-hidden'
 
         out_dir = self.build(dataset)
 
@@ -79,7 +78,7 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_toctree_maxdepth(self):
-        dataset = os.path.join(self.datasets, 'toctree-maxdepth')
+        dataset = self.datasets / 'toctree-maxdepth'
 
         out_dir = self.build(dataset)
 
@@ -99,7 +98,7 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_toctree_numbered_default(self):
-        dataset = os.path.join(self.datasets, 'toctree-numbered')
+        dataset = self.datasets / 'toctree-numbered'
 
         out_dir = self.build(dataset)
 
@@ -147,7 +146,7 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_toctree_numbered_depth(self):
-        dataset = os.path.join(self.datasets, 'toctree-numbered-depth')
+        dataset = self.datasets / 'toctree-numbered-depth'
 
         out_dir = self.build(dataset)
 
@@ -183,7 +182,7 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_toctree_numbered_disable(self):
-        dataset = os.path.join(self.datasets, 'toctree-numbered')
+        dataset = self.datasets / 'toctree-numbered'
 
         config = dict(self.config)
         config['confluence_add_secnumbers'] = False
@@ -236,7 +235,7 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
         # Ensure that the toctree secnumber suffix value can be set to an
         # empty string.
 
-        dataset = os.path.join(self.datasets, 'toctree-numbered')
+        dataset = self.datasets / 'toctree-numbered'
 
         config = dict(self.config)
         config['confluence_secnumber_suffix'] = ''
@@ -287,7 +286,7 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
 
     @setup_builder('confluence')
     def test_storage_sphinx_toctree_numbered_secnumbers_suffix_set(self):
-        dataset = os.path.join(self.datasets, 'toctree-numbered')
+        dataset = self.datasets / 'toctree-numbered'
 
         config = dict(self.config)
         config['confluence_secnumber_suffix'] = '!Z /+4'

--- a/tests/unit-tests/test_sphinx_versionadded.py
+++ b/tests/unit-tests/test_sphinx_versionadded.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxVersionAdded(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceSphinxVersionAdded(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'versionadded')
+        cls.dataset = cls.datasets / 'versionadded'
 
     @setup_builder('confluence')
     def test_storage_sphinx_versionadded_defaults(self):

--- a/tests/unit-tests/test_sphinx_versionchanged.py
+++ b/tests/unit-tests/test_sphinx_versionchanged.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceSphinxVersionChanged(ConfluenceTestCase):
@@ -12,7 +11,7 @@ class TestConfluenceSphinxVersionChanged(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'versionchanged')
+        cls.dataset = cls.datasets / 'versionchanged'
 
     @setup_builder('confluence')
     def test_storage_sphinx_versionchanged_defaults(self):

--- a/tests/unit-tests/test_svg.py
+++ b/tests/unit-tests/test_svg.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 import xml.etree.ElementTree as xml_et
 
 
@@ -13,10 +12,10 @@ class TestSvg(ConfluenceTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.dataset = os.path.join(cls.datasets, 'svg')
+        cls.dataset = cls.datasets / 'svg'
 
-    def _extract_svg_size(self, fname):
-        with open(fname, 'rb') as f:
+    def _extract_svg_size(self, svg_file):
+        with svg_file.open('rb') as f:
             svg_data = f.read()
 
         svg_root = xml_et.fromstring(svg_data)
@@ -62,8 +61,8 @@ class TestSvg(ConfluenceTestCase):
             self.assertFalse(attachment.has_attr('ac:height'))
             self.assertFalse(attachment.has_attr('ac:width'))
 
-            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
-            with open(fname, 'rb') as f:
+            attachment_file = out_dir / 'svgs' / attachment['ri:filename']
+            with attachment_file.open('rb') as f:
                 svg_data = f.read()
                 self.assertTrue(svg_data.lstrip().startswith(b'<?xml'))
 
@@ -79,7 +78,7 @@ class TestSvg(ConfluenceTestCase):
             self.assertFalse(attachment.has_attr('ac:height'))
             self.assertFalse(attachment.has_attr('ac:width'))
 
-            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            fname = out_dir / 'svgs' / attachment['ri:filename']
             svg_width, svg_height = self._extract_svg_size(fname)
             self.assertEqual(svg_height, 100)
             self.assertEqual(svg_width, 25)
@@ -96,7 +95,7 @@ class TestSvg(ConfluenceTestCase):
             self.assertFalse(attachment.has_attr('ac:height'))
             self.assertFalse(attachment.has_attr('ac:width'))
 
-            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            fname = out_dir / 'svgs' / attachment['ri:filename']
             svg_width, svg_height = self._extract_svg_size(fname)
             self.assertEqual(svg_height, 75)
             self.assertEqual(svg_width, 75)
@@ -109,7 +108,7 @@ class TestSvg(ConfluenceTestCase):
             self.assertFalse(attachment.has_attr('ac:height'))
             self.assertFalse(attachment.has_attr('ac:width'))
 
-            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            fname = out_dir / 'svgs' / attachment['ri:filename']
             svg_width, svg_height = self._extract_svg_size(fname)
             self.assertEqual(svg_height, 192)
             self.assertEqual(svg_width, 192)
@@ -122,7 +121,7 @@ class TestSvg(ConfluenceTestCase):
             self.assertFalse(attachment.has_attr('ac:height'))
             self.assertFalse(attachment.has_attr('ac:width'))
 
-            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            fname = out_dir / 'svgs' / attachment['ri:filename']
             svg_width, svg_height = self._extract_svg_size(fname)
             self.assertEqual(svg_height, 50)
             self.assertEqual(svg_width, 1600)
@@ -135,7 +134,7 @@ class TestSvg(ConfluenceTestCase):
             self.assertFalse(attachment.has_attr('ac:height'))
             self.assertFalse(attachment.has_attr('ac:width'))
 
-            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            fname = out_dir / 'svgs' / attachment['ri:filename']
             svg_width, svg_height = self._extract_svg_size(fname)
             self.assertEqual(svg_height, 200)
             self.assertEqual(svg_width, 200)
@@ -152,7 +151,7 @@ class TestSvg(ConfluenceTestCase):
             self.assertFalse(attachment.has_attr('ac:height'))
             self.assertFalse(attachment.has_attr('ac:width'))
 
-            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            fname = out_dir / 'svgs' / attachment['ri:filename']
             svg_width, svg_height = self._extract_svg_size(fname)
             self.assertEqual(svg_height, 200)
             self.assertEqual(svg_width, 50)
@@ -165,7 +164,7 @@ class TestSvg(ConfluenceTestCase):
             self.assertFalse(attachment.has_attr('ac:height'))
             self.assertFalse(attachment.has_attr('ac:width'))
 
-            fname = os.path.join(out_dir, 'svgs', attachment['ri:filename'])
+            fname = out_dir / 'svgs' / attachment['ri:filename']
             svg_width, svg_height = self._extract_svg_size(fname)
             self.assertEqual(svg_height, 200)
             self.assertEqual(svg_width, 50)

--- a/tests/unit-tests/test_translator.py
+++ b/tests/unit-tests/test_translator.py
@@ -2,10 +2,10 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from collections import namedtuple
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.translator import ConfluenceBaseTranslator
 from tests.lib import prepare_conf
 from tests.lib import prepare_sphinx
-import os
 import unittest
 
 Reporter = namedtuple('Reporter', 'warning')
@@ -13,7 +13,7 @@ Reporter = namedtuple('Reporter', 'warning')
 
 class DummyDocument(dict):
     def __init__(self, source, warn=False):
-        self['source'] = source
+        self['source'] = str(source)
         self.reporter = Reporter(warn)
 
 
@@ -21,11 +21,11 @@ class TestConfluenceBaseTranslator(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = prepare_conf()
-        cls.test_dir = os.path.dirname(os.path.realpath(__file__))
+        cls.test_dir = Path(__file__).parent.resolve()
 
     def test_translator_docname_and_docparent(self):
-        mock_ds = os.path.join(self.test_dir, 'datasets', 'common')
-        mock_docpath = os.path.join(mock_ds, 'foo', 'bar', 'baz.rst')
+        mock_ds = self.test_dir / 'datasets' / 'common'
+        mock_docpath = mock_ds / 'foo' / 'bar' / 'baz.rst'
         doc = DummyDocument(mock_docpath)
 
         # prepare a dummy application; no need to actually build

--- a/tests/unit-tests/test_usecase_nested_ref.py
+++ b/tests/unit-tests/test_usecase_nested_ref.py
@@ -4,7 +4,6 @@
 from tests.lib.parse import parse
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
-import os
 
 
 class TestConfluenceUseCaseNestedRef(ConfluenceTestCase):
@@ -13,7 +12,7 @@ class TestConfluenceUseCaseNestedRef(ConfluenceTestCase):
         super().setUpClass()
 
         cls.config['root_doc'] = 'nested-ref-contents'
-        cls.dataset = os.path.join(cls.datasets, 'use-cases')
+        cls.dataset = cls.datasets / 'use-cases'
         cls.filenames = [
             'nested-ref-contents',
             'nested-ref-external',


### PR DESCRIPTION
This is part of an ongoing maintenance task to the implementation to use newer capabilities of Python that are supported on the oldest interpreter version this extension supports.

### register message locale using pathlib

Updating the implementation to register this package's locale with
Sphinx to use pathlib instead of raw strings.

### builder: manage a pathlib output directory

Updating the implementation to manage a builder member variable `out_dir`, which provides a path-like object instead of a string from Sphinx's `outdir` variable. This commit also adjusts the implementation that uses the output directory to take advantage of pathlib capabilities.

### tests: use pathlib

Updating the testing implementation to use the pathlib module for all path-related operations.

