### PR TITLE
utilize f-strings

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -134,8 +134,7 @@ class ConfluenceBuilder(Builder):
         old_url = self.config.confluence_server_url
         new_url = ConfluenceUtil.normalize_base_url(old_url)
         if old_url != new_url:
-            self.warn('normalizing confluence url from '
-                '{} to {} '.format(old_url, new_url))
+            self.warn(f'normalizing confluence url from {old_url} to {new_url}')
             self.config.confluence_server_url = new_url
 
         # detect if Confluence Cloud if using the Atlassian domain
@@ -611,7 +610,7 @@ class ConfluenceBuilder(Builder):
                 self.state.register_upload_id(docname, page_id)
             else:
                 self.warn('cannot publish asset since publishing '
-                    'point cannot be found ({}): {}'.format(key, docname))
+                    f'point cannot be found ({key}): {docname}')
                 return
 
         attachment_id = None
@@ -1166,9 +1165,9 @@ class ConfluenceBuilder(Builder):
                 doctitle = f'autogen-{docname}'
                 if self.publish:
                     self.warn('document will be published using an '
-                        'generated title value: {}'.format(docname))
+                        f'generated title value: {docname}')
             elif self.publish:
                 self.warn('document will not be published since it '
-                    'has no title: {}'.format(docname))
+                    f'has no title: {docname}')
 
         return doctitle

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -182,9 +182,9 @@ def report_main(args_parser):
                     for o in root.findall('buildNumber'):
                         info += '     build: ' + o.text + '\n'
                 else:
-                    logger.error('bad response from server ({})'.format(
-                        rsp.status_code))
-                    info += f'   fetched: error ({rsp.status_code})\n'
+                    code = rsp.status_code
+                    logger.error(f'bad response from server ({code})')
+                    info += f'   fetched: error ({code})\n'
                     rv = 1
             except Exception:  # noqa: BLE001
                 sys.stdout.flush()

--- a/sphinxcontrib/confluencebuilder/intersphinx.py
+++ b/sphinxcontrib/confluencebuilder/intersphinx.py
@@ -34,13 +34,14 @@ def build_intersphinx(builder):
     inventory_db = builder.out_dir / INVENTORY_FILENAME
     with inventory_db.open('wb') as f:
         # header
-        f.write((
-            '# Sphinx inventory version 2\n'
-            '# Project: {}\n'
-            '# Version: {}\n'
-            '# The remainder of this file is compressed using zlib.\n'.format(
-                escape(builder.env.config.project),
-                escape(builder.env.config.version))).encode())
+        f.write(
+            (
+                '# Sphinx inventory version 2\n'
+                f'# Project: {escape(builder.env.config.project)}\n'
+                f'# Version: {escape(builder.env.config.version)}\n'
+                '# The remainder of this file is compressed using zlib.\n'
+            ).encode()
+        )
 
         # contents
         compressor = zlib.compressobj(9)
@@ -74,8 +75,7 @@ def build_intersphinx(builder):
                     uri += '#' + anchor
                 if dispname == name:
                     dispname = '-'
-                entry = ('%s %s:%s %s %s %s\n' %
-                         (name, domainname, typ, prio, uri, dispname))
+                entry = f'{name} {domainname}:{typ} {prio} {uri} {dispname}\n'
                 logger.verbose('(intersphinx) ' + entry.strip())
                 f.write(compressor.compress(entry.encode('utf-8')))
 

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -86,7 +86,7 @@ def rate_limited_retries():
             if self.config.confluence_publish_delay:
                 delay = self.config.confluence_publish_delay
                 logger.verbose('user-set api delay set; '
-                               'waiting {} seconds...'.format(math.ceil(delay)))
+                               f'waiting {math.ceil(delay)} seconds...')
                 time.sleep(delay)
 
             # if confluence asked us to wait so many seconds before a next
@@ -94,7 +94,7 @@ def rate_limited_retries():
             if self.next_delay:
                 delay = self.next_delay
                 logger.verbose('rate-limit header detected; '
-                               'waiting {} seconds...'.format(math.ceil(delay)))
+                               f'waiting {math.ceil(delay)} seconds...')
                 time.sleep(delay)
                 self.next_delay = None
 
@@ -128,7 +128,7 @@ def rate_limited_retries():
 
                     # wait the calculated delay before retrying again
                     logger.warn('rate-limit response detected; '
-                                'waiting {} seconds...'.format(math.ceil(delay)))
+                                f'waiting {math.ceil(delay)} seconds...')
                     time.sleep(delay)
                     self.last_retry = delay
                     attempt += 1
@@ -373,8 +373,8 @@ class Rest:
                 # user once
                 if delay >= 60 and not self._reported_large_delay:
                     logger.warn('(warning) site has reported a long '
-                                'rate-limit delay ({} seconds)'.format(
-                                math.ceil(delay)))
+                                'rate-limit delay '
+                                f'({math.ceil(delay)} seconds)')
                     self._reported_large_delay = True
 
         # check if Confluence reports a `Deprecation` header in the response;

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -59,8 +59,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
 
     def get_target_uri(self, docname, typ=None):
         if docname in self.env.all_docs:
-            return '{}{}#{}'.format(
-                self.config.root_doc, self.link_suffix, docname)
+            return f'{self.config.root_doc}{self.link_suffix}#{docname}'
         else:
             return self.link_transform(docname)
 

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -105,9 +105,9 @@ class ConfluenceState:
         offset = 2
         while title.lower() in ConfluenceState.title2doc:
             if offset == 2:
+                docname2 = ConfluenceState.title2doc[title.lower()]
                 logger.warn('title conflict detected with '
-                    "'{}' and '{}'".format(
-                        ConfluenceState.title2doc[title.lower()], docname))
+                    f"'{docname2}' and '{docname}'")
 
             tail = f' ({offset}){base_tail}'
             if len(base_title) + len(tail) > try_max:
@@ -227,8 +227,8 @@ class ConfluenceState:
                 )
             except KeyError:
                 raise ConfluenceConfigError(
-                    "Configured confluence_publish_prefix '{postfix}' has an "
-                    "unknown template replacement.".format(postfix=postfix))
+                    f"Configured confluence_publish_prefix '{postfix}' has an "
+                    "unknown template replacement.")
         return postfix
 
     @staticmethod

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -147,9 +147,8 @@ def prepare_math_images(builder, doctree):
                 if 'ids' in new_node:
                     math_image_ids.extend(new_node['ids'])
 
-        except imgmath.MathExtError as exc:
-            ConfluenceLogger.warn('inline latex {}: {}'.format(
-                node.astext(), exc))
+        except imgmath.MathExtError as ex:
+            ConfluenceLogger.warn(f'inline latex {node.astext()}: {ex}')
 
     # v2 editor will manually inject anchors in an image-managed
     # section to avoid a newline spacing between the anchor and
@@ -215,8 +214,9 @@ def replace_graphviz_nodes(builder, doctree):
     mock_translator = MockTranslator(builder)
 
     for node in findall(doctree, graphviz):
+        node_code = node['code']
         try:
-            _, out_filename = render_dot(mock_translator, node['code'],
+            _, out_filename = render_dot(mock_translator, node_code,
                 node['options'], builder.graphviz_output_format, 'graphviz')
             if not out_filename:
                 node.parent.remove(node)
@@ -226,8 +226,8 @@ def replace_graphviz_nodes(builder, doctree):
             if 'align' in node:
                 new_node['align'] = node['align']
             node.replace_self(new_node)
-        except GraphvizError as exc:
-            ConfluenceLogger.warn('dot code {}: {}'.format(node['code'], exc))
+        except GraphvizError as ex:
+            ConfluenceLogger.warn(f'dot code {node_code}: {ex}')
             node.parent.remove(node)
 
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -71,14 +71,14 @@ def main():
             target_unit_test_name_pattern)
         if not target_unit_tests:
             print('\nERROR: unable to find test with pattern: '
-                '{}\n'.format(target_unit_test_name_pattern))
+                f'{target_unit_test_name_pattern}\n')
             if issued:
                 issued[0].debug()
             sys.exit(1)
 
+        total_tests = len(target_unit_tests)
         print('')
-        print('running specific test(s) (total: {})'.format(
-            len(target_unit_tests)))
+        print(f'running specific test(s) (total: {total_tests})')
         for target_unit_test in target_unit_tests:
             print(f' {target_unit_test.id()}')
         print('')

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -74,16 +74,16 @@ class ConfluenceInstanceServer(server_socket.ThreadingMixIn,
 
         with self.mtx:
             if self.del_req or self.get_req or self.put_req:
-                raise Exception('''unhandled requests detected
+                raise Exception(f'''unhandled requests detected
 
 (get requests)
-{}
+{self.get_req}
 
 (put requests)
-{}
+{self.put_req}
 
 (del requests)
-{}'''.format(self.get_req, self.put_req, self.del_req))
+{self.del_req}''')
 
     def pop_delete_request(self):
         """

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -88,10 +88,10 @@ class TestConfluenceValidation(unittest.TestCase):
         cls.config['confluence_publish_postfix'] = ''
         cls.config['confluence_cleanup_archive'] = False
         cls.config['confluence_sourcelink']['version'] = cls.test_version
-        cls.config['rst_epilog'] = """
-.. |test_key| replace:: {}
-.. |test_desc| replace:: {}
-""".format(cls.test_key, cls.test_desc)
+        cls.config['rst_epilog'] = f'''
+.. |test_key| replace:: {cls.test_key}
+.. |test_desc| replace:: {cls.test_desc}
+'''
 
         # find validate-sets base folder
         test_dir = Path(__file__).parent.resolve()

--- a/tests/unit-tests/test_config_postfix_formatting.py
+++ b/tests/unit-tests/test_config_postfix_formatting.py
@@ -88,8 +88,7 @@ class TestFormatPostfix(ConfluenceTestCase):
         postfix = ConfluenceState._format_postfix(
             postfix=confluence_publish_prefix, docname=test_docname,
             config=config)
-        self.assertEqual(postfix, '- ({hash})'.format(
-            hash=self.test_hash[0:10]))
+        self.assertEqual(postfix, f'- ({self.test_hash[0:10]})')
 
 
 class TestRegisterTitle(ConfluenceTestCase):

--- a/tests/unit-tests/test_sphinx_image_candidate.py
+++ b/tests/unit-tests/test_sphinx_image_candidate.py
@@ -26,8 +26,7 @@ class TestConfluenceSphinxImageCandidate(ConfluenceTestCase):
 
             self.assertIsNotNone(ext)
 
-            pyver = 'py{}{}'.format(sys.version_info.major,
-                sys.version_info.minor)
+            pyver = f'py{sys.version_info.major}{sys.version_info.minor}'
             doc_dir = prepare_dirs(postfix=f'-{pyver}-docs-{ext[1:]}')
             out_dir = prepare_dirs(postfix=f'-{pyver}-out-{ext[1:]}')
 


### PR DESCRIPTION
Updating various implementation to take advantage of f-strings over the use of printf (UP031) and format (UP032). This includes also tweaks to original format calls to use variables for some complex values, as well as even dropping format calls for simple string concatenation.