### PR TITLE
drop legacy IOError handling

### DIFF
--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -124,5 +124,5 @@ class ConfluenceLogger:
                 file.write('[%s]\n' % container)
                 file.write(data)
                 file.write('\n')
-        except (IOError, OSError) as err:
+        except OSError as err:
             ConfluenceLogger.warn('unable to trace: %s' % err)

--- a/sphinxcontrib/confluencebuilder/svg.py
+++ b/sphinxcontrib/confluencebuilder/svg.py
@@ -72,7 +72,7 @@ def confluence_supported_svg(builder, node):
     try:
         with abs_path.open('rb') as f:
             svg_data = f.read()
-    except (IOError, OSError) as err:
+    except OSError as err:
         builder.warn('error reading svg: %s' % err)
         return
 
@@ -203,7 +203,7 @@ def confluence_supported_svg(builder, node):
         try:
             with out_file.open('wb') as f:
                 f.write(svg_data)
-        except (IOError, OSError) as err:
+        except OSError as err:
             builder.warn('error writing svg: %s' % err)
             return
 

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -94,7 +94,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
             try:
                 with header_file.open(encoding='utf-8') as file:
                     header_template_data = file.read()
-            except (IOError, OSError) as err:
+            except OSError as err:
                 self.warn(f'error reading file {header_file}: {err}')
 
             # if no data is supplied, the file is plain text
@@ -119,7 +119,7 @@ class ConfluenceBaseTranslator(BaseTranslator):
             try:
                 with footer_file.open(encoding='utf-8') as file:
                     footer_template_data = file.read()
-            except (IOError, OSError) as err:
+            except OSError as err:
                 self.warn(f'error reading file {footer_file}: {err}')
 
             # if no data is supplied, the file is plain text


### PR DESCRIPTION
Remove all legacy cases of handling IOError, since this is no longer required on the Python versions this extension supports.