### PR TITLE
publisher: adding more helpful unknown confluence instance exception

### DIFF
--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -267,6 +267,32 @@ the exception message above this message.
 ''')
 
 
+class ConfluenceUnknownInstanceError(ConfluenceError):
+    def __init__(self, server_url, space_key, uname, pw_set, token_set):
+        uname_value = uname if uname else '(empty)'
+        pw_value = '<set>' if pw_set else '(empty)'
+        token_value = '<set>' if token_set else '(empty)'
+        super().__init__(f'''
+---
+Unknown Confluence URL or invalid/restricted space detected
+
+An issue has been detected when trying to communicate with the
+configured Confluence instance. Ensure the instance is running and
+inspect that the configured Confluence URL is valid:
+
+    {server_url}
+
+If the instance is valid, ensure the configured space key and approriate
+authentication permissions are configured.
+
+                   Space key: {space_key}
+                    Username: {uname_value}
+       Password or API Token: {pw_value}
+ Personal Access Token (PAT): {token_value}
+---
+''')
+
+
 class ConfluenceUnreconciledPageError(ConfluenceError):
     def __init__(self, page_name, page_id, url, details):
         super().__init__(f'''

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -17,6 +17,7 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluencePermissionError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluencePublishAncestorError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluencePublishSelfAncestorError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceUnexpectedCdataError
+from sphinxcontrib.confluencebuilder.exceptions import ConfluenceUnknownInstanceError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceUnreconciledPageError
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.rest import Rest
@@ -69,6 +70,18 @@ class ConfluencePublisher:
         try:
             rsp = self.rest_client.get(f'space/{self.space_key}')
         except ConfluenceBadApiError as ex:
+            if ex.status_code == 404:
+                pw_set = bool(self.config.confluence_server_pass)
+                token_set = bool(self.config.confluence_publish_token)
+
+                raise ConfluenceUnknownInstanceError(
+                    server_url,
+                    self.space_key,
+                    self.config.confluence_server_user,
+                    pw_set,
+                    token_set,
+                ) from ex
+
             raise ConfluenceBadServerUrlError(server_url, ex) from ex
 
         # sanity check that we have a sane response


### PR DESCRIPTION
Provide a more helpful message on an initial 404 error message. If the first request fails with a 404, aside from a bad URL, this could also mean a bad/restricted space. Try to convey to the user that this extension is not aware which specific reason the request failed, but give more options to say to check a combination of the server URL, the space ID and authentication options.