### PR TITLE
tox: introduce a mypy environment

### DIFF
--- a/requirements_types.txt
+++ b/requirements_types.txt
@@ -1,0 +1,2 @@
+types-docutils
+types-requests

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,16 @@ commands =
     sphinxcontrib \
     tests
 
+[testenv:mypy]
+deps =
+    {[testenv]deps}
+    -r{toxinidir}/requirements_types.txt
+    mypy
+commands =
+    mypy \
+    --explicit-package-bases \
+    sphinxcontrib
+
 [testenv:{,py38-,py39-,py310-,py311-,py312-}sandbox]
 deps =
     -r{toxinidir}/sandbox/requirements.txt


### PR DESCRIPTION
Provides support to run the Mypy static type checker through tox.

Not in a passing state at this time, so the environment will not be enabled by default just yet.