### PR TITLE
config: handle empty-str publish-debug

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -91,16 +91,16 @@ def apply_defaults(builder):
 
     # ensure confluence_publish_debug is set with its expected enum value
     publish_debug = conf.confluence_publish_debug
-    if publish_debug is not None and publish_debug is not False:
+    if not isinstance(publish_debug, PublishDebug):
         # a boolean-provided publish debug is deprecated, but we will accept
         # it as its original implementation as an indication to enable
         # urllib3 logs
         if publish_debug is True:
             conf.confluence_publish_debug = PublishDebug.urllib3
-        elif not isinstance(publish_debug, PublishDebug):
+        elif isinstance(publish_debug, str) and publish_debug:
             conf.confluence_publish_debug = PublishDebug[publish_debug.lower()]
-    else:
-        conf.confluence_publish_debug = PublishDebug.none
+        else:
+            conf.confluence_publish_debug = PublishDebug.none
 
     if conf.confluence_publish_intersphinx is None:
         conf.confluence_publish_intersphinx = True

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -630,6 +630,25 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         with self.assertRaises(ConfluenceConfigError):
             self._try_config()
 
+    def test_config_check_publish_debug(self):
+        self.config['confluence_publish_debug'] = ''
+        self._try_config()
+
+        self.config['confluence_publish_debug'] = 'urllib3'
+        self._try_config()
+
+        self.config['confluence_publish_debug'] = 'unknown-entry'
+        with self.assertRaises(ConfluenceConfigError):
+            self._try_config()
+
+        self.config['confluence_publish_debug'] = [1, 2, 3]
+        with self.assertRaises(ConfluenceConfigError):
+            self._try_config()
+
+        self.config['confluence_publish_debug'] = True
+        with self.assertRaises(SphinxWarning):
+            self._try_config()
+
     def test_config_check_publish_delay(self):
         self.config['confluence_publish_delay'] = 0.3
         self._try_config()


### PR DESCRIPTION
When a user sets `confluence_publish_debug` to an empty string, such a configuration state should indicate to not perform any publish debugging. However, with the value set, the configuration handling will result in an unexpected exception. Adjusting the implementation to properly handle this case.