### PR TITLE
tests: boost validating testing timeout

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -50,7 +50,7 @@ class TestConfluenceValidation(unittest.TestCase):
             'container': 'tests/validation-sets/',
         }
         cls.config['confluence_space_key'] = space_key
-        cls.config['confluence_timeout'] = 10
+        cls.config['confluence_timeout'] = 30
         cls.config['imgmath_font_size'] = 14
         cls.config['imgmath_image_format'] = 'svg'
         cls.config['imgmath_use_preview'] = True


### PR DESCRIPTION
This commit increases the connection timeout for validation testing from ten seconds to thirty seconds. It has been observed when testing the Confluence Cloud may take a bit longer to process large requests (e.g. may be busy to delaying interaction), and could trigger a timeout. Using the increased time seems to resolve any issues when testing.