### PR TITLE
Accept path-like configuration options

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -41,6 +41,7 @@ from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import first
 from sphinxcontrib.confluencebuilder.util import handle_cli_file_subset
 from sphinxcontrib.confluencebuilder.writer import ConfluenceWriter
+import os
 import tempfile
 
 
@@ -211,7 +212,7 @@ class ConfluenceBuilder(Builder):
             if value is None:
                 return None
 
-            if isinstance(value, str):
+            if isinstance(value, (str, os.PathLike)):
                 files = extract_strings_from_file(value)
             else:
                 files = value

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -278,7 +278,6 @@ The following editors are supported:
     # confluence_footer_file
     try:
         validator.conf('confluence_footer_file') \
-                 .string() \
                  .file()
     except ConfluenceConfigurationError as e:
         raise ConfluenceConfigurationError('''\
@@ -315,7 +314,6 @@ that contains no spaces.
     # confluence_header_file
     try:
         validator.conf('confluence_header_file') \
-                 .string() \
                  .file()
     except ConfluenceConfigurationError as e:
         raise ConfluenceConfigurationError('''\
@@ -534,16 +532,15 @@ navigational buttons onto generated pages. Accepted values include 'bottom',
         # if provided a file via command line, treat as a list
         def conf_translate(value):
             return handle_cli_file_subset(builder, option, value)
+
         value = conf_translate(value)
+        option_val = validator.conf(option, conf_translate)
 
         try:
-            validator.conf(option, conf_translate) \
-                     .string_or_strings()
-
-            if isinstance(value, str):
-                validator.docnames_from_file()
+            if isinstance(value, (str, os.PathLike)):
+                option_val.docnames_from_file()
             else:
-                validator.docnames()
+                option_val.docnames()
         except ConfluenceConfigurationError as e:
             raise ConfluenceConfigurationError('''\
 {msg}

--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceConfigurationError
 from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import str2bool
@@ -152,15 +153,14 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if not (isinstance(value, (list, set, tuple)) or not all(
-                    isinstance(label, str) for label in value)):
+            if not (isinstance(value, (list, set, tuple))) or not all(
+                    isinstance(label, (str, os.PathLike)) for label in value):
                 raise ConfluenceConfigurationError(
                     '%s is not a collection of filenames' % self.key)
 
             for docname in value:
                 if not any(
-                        os.path.isfile(
-                            os.path.join(self.env.srcdir, docname + suffix))
+                        Path(self.env.srcdir, docname + suffix).is_file()
                         for suffix in self.config.source_suffix):
                     raise ConfluenceConfigurationError(
                         f'{self.key} is missing document {docname}')
@@ -186,16 +186,12 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if not isinstance(value, str) or not os.path.isfile(
-                    os.path.join(self.env.srcdir, value)):
-                raise ConfluenceConfigurationError(
-                    '%s is not a file' % self.key)
+            self.file()
 
             docnames = extract_strings_from_file(value)
             for docname in docnames:
                 if not any(
-                        os.path.isfile(
-                            os.path.join(self.env.srcdir, docname + suffix))
+                        Path(self.env.srcdir, docname + suffix).is_file()
                         for suffix in self.config.source_suffix):
                     raise ConfluenceConfigurationError(
                         f'{self.key} is missing document {docname}')
@@ -247,8 +243,8 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if not isinstance(value, str) or not os.path.isfile(
-                    os.path.join(self.env.srcdir, value)):
+            if not isinstance(value, (str, os.PathLike)) or \
+                    not Path(self.env.srcdir, value).is_file():
                 raise ConfluenceConfigurationError(
                     '%s is not a file' % self.key)
 
@@ -378,8 +374,8 @@ class ConfigurationValidation:
         value = self._value()
 
         if value is not None:
-            if not isinstance(value, str) or not os.path.exists(
-                    os.path.join(self.env.srcdir, value)):
+            if not isinstance(value, (str, os.PathLike)) or \
+                    not Path(self.env.srcdir, value).exists():
                 raise ConfluenceConfigurationError(
                     '%s is not a path' % self.key)
 

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -2,6 +2,7 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from contextlib import contextmanager
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_SIZE
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_X_HEIGHT
@@ -321,19 +322,19 @@ def handle_cli_file_subset(builder, option, value):
         the resolved configuration value
     """
 
-    if option in builder.config['overrides'] and isinstance(value, str):
+    if option in builder.config['overrides'] and \
+            isinstance(value, (str, os.PathLike)):
         if not value:
             # an empty command line subset is an "unset" request
             # (and not an empty list); if no values are detected,
             # return `None`
             return None
         else:
-            if os.path.isabs(value):
-                target_file = value
-            else:
-                target_file = os.path.join(builder.env.srcdir, value)
+            target_file = Path(value)
+            if not target_file.is_absolute():
+                target_file = Path(builder.env.srcdir, value)
 
-            if os.path.isfile(target_file):
+            if target_file.is_file():
                 value = target_file
             else:
                 value = value.split(',')

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -188,31 +188,48 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_ca_cert(self):
-        valid_cert_dir = str(self.test_dir)
-        valid_cert_file = str(self.dummy_exists)
-        missing_cert = str(self.dummy_missing)
+        valid_cert_dir = self.test_dir
+        valid_cert_file = self.dummy_exists
+        missing_cert = self.dummy_missing
 
         self.config['confluence_ca_cert'] = valid_cert_dir
         self._try_config()
 
+        self.config['confluence_ca_cert'] = str(valid_cert_dir)
+        self._try_config()
+
         self.config['confluence_ca_cert'] = valid_cert_file
+        self._try_config()
+
+        self.config['confluence_ca_cert'] = str(valid_cert_file)
         self._try_config()
 
         self.config['confluence_ca_cert'] = missing_cert
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
+        self.config['confluence_ca_cert'] = str(missing_cert)
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
     def test_config_check_client_cert(self):
-        valid_cert = str(self.dummy_exists)
-        missing_cert = str(self.dummy_missing)
+        valid_cert = self.dummy_exists
+        missing_cert = self.dummy_missing
 
         self.config['confluence_client_cert'] = valid_cert
+        self._try_config()
+
+        self.config['confluence_client_cert'] = str(valid_cert)
         self._try_config()
 
         self.config['confluence_client_cert'] = (valid_cert, valid_cert)
         self._try_config()
 
         self.config['confluence_client_cert'] = missing_cert
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_client_cert'] = str(missing_cert)
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
@@ -350,13 +367,20 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_footer_file(self):
-        valid_footer = str(self.dummy_exists)
-        missing_footer = str(self.dummy_missing)
+        valid_footer = self.dummy_exists
+        missing_footer = self.dummy_missing
 
         self.config['confluence_footer_file'] = valid_footer
         self._try_config()
 
+        self.config['confluence_footer_file'] = str(valid_footer)
+        self._try_config()
+
         self.config['confluence_footer_file'] = missing_footer
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_footer_file'] = str(missing_footer)
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
@@ -373,13 +397,20 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_header_file(self):
-        valid_header = str(self.dummy_exists)
-        missing_header = str(self.dummy_missing)
+        valid_header = self.dummy_exists
+        missing_header = self.dummy_missing
 
         self.config['confluence_header_file'] = valid_header
         self._try_config()
 
+        self.config['confluence_header_file'] = str(valid_header)
+        self._try_config()
+
         self.config['confluence_header_file'] = missing_header
+        with self.assertRaises(ConfluenceConfigurationError):
+            self._try_config()
+
+        self.config['confluence_header_file'] = str(missing_header)
         with self.assertRaises(ConfluenceConfigurationError):
             self._try_config()
 
@@ -671,6 +702,9 @@ class TestConfluenceConfigChecks(unittest.TestCase):
 
             # file with a valid document list
             self.assertTrue(valid_list.is_file())
+            self.config[option] = valid_list
+            self._try_config(dataset=dataset)
+
             self.config[option] = str(valid_list)
             self._try_config(dataset=dataset)
 
@@ -691,12 +725,20 @@ class TestConfluenceConfigChecks(unittest.TestCase):
 
             # file with invalid document list
             self.assertTrue(invalid_list.is_file())
+            self.config[option] = invalid_list
+            with self.assertRaises(ConfluenceConfigurationError):
+                self._try_config(dataset=dataset)
+
             self.config[option] = str(invalid_list)
             with self.assertRaises(ConfluenceConfigurationError):
                 self._try_config(dataset=dataset)
 
             # missing file
             self.assertFalse(missing_list.is_file())
+            self.config[option] = missing_list
+            with self.assertRaises(ConfluenceConfigurationError):
+                self._try_config(dataset=dataset)
+
             self.config[option] = str(missing_list)
             with self.assertRaises(ConfluenceConfigurationError):
                 self._try_config(dataset=dataset)

--- a/tests/unit-tests/test_config_header_footer.py
+++ b/tests/unit-tests/test_config_header_footer.py
@@ -18,8 +18,8 @@ class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
         config = dict(self.config)
         footer_tpl = self.templates_dir / 'sample-footer.tpl'
         header_tpl = self.templates_dir / 'sample-header.tpl'
-        config['confluence_footer_file'] = str(footer_tpl)
-        config['confluence_header_file'] = str(header_tpl)
+        config['confluence_footer_file'] = footer_tpl
+        config['confluence_header_file'] = header_tpl
 
         out_dir = self.build(self.dataset, config=config)
 

--- a/tests/unit-tests/test_config_publish_list.py
+++ b/tests/unit-tests/test_config_publish_list.py
@@ -67,7 +67,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
         ], any_order=True)
 
     def test_config_publishlist_allow_list_file_default_abs(self):
-        publish_list = str(self.dataset / 'publish-list-default')
+        publish_list = self.dataset / 'publish-list-default'
 
         config = dict(self.config)
         config['confluence_publish_allowlist'] = publish_list
@@ -93,7 +93,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
         ], any_order=True)
 
     def test_config_publishlist_allow_list_file_empty(self):
-        publish_list = str(self.dataset / 'publish-list-empty')
+        publish_list = self.dataset / 'publish-list-empty'
 
         config = dict(self.config)
         config['confluence_publish_allowlist'] = publish_list
@@ -198,7 +198,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
         ], any_order=True)
 
     def test_config_publishlist_deny_list_file_default_abs(self):
-        publish_list = str(self.dataset / 'publish-list-default')
+        publish_list = self.dataset / 'publish-list-default'
 
         config = dict(self.config)
         config['confluence_publish_denylist'] = publish_list
@@ -222,7 +222,7 @@ class TestConfluenceConfigPublishList(ConfluenceTestCase):
         ], any_order=True)
 
     def test_config_publishlist_deny_list_file_empty(self):
-        publish_list = str(self.dataset / 'publish-list-empty')
+        publish_list = self.dataset / 'publish-list-empty'
 
         config = dict(self.config)
         config['confluence_publish_denylist'] = publish_list

--- a/tests/unit-tests/test_sdoc_genindex.py
+++ b/tests/unit-tests/test_sdoc_genindex.py
@@ -85,8 +85,8 @@ class TestSdocGenindex(ConfluenceTestCase):
         # defined header/footer data is also injected into the document.
 
         dataset = self.datasets / 'sdoc' / 'genindex'
-        footer_tpl = str(self.templates_dir / 'sample-footer.tpl')
-        header_tpl = str(self.templates_dir / 'sample-header.tpl')
+        footer_tpl = self.templates_dir / 'sample-footer.tpl'
+        header_tpl = self.templates_dir / 'sample-header.tpl'
 
         config = dict(self.config)
         config['confluence_use_index'] = True

--- a/tests/unit-tests/test_sdoc_modindex.py
+++ b/tests/unit-tests/test_sdoc_modindex.py
@@ -95,8 +95,8 @@ class TestSdocModindex(ConfluenceTestCase):
         # defined header/footer data is also injected into the document.
 
         dataset = self.datasets / 'sdoc' / 'py-modindex'
-        footer_tpl = str(self.templates_dir / 'sample-footer.tpl')
-        header_tpl = str(self.templates_dir / 'sample-header.tpl')
+        footer_tpl = self.templates_dir / 'sample-footer.tpl'
+        header_tpl = self.templates_dir / 'sample-header.tpl'
 
         config = dict(self.config)
         config['confluence_domain_indices'] = True

--- a/tests/unit-tests/test_sdoc_search.py
+++ b/tests/unit-tests/test_sdoc_search.py
@@ -63,8 +63,8 @@ class TestSdocSearch(ConfluenceTestCase):
         # defined header/footer data is also injected into the document.
 
         dataset = self.datasets / 'minimal'
-        footer_tpl = str(self.templates_dir / 'sample-footer.tpl')
-        header_tpl = str(self.templates_dir / 'sample-header.tpl')
+        footer_tpl = self.templates_dir / 'sample-footer.tpl'
+        header_tpl = self.templates_dir / 'sample-header.tpl'
 
         config = dict(self.config)
         config['confluence_include_search'] = True


### PR DESCRIPTION
For various configuration options, sanity checks for path-related options would require values to be string values. If a user defined these values using PathLib, a configuration exception would be thrown (and a user would have to workaround by explicitly str-casting the values). To be flexible for these configurations, ensure all path-related options can accept both `str` or `os.PathLike` typed entries.