### PR TITLE
tests: add unit test to validate report builder initialization

### DIFF
--- a/tests/unit-tests/test_report_builder.py
+++ b/tests/unit-tests/test_report_builder.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+
+
+class TestReportBuilder(ConfluenceTestCase):
+    @setup_builder(ConfluenceReportBuilder.name)
+    def test_report_builder(self):
+        # sanity check that this builder can be prepared
+        with self.prepare(self.datasets / 'minimal') as app:
+            self.assertIsInstance(app.builder, ConfluenceReportBuilder)


### PR DESCRIPTION
Defines a simple unit test that requests the creation of a report builder. This is to help ensure that this mocked builder has no issues in loading with the active Sphinx version.