### PR TITLE
config: capture non-str value error for enum check

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/validation.py
+++ b/sphinxcontrib/confluencebuilder/config/validation.py
@@ -219,7 +219,7 @@ class ConfigurationValidation:
         if value is not None and not isinstance(value, etype):
             try:
                 value = etype[value.lower()]
-            except KeyError:
+            except (AttributeError, KeyError):
                 raise ConfluenceConfigError(
                     f'{self.key} is not an enumeration ({etype.__name__})')
 


### PR DESCRIPTION
The enumeration check for a string type can help ensure a provided string matches to a specific enumeration type. However, if a user defines a non-string value, the configuration check will fail with an attribute error. To prevent this exception cause so we can manage our own configuration error, also include `AttributeError` to the exception list to capture.