### PR TITLE
Use pathlib (Part 2)

### DIFF
--- a/sphinxcontrib/confluencebuilder/__main__.py
+++ b/sphinxcontrib/confluencebuilder/__main__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinx.util.console import color_terminal
 from sphinx.util.console import nocolor  # pylint: disable=no-name-in-module
 from sphinxcontrib.confluencebuilder import __version__ as version
@@ -29,7 +30,7 @@ def main():
     parser.add_argument('--verbose', '-V', action='count', default=0)
     parser.add_argument('--version', action='version',
         version='%(prog)s ' + version)
-    parser.add_argument('--work-dir')
+    parser.add_argument('--work-dir', type=Path)
 
     args, _ = parser.parse_known_args()
     if args.help:

--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -274,7 +274,8 @@ class ConfluenceAssetManager:
 
         if path not in self.path2asset:
             hash_ = ConfluenceUtil.hash_asset(path)
-            type_ = guess_mimetype(path, default=DEFAULT_CONTENT_TYPE)
+            # str-cast for sphinx-6.1
+            type_ = guess_mimetype(str(path), default=DEFAULT_CONTENT_TYPE)
         else:
             hash_ = self.path2asset[path].hash
             type_ = self.path2asset[path].type

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -152,7 +152,7 @@ class ConfluenceBuilder(Builder):
         if new_url:
             self.cloud = new_url.endswith('.atlassian.net/wiki/')
 
-        self.assets = ConfluenceAssetManager(config, self.env, self.outdir)
+        self.assets = ConfluenceAssetManager(config, self.env, self.out_dir)
         self.writer = ConfluenceWriter(self)
         self.config.sphinx_verbosity = self._verbose
         self.publisher.init(self.config, self.cloud)
@@ -789,13 +789,13 @@ class ConfluenceBuilder(Builder):
             for asset in status_iterator(assets, 'publishing assets... ',
                     length=len(assets), verbosity=self._verbose,
                     stringify_func=to_asset_name):
-                key, absfile, type_, hash_, docname = asset
+                key, abs_file, type_, hash_, docname = asset
                 if self._check_publish_skip(docname):
                     self.verbose(key + ' skipped due to configuration')
                     continue
 
                 try:
-                    with open(absfile, 'rb') as file:
+                    with abs_file.open('rb') as file:
                         output = file.read()
                         self.publish_asset(key, docname, output, type_, hash_)
                 except OSError as err:

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from docutils import nodes
 from docutils.io import StringOutput
 from pathlib import Path
-from os import path
 from sphinx import addnodes
 from sphinx import version_info as sphinx_version_info
 from sphinx.builders import Builder
@@ -910,13 +909,13 @@ class ConfluenceBuilder(Builder):
             header_template_data = ''
 
             if self.config.confluence_header_file is not None:
-                fname = path.join(self.env.srcdir,
+                header_file = Path(self.env.srcdir,
                     self.config.confluence_header_file)
                 try:
-                    with open(fname, encoding='utf-8') as file:
+                    with header_file.open(encoding='utf-8') as file:
                         header_template_data = file.read() + '\n'
                 except OSError as err:
-                    self.warn(f'error reading file {fname}: {err}')
+                    self.warn(f'error reading file {header_file}: {err}')
 
                 # if no data is supplied, the file is plain text
                 if self.config.confluence_header_data is None:
@@ -932,13 +931,13 @@ class ConfluenceBuilder(Builder):
             footer_template_data = ''
 
             if self.config.confluence_footer_file is not None:
-                fname = path.join(self.env.srcdir,
+                footer_file = Path(self.env.srcdir,
                     self.config.confluence_footer_file)
                 try:
-                    with open(fname, encoding='utf-8') as file:
+                    with footer_file.open(encoding='utf-8') as file:
                         footer_template_data = file.read() + '\n'
                 except OSError as err:
-                    self.warn(f'error reading file {fname}: {err}')
+                    self.warn(f'error reading file {footer_file}: {err}')
 
                 # if no data is supplied, the file is plain text
                 if self.config.confluence_footer_data is None:

--- a/sphinxcontrib/confluencebuilder/cmd/build.py
+++ b/sphinxcontrib/confluencebuilder/cmd/build.py
@@ -2,10 +2,10 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from contextlib import suppress
+from pathlib import Path
 from sphinx.application import Sphinx
 from sphinx.util.docutils import docutils_namespace
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
-import os
 import sys
 
 #: default builder to invoke when one is not specified
@@ -26,7 +26,7 @@ def build_main(args_parser):
     """
 
     args_parser.add_argument('-D', action='append', default=[], dest='define')
-    args_parser.add_argument('--output-dir', '-o')
+    args_parser.add_argument('--output-dir', '-o', type=Path)
 
     known_args = sys.argv[1:]
     args, unknown_args = args_parser.parse_known_args(known_args)
@@ -42,12 +42,12 @@ def build_main(args_parser):
             logger.error('invalid define provided in command line')
             return 1
 
-    work_dir = args.work_dir if args.work_dir else os.getcwd()
+    work_dir = args.work_dir if args.work_dir else Path.cwd()
     if args.output_dir:
         output_dir = args.output_dir
     else:
-        output_dir = os.path.join(work_dir, '_build', 'confluence')
-    doctrees_dir = os.path.join(output_dir, '.doctrees')
+        output_dir = work_dir / '_build' / 'confluence'
+    doctrees_dir = output_dir / '.doctrees'
     builder = args.action if args.action else DEFAULT_BUILDER
 
     verbosity = 0

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -3,6 +3,7 @@
 
 from collections import OrderedDict
 from docutils import __version__ as docutils_version
+from pathlib import Path
 from requests import __version__ as requests_version
 from sphinx import __version__ as sphinx_version
 from sphinx.application import Sphinx
@@ -19,7 +20,6 @@ from sphinxcontrib.confluencebuilder.util import temp_dir
 from urllib.parse import urlparse
 from urllib3 import __version__ as urllib3_version
 from xml.etree import ElementTree
-import os
 import platform
 import sys
 import traceback
@@ -68,7 +68,7 @@ def report_main(args_parser):
 
     rv = 0
     offline = args.offline
-    work_dir = args.work_dir if args.work_dir else os.getcwd()
+    work_dir = args.work_dir if args.work_dir else Path.cwd()
 
     # setup sphinx engine to extract configuration
     config = {}
@@ -81,8 +81,8 @@ def report_main(args_parser):
             print('fetching configuration information...')
             builder = ConfluenceReportBuilder.name
             app = Sphinx(
-                work_dir,            # document sources
-                work_dir,            # directory with configuration
+                str(work_dir),       # document sources
+                str(work_dir),       # directory with configuration
                 tmp_dir,             # output for built documents
                 tmp_dir,             # output for doctree files
                 builder,             # builder to execute
@@ -126,7 +126,7 @@ def report_main(args_parser):
         sys.stdout.flush()
         tb_msg = traceback.format_exc()
         logger.error(tb_msg)
-        if os.path.isfile(os.path.join(work_dir, 'conf.py')):
+        if Path(work_dir / 'conf.py').is_file():
             configuration_load_issue = 'unable to load configuration'
             configuration_load_issue += '\n\n' + tb_msg.strip()
         else:

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -83,8 +83,8 @@ def report_main(args_parser):
             app = Sphinx(
                 str(work_dir),       # document sources
                 str(work_dir),       # directory with configuration
-                tmp_dir,             # output for built documents
-                tmp_dir,             # output for doctree files
+                str(tmp_dir),        # output for built documents
+                str(tmp_dir),        # output for doctree files
                 builder,             # builder to execute
                 status=sys.stdout,   # sphinx status output
                 warning=sys.stderr)  # sphinx warning output

--- a/sphinxcontrib/confluencebuilder/cmd/wipe.py
+++ b/sphinxcontrib/confluencebuilder/cmd/wipe.py
@@ -65,8 +65,8 @@ To use this action, the argument '--danger' must be set.
             app = Sphinx(
                 str(work_dir),       # document sources
                 str(work_dir),       # directory with configuration
-                tmp_dir,             # output for built documents
-                tmp_dir,             # output for doctree files
+                str(tmp_dir),        # output for built documents
+                str(tmp_dir),        # output for doctree files
                 'confluence',        # builder to execute
                 status=sys.stdout,   # sphinx status output
                 warning=sys.stderr)  # sphinx warning output

--- a/sphinxcontrib/confluencebuilder/cmd/wipe.py
+++ b/sphinxcontrib/confluencebuilder/cmd/wipe.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinx.application import Sphinx
 from sphinx.locale import __
 from sphinx.util.docutils import docutils_namespace
@@ -8,7 +9,6 @@ from sphinxcontrib.confluencebuilder.config import process_ask_configs
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.util import temp_dir
-import os
 import sys
 import traceback
 
@@ -34,7 +34,7 @@ def wipe_main(args_parser):
     if unknown_args:
         logger.warn('unknown arguments: {}'.format(' '.join(unknown_args)))
 
-    work_dir = args.work_dir if args.work_dir else os.getcwd()
+    work_dir = args.work_dir if args.work_dir else Path.cwd()
 
     # protection warning
     if not args.danger:
@@ -63,8 +63,8 @@ To use this action, the argument '--danger' must be set.
     try:
         with temp_dir() as tmp_dir, docutils_namespace():
             app = Sphinx(
-                work_dir,            # document sources
-                work_dir,            # directory with configuration
+                str(work_dir),       # document sources
+                str(work_dir),       # directory with configuration
                 tmp_dir,             # output for built documents
                 tmp_dir,             # output for doctree files
                 'confluence',        # builder to execute
@@ -86,7 +86,7 @@ To use this action, the argument '--danger' must be set.
     except Exception:  # noqa: BLE001
         sys.stdout.flush()
         logger.error(traceback.format_exc())
-        if os.path.isfile(os.path.join(work_dir, 'conf.py')):
+        if Path(work_dir / 'conf.py').is_file():
             logger.error('unable to load configuration')
         else:
             logger.error('no documentation/missing configuration')

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.config.notifications import deprecated
 from sphinxcontrib.confluencebuilder.config.notifications import warnings
 from sphinxcontrib.confluencebuilder.config.validation import ConfigurationValidation
@@ -170,7 +171,7 @@ certificate/key-pair, or a 2-tuple of the certificate and key.
 ''')
 
         for cert in cert_files:
-            if cert and not os.path.isfile(os.path.join(env.srcdir, cert)):
+            if cert and not Path(env.srcdir, cert).is_file():
                 raise ConfluenceConfigurationError('''\
 confluence_client_cert missing certificate file
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.util import str2bool
-import os
 
 
 # configures the default editor to publication
@@ -43,13 +43,13 @@ def apply_defaults(builder):
     if conf.confluence_adv_restricted is None:
         conf.confluence_adv_restricted = []
 
-    if conf.confluence_ca_cert and not os.path.isabs(conf.confluence_ca_cert):
-        # if the ca path is not an absolute path, the path is a relative
-        # path based on the source directory (i.e. passed configuration
-        # checks); resolve the file here before it eventually gets provided
-        # to Requests
-        conf.confluence_ca_cert = os.path.join(
-            env.srcdir, conf.confluence_ca_cert)
+    if conf.confluence_ca_cert:
+        if not Path(conf.confluence_ca_cert).is_absolute():
+            # if the ca path is not an absolute path, the path is a relative
+            # path based on the source directory (i.e. passed configuration
+            # checks); resolve the file here before it eventually gets provided
+            # to Requests
+            conf.confluence_ca_cert = Path(env.srcdir, conf.confluence_ca_cert)
 
     if conf.confluence_cleanup_search_mode is None:
         # the default is `search`, since on Confluence Server/DC; the `direct`

--- a/sphinxcontrib/confluencebuilder/env.py
+++ b/sphinxcontrib/confluencebuilder/env.py
@@ -135,7 +135,7 @@ class ConfluenceCacheInfo:
             return doc_hash
 
         # determine the hash of the document based on data + config-hash
-        src_file = self.env.doc2path(docname)
+        src_file = Path(self.env.doc2path(docname))
         src_file_hash = ConfluenceUtil.hash_asset(src_file)
         doc_hash_data = self._active_hash + src_file_hash
         doc_hash = ConfluenceUtil.hash(doc_hash_data)

--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -3,6 +3,7 @@
 
 from collections import deque
 from contextlib import suppress
+from pathlib import Path
 from sphinx.util import logging
 from sphinx.util.console import bold  # pylint: disable=no-name-in-module
 import sys
@@ -118,7 +119,8 @@ class ConfluenceLogger:
         This is solely for manually debugging unexpected scenarios.
         """
         try:
-            with open('trace.log', 'a', encoding='utf-8') as file:
+            trace_file = Path('trace.log')
+            with trace_file.open('a', encoding='utf-8') as file:
                 file.write('[%s]\n' % container)
                 file.write(data)
                 file.write('\n')

--- a/sphinxcontrib/confluencebuilder/storage/index.py
+++ b/sphinxcontrib/confluencebuilder/storage/index.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinx.environment.adapters.indexentries import IndexEntries
 from sphinxcontrib.confluencebuilder.locale import L as sccb_translation
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
 from sphinxcontrib.confluencebuilder.storage import intern_uri_anchor_value
-import os
 import pkgutil
 import posixpath
 
@@ -48,8 +48,8 @@ def generate_storage_format_domainindex(builder, docname, f):
     else:
         domainindex_fname = 'domainindex.html'
 
-    domainindex_template = os.path.join('templates', domainindex_fname)
-    template_data = pkgutil.get_data(__name__, domainindex_template)
+    domainindex_template = Path('templates', domainindex_fname)
+    template_data = pkgutil.get_data(__name__, str(domainindex_template))
 
     # process the template with the generated index
     ctx = {
@@ -96,8 +96,8 @@ def generate_storage_format_genindex(builder, docname, f):
     else:
         genindex_fname = 'genindex.html'
 
-    genindex_template = os.path.join('templates', genindex_fname)
-    template_data = pkgutil.get_data(__name__, genindex_template)
+    genindex_template = Path('templates', genindex_fname)
+    template_data = pkgutil.get_data(__name__, str(genindex_template))
 
     # process the template with the generated index
     ctx = {
@@ -125,7 +125,9 @@ def process_doclink(config, refuri):
         the document's title and anchor value
     """
 
-    docname = posixpath.normpath(os.path.splitext(refuri.split('#')[0])[0])
+    doc_path = Path(refuri.split('#')[0])
+    doc_raw_id = doc_path.parent / doc_path.stem
+    docname = posixpath.normpath(doc_raw_id.as_posix())
     doctitle = ConfluenceState.title(docname)
     anchor_value = intern_uri_anchor_value(docname, refuri)
 

--- a/sphinxcontrib/confluencebuilder/storage/search.py
+++ b/sphinxcontrib/confluencebuilder/storage/search.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from pathlib import Path
 from sphinxcontrib.confluencebuilder.locale import L as sccb_translation
-import os
 import pkgutil
 
 
@@ -23,8 +23,8 @@ def generate_storage_format_search(builder, docname, f):
     space_name = builder.config.confluence_space_name
 
     # fetch raw template data
-    search_template = os.path.join('templates', 'search.html')
-    template_data = pkgutil.get_data(__name__, search_template)
+    search_template = Path('templates', 'search.html')
+    template_data = pkgutil.get_data(__name__, str(search_template))
 
     # process the template with the generated index
     ctx = {

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -4,7 +4,7 @@
 
 from contextlib import suppress
 from docutils import nodes
-from os import path
+from pathlib import Path
 from sphinx import addnodes
 from sphinx.locale import _ as SL
 from sphinx.locale import admonitionlabels
@@ -1340,8 +1340,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 self._reference_context.append(self._end_ac_link_body(node))
 
     def _visit_reference_intern_uri(self, node):
-        docname = posixpath.normpath(
-            self.docparent + path.splitext(node['refuri'].split('#')[0])[0])
+        doc_path = Path(node['refuri'].split('#')[0])
+        doc_raw_id = Path(self.docparent) / doc_path.parent / doc_path.stem
+        docname = posixpath.normpath(doc_raw_id.as_posix())
         doctitle = self.state.title(docname)
         if not doctitle:
             self.warn('unable to build link to document due to '
@@ -2517,8 +2518,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             self.body.append(self._start_ac_macro(node, 'panel'))
             self.body.append(self._start_ac_rich_text_body_macro(node))
 
-        docname = posixpath.normpath(self.docparent +
-            path.splitext(PARAMS(node)['href'].split('#')[0])[0])
+        doc_path = Path(PARAMS(node)['href'].split('#')[0])
+        doc_raw_id = Path(self.docparent) / doc_path.parent / doc_path.stem
+        docname = posixpath.normpath(doc_raw_id.as_posix())
         doctitle = self.state.title(docname)
         if doctitle:
             attribs = {}
@@ -2550,8 +2552,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         raise nodes.SkipNode
 
     def visit_confluence_doc_card_inline(self, node):
-        docname = posixpath.normpath(self.docparent +
-            path.splitext(node['reftarget'].split('#')[0])[0])
+        doc_path = Path(node['reftarget'].split('#')[0])
+        doc_raw_id = Path(self.docparent) / doc_path.parent / doc_path.stem
+        docname = posixpath.normpath(doc_raw_id.as_posix())
         doctitle = self.state.title(docname)
         if doctitle:
             doctitle = self.encode(doctitle)

--- a/sphinxcontrib/confluencebuilder/svg.py
+++ b/sphinxcontrib/confluencebuilder/svg.py
@@ -65,7 +65,7 @@ def confluence_supported_svg(builder, node):
         return
 
     # ignore non-svgs
-    mimetype = guess_mimetype(abs_path)
+    mimetype = guess_mimetype(str(abs_path))  # cast for sphinx-6.1
     if mimetype != 'image/svg+xml':
         return
 

--- a/sphinxcontrib/confluencebuilder/svg.py
+++ b/sphinxcontrib/confluencebuilder/svg.py
@@ -60,17 +60,17 @@ def confluence_supported_svg(builder, node):
         return
 
     # invalid uri/path
-    uri_abspath = find_env_abspath(builder.env, builder.outdir, uri)
-    if not uri_abspath:
+    abs_path = find_env_abspath(builder.env, builder.out_dir, uri)
+    if not abs_path:
         return
 
     # ignore non-svgs
-    mimetype = guess_mimetype(uri_abspath)
+    mimetype = guess_mimetype(abs_path)
     if mimetype != 'image/svg+xml':
         return
 
     try:
-        with open(uri_abspath, 'rb') as f:
+        with abs_path.open('rb') as f:
             svg_data = f.read()
     except (IOError, OSError) as err:
         builder.warn('error reading svg: %s' % err)

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -89,10 +89,10 @@ class ConfluenceBaseTranslator(BaseTranslator):
         # prepend header (if any)
         if self.builder.config.confluence_header_file is not None:
             header_template_data = ''
-            header_file = path.join(self.builder.env.srcdir,
+            header_file = Path(self.builder.env.srcdir,
                 self.builder.config.confluence_header_file)
             try:
-                with open(header_file, encoding='utf-8') as file:
+                with header_file.open(encoding='utf-8') as file:
                     header_template_data = file.read()
             except (IOError, OSError) as err:
                 self.warn(f'error reading file {header_file}: {err}')
@@ -114,10 +114,10 @@ class ConfluenceBaseTranslator(BaseTranslator):
         # append footer (if any)
         if self.builder.config.confluence_footer_file is not None:
             footer_template_data = ''
-            footer_file = path.join(self.builder.env.srcdir,
+            footer_file = Path(self.builder.env.srcdir,
                 self.builder.config.confluence_footer_file)
             try:
-                with open(footer_file, encoding='utf-8') as file:
+                with footer_file.open(encoding='utf-8') as file:
                     footer_template_data = file.read()
             except (IOError, OSError) as err:
                 self.warn(f'error reading file {footer_file}: {err}')

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -3,7 +3,7 @@
 
 from docutils import nodes
 from docutils.nodes import NodeVisitor as BaseTranslator
-from os import path
+from pathlib import Path
 from sphinx.util.images import get_image_size
 from sphinx.util.images import guess_mimetype
 from sphinx.util.osutil import SEP
@@ -49,9 +49,10 @@ class ConfluenceBaseTranslator(BaseTranslator):
         # for relative document uris
         # (see '_visit_reference_intern_uri')
         if SEP in self.docname:
-            self.docparent = self.docname[0 : self.docname.rfind(SEP) + 1]
+            docparent = self.docname[0 : self.docname.rfind(SEP) + 1]
         else:
-            self.docparent = ''
+            docparent = ''
+        self.docparent = Path(docparent)
 
         self.assets = builder.assets
         self.body = []

--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
@@ -2,7 +2,7 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from docutils import nodes
-from os import path
+from pathlib import Path
 from sphinx import addnodes
 from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.nodes import confluence_expand
@@ -68,11 +68,11 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
             # directory; which the processing of a download_reference will
             # strip and use the asset directory has the container folder to find
             # the file in
-            mock_docname = path.join(builder.config.assets_dir, 'mock')
+            mock_docname = Path(builder.config.assets_dir, 'mock')
             new_node = addnodes.download_reference(
                 node.astext(),
                 node.astext(),
-                refdoc=mock_docname,
+                refdoc=str(mock_docname),
                 refexplicit=True,
                 reftarget=node['refuri'],
             )

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -399,6 +399,6 @@ def temp_dir():
     """
     dir_ = tempfile.mkdtemp()
     try:
-        yield dir_
+        yield Path(dir_)
     finally:
         shutil.rmtree(dir_, ignore_errors=True)

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -185,8 +185,9 @@ def extract_strings_from_file(filename):
     """
     filelist = []
 
-    if os.path.isfile(filename):
-        with open(filename) as f:
+    file = Path(filename) if isinstance(filename, str) else filename
+    if file.is_file():
+        with file.open() as f:
             for raw_line in f:
                 line = raw_line.strip()
                 if not line or line.startswith('#'):

--- a/tests/unit-tests/test_cache.py
+++ b/tests/unit-tests/test_cache.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
-from pathlib import Path
 from sphinxcontrib.confluencebuilder.util import temp_dir
 from tests.lib import prepare_dirs
 from tests.lib.testcase import ConfluenceTestCase
@@ -98,7 +97,6 @@ class TestCache(ConfluenceTestCase):
                 pass
 
         with temp_dir() as src_dir:
-            src_dir = Path(src_dir)
             index_file = src_dir / 'index.rst'
             write_doc(index_file, '''\
 index

--- a/tests/unit-tests/test_legacy_pages.py
+++ b/tests/unit-tests/test_legacy_pages.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
-from pathlib import Path
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.util import temp_dir
 from tests.lib import prepare_dirs
@@ -39,7 +38,6 @@ class TestConfluenceLegacyPages(ConfluenceTestCase):
         out_dir = prepare_dirs()
 
         with temp_dir() as src_dir:
-            src_dir = Path(src_dir)
             conf_file = src_dir / 'conf.py'
             write_doc(conf_file, '')
 

--- a/tests/unit-tests/test_translator.py
+++ b/tests/unit-tests/test_translator.py
@@ -33,4 +33,4 @@ class TestConfluenceBaseTranslator(unittest.TestCase):
             translator = ConfluenceBaseTranslator(doc, app.builder)
 
         self.assertEqual(translator.docname, 'foo/bar/baz')
-        self.assertEqual(translator.docparent, 'foo/bar/')
+        self.assertEqual(translator.docparent.as_posix(), 'foo/bar')


### PR DESCRIPTION
This is a continuation of effort done by #886. This completes the desired effort at utilizing the pathlib module for various path-related capabilities. This also has the bonus of removing all path-related warnings generated when using ruff (ideally, later to be used by default over other linters).

- adjust mainline args to use pathlib
- logger: manage tracefile using pathlib
- util: update context-supported temp_dir to use pathlib
- translator: adjust doc-path processing (internal links) to use pathlib
- transmute: adjust sphinx-toolbox docname mocking to use pathlib
- adjust search/index page processing to use pathlib
- adjust asset processing to use pathlib
- adjust configuration processing to use pathlib