### PR TITLE
tests: provide a unique output path to support parallel tox runs

### DIFF
--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -516,6 +516,13 @@ def prepare_dirs(container=None, postfix=None):
     test_dir = lib_dir.parent
     base_dir = test_dir.parent
     output_dir = base_dir / 'output'
+
+    # attempt to nest under a tox environment folder, to help prevent
+    # issues running in parallel mode
+    suboutput_dir = os.getenv('TOX_ENV_NAME')
+    if suboutput_dir:
+        output_dir = output_dir / suboutput_dir
+
     container_dir = output_dir / container
     if postfix:
         container_dir = container_dir.parent / (container_dir.name + postfix)


### PR DESCRIPTION
When populating an output directory for a unit test, build the path taking into consideration the active tox environment name (if any). If one is set, use the environment name as a sub-folder to place between the output folder and a container/test-method name. This should prevent any issues between various unit tests running, where each environment is separated.