### PR TITLE
Support REST v2 API Calls

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -489,6 +489,26 @@ Generic configuration
 Publishing configuration
 ------------------------
 
+.. |confluence_api_mode| replace:: ``confluence_api_mode``
+.. _confluence_api_mode:
+
+.. confval:: confluence_api_mode
+
+    Configures the API mode to use for REST requests. Certain Confluence
+    instances support a newer version of REST APIs (e.g. Confluence Cloud).
+    This extension will attempt to use an appropriate API mode for a
+    configuration set. However, a user can override the operating API mode
+    based on preference or when handling situations where this extension
+    cannot automatically determine the best API mode to use. Values
+    accepted are either ``v1`` or ``v2``.
+
+    .. code-block:: python
+
+        confluence_api_mode = 'v2'
+
+    By default, if a Confluence Cloud configuration is detected, this
+    extension will use ``v2``. For all other cases, the default is ``v1``.
+
 .. |confluence_ask_password| replace:: ``confluence_ask_password``
 .. _confluence_ask_password:
 
@@ -1478,17 +1498,6 @@ Advanced publishing configuration
 
     See also |confluence_publish_allowlist|_.
 
-.. confval:: confluence_publish_disable_api_prefix
-
-    A boolean value which explicitly disables the use of the ``rest/api`` in
-    the Confluence publish URL. This can be useful for environments where the
-    API endpoint for a Confluence instance is proxied through a non-standard
-    location. By default, API prefixes are enabled with a value of ``False``.
-
-    .. code-block:: python
-
-        confluence_publish_disable_api_prefix = True
-
 .. |confluence_publish_dryrun| replace:: ``confluence_publish_dryrun``
 .. _confluence_publish_dryrun:
 
@@ -1621,6 +1630,40 @@ Advanced publishing configuration
         confluence_publish_orphan_container = 123456
 
     See also |confluence_publish_orphan|_.
+
+.. |confluence_publish_override_api_prefix| replace:: ``confluence_publish_override_api_prefix``
+.. _confluence_publish_override_api_prefix:
+
+.. confval:: confluence_publish_override_api_prefix
+
+    .. versionadded:: 2.5
+
+    Allows a user to override the path-prefix value used for API requests.
+    API paths are commonly prefixed, such as ``rest/api/`` for API v1 and
+    ``api/v2/`` for API v2. However, if a user is interacting with a Confluence
+    instance which system administrators have configured non-standard
+    locations for API endpoints, requests made by this extension will fail.
+
+    To support custom API endpoint paths, this option can be used to indicate
+    what prefix to use, if any. By default, this extension operates with an
+    API prefix configuration matching the following:
+
+    .. code-block:: python
+
+        confluence_publish_override_api_prefix = {
+            'v1': 'rest/api/',
+            'v2': 'api/v2/',
+        }
+
+    Users may define a dictionary using |confluence_api_mode|_ values for
+    keys, followed by a prefix override for their environment. For example,
+    to disable prefixes for any API v1 request, the following may be used:
+
+    .. code-block:: python
+
+        confluence_publish_override_api_prefix = {
+            'v1': '',
+        }
 
 .. confval:: confluence_parent_override_transform
 
@@ -2070,6 +2113,12 @@ Deprecated options
         confluence_parent_page_id_check = 123456
 
     See also |confluence_parent_page|_.
+
+.. confval:: confluence_publish_disable_api_prefix
+
+    .. versionchanged:: 2.5
+
+    This option has been replaced by |confluence_publish_override_api_prefix|_.
 
 .. confval:: confluence_publish_subset
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -115,6 +115,8 @@ def setup(app):
     cm.add_conf_bool('singleconfluence_toctree', 'singleconfluence')
 
     # (configuration - publishing)
+    # API mode to use for REST calls.
+    cm.add_conf('confluence_api_mode')
     # Request for publish password to come from interactive session.
     cm.add_conf_bool('confluence_ask_password')
     # Request for publish username to come from interactive session.
@@ -195,12 +197,12 @@ def setup(app):
     cm.add_conf('confluence_publish_denylist')
     # Whether to check for changes on remote before publishing.
     cm.add_conf_bool('confluence_publish_force')
-    # Disable adding `rest/api` to REST requests.
-    cm.add_conf_bool('confluence_publish_disable_api_prefix')
     # Header(s) to use for Confluence REST interaction.
     cm.add_conf('confluence_publish_headers')
     # Whether to publish a generated intersphinx database to the root document
     cm.add_conf_bool('confluence_publish_intersphinx')
+    # Override the path prefixes for various REST API requests.
+    cm.add_conf('confluence_publish_override_api_prefix')
     # Manipulate a requests instance.
     cm.add_conf('confluence_request_session_override')
     # Authentication passthrough for Confluence REST interaction.
@@ -263,6 +265,8 @@ def setup(app):
     cm.add_conf_bool('confluence_adv_permit_raw_html')
     # replaced by confluence_root_homepage
     cm.add_conf('confluence_master_homepage')
+    # replaced by confluence_publish_override_api_prefix
+    cm.add_conf_bool('confluence_publish_disable_api_prefix')
     # replaced by confluence_publish_allowlist
     cm.add_conf('confluence_publish_subset')
     # replaced by confluence_purge_from_root

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -152,7 +152,7 @@ def report_main(args_parser):
 
             publisher.connect()
             info += ' connected: yes\n'
-            session = publisher.rest_client.session
+            session = publisher.rest.session
         except Exception:  # noqa: BLE001
             sys.stdout.flush()
             logger.error(traceback.format_exc())

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -2,6 +2,7 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from pathlib import Path
+from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceApiModeConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceCleanupSearchModeConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceClientCertBadTupleConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceClientCertMissingCertConfigError
@@ -37,6 +38,7 @@ from sphinxcontrib.confluencebuilder.config.notifications import deprecated
 from sphinxcontrib.confluencebuilder.config.notifications import warnings
 from sphinxcontrib.confluencebuilder.config.validation import ConfigurationValidation
 from sphinxcontrib.confluencebuilder.debug import PublishDebug
+from sphinxcontrib.confluencebuilder.std.confluence import API_MODES
 from sphinxcontrib.confluencebuilder.std.confluence import EDITORS
 from sphinxcontrib.confluencebuilder.util import handle_cli_file_subset
 from requests.auth import AuthBase
@@ -109,6 +111,17 @@ def validate_configuration(builder):
     # confluence_adv_writer_no_section_cap
     validator.conf('confluence_adv_writer_no_section_cap') \
              .bool()
+
+    # ##################################################################
+
+    # confluence_api_mode
+    validator.conf('confluence_api_mode') \
+             .string()
+
+    if config.confluence_api_mode:
+        if config.confluence_api_mode not in API_MODES:
+            modes = '\n - '.join(API_MODES)
+            raise ConfluenceApiModeConfigError(modes)
 
     # ##################################################################
 
@@ -536,6 +549,12 @@ def validate_configuration(builder):
     # confluence_publish_orphan_container
     validator.conf('confluence_publish_orphan_container') \
              .int_()
+
+    # ##################################################################
+
+    # confluence_publish_orphan_container
+    validator.conf('confluence_publish_override_api_prefix') \
+             .dict_str_str()
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -108,6 +108,16 @@ def apply_defaults(builder):
     if conf.confluence_publish_orphan is None:
         conf.confluence_publish_orphan = True
 
+    if conf.confluence_publish_override_api_prefix is None:
+        # confluence_publish_disable_api_prefix is deprecated, but we will
+        # use its presence to configure v1 api for old config support
+        if conf.confluence_publish_disable_api_prefix:
+            conf.confluence_publish_override_api_prefix = {
+                'v1': '',
+            }
+        else:
+            conf.confluence_publish_override_api_prefix = {}
+
     if conf.confluence_remove_title is None:
         conf.confluence_remove_title = True
 

--- a/sphinxcontrib/confluencebuilder/config/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/config/exceptions.py
@@ -9,6 +9,17 @@ class ConfluenceConfigError(ConfluenceError, ConfigError):
     pass
 
 
+class ConfluenceApiModeConfigError(ConfluenceConfigError):
+    def __init__(self, modes):
+        super().__init__(f'''\
+invalid api version provided in confluence_api_mode
+
+The following API modes are supported:
+
+ - {modes}
+''')
+
+
 class ConfluenceCleanupSearchModeConfigError(ConfluenceConfigError):
     def __init__(self, msg):
         super().__init__(f'''\

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -22,6 +22,8 @@ DEPRECATED_CONFIGS = {
         'option does nothing',
     'confluence_parent_page_id_check':
         '"confluence_parent_page" now accepts a page id',
+    'confluence_publish_disable_api_prefix':
+        'use "confluence_publish_override_api_prefix" instead',
     'confluence_publish_subset':
         'use "confluence_publish_allowlist" instead',
     'confluence_purge_from_master':

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -44,6 +44,8 @@ class ConfluencePublisher:
     def init(self, config, cloud=None):
         self.cloud = cloud
         self.config = config
+        self.rest = None
+
         self.append_labels = config.confluence_append_labels
         self.dryrun = config.confluence_publish_dryrun
         self.notify = not config.confluence_disable_notifications
@@ -164,7 +166,8 @@ class ConfluencePublisher:
         self.space_type = rsp['type']
 
     def disconnect(self):
-        self.rest.close()
+        if self.rest:
+            self.rest.close()
 
     def archive_page(self, page_id):
         if self.dryrun:

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -461,7 +461,11 @@ class ConfluencePublisher:
         attachment = None
         attachment_id = None
 
-        url = f'{self.APIV1}content/{page_id}/child/attachment'
+        if self.api_mode == 'v2':
+            url = f'{self.APIV2}pages/{page_id}/attachments'
+        else:
+            url = f'{self.APIV1}content/{page_id}/child/attachment'
+
         rsp = self.rest.get(url, {
             'filename': name,
         })
@@ -488,7 +492,11 @@ class ConfluencePublisher:
         """
         attachment_info = {}
 
-        url = f'{self.APIV1}content/{page_id}/child/attachment'
+        if self.api_mode == 'v2':
+            url = f'{self.APIV2}pages/{page_id}/attachments'
+        else:
+            url = f'{self.APIV1}content/{page_id}/child/attachment'
+
         search_fields = {}
 
         # Configure a larger limit value than the default (no provided
@@ -687,10 +695,12 @@ class ConfluencePublisher:
 
         # check if attachment (of same hash) is already published to this page
         comment = None
-        if attachment and 'metadata' in attachment:
-            metadata = attachment['metadata']
-            if 'comment' in metadata:
-                comment = metadata['comment']
+        if attachment:
+            if self.api_mode == 'v2':
+                comment = attachment.get('comment')
+            elif 'metadata' in attachment:
+                metadata = attachment['metadata']
+                comment = metadata.get('comment')
 
         if not force and comment:
             parts = comment.split(HASH_KEY + ':', 1)

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -560,10 +560,13 @@ class ConfluencePublisher:
             the page id and page object
         """
 
-        page = self.rest.get(f'{self.APIV1}content/{page_id}', {
-            'status': 'current',
-            'expand': expand,
-        })
+        if self.api_mode == 'v2':
+            page = self.rest.get(f'{self.APIV2}pages/{page_id}')
+        else:
+            page = self.rest.get(f'{self.APIV1}content/{page_id}', {
+                'status': 'current',
+                'expand': expand,
+            })
 
         if page:
             assert int(page_id) == int(page['id'])
@@ -1161,7 +1164,10 @@ class ConfluencePublisher:
             self._onlynew('space home updates restricted')
             return
 
-        page = self.rest.get(f'{self.APIV1}content/{page_id}', None)
+        if self.api_mode == 'v2':
+            page = self.rest.get(f'{self.APIV2}pages/{page_id}')
+        else:
+            page = self.rest.get(f'{self.APIV1}content/{page_id}', None)
         try:
             self.rest.put('space', self.space_key, {
                 'key': self.space_key,

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1015,9 +1015,8 @@ class ConfluencePublisher:
             )
             raise ConfluencePermissionError(msg) from ex
 
-        if not self.watch:
-            self.rest.delete(f'{self.APIV1}user/watch/content',
-                uploaded_page_id)
+        # perform any required post-page update actions
+        self._post_page_actions(uploaded_page_id)
 
         return uploaded_page_id
 
@@ -1069,8 +1068,8 @@ class ConfluencePublisher:
             )
             raise ConfluencePermissionError(msg) from ex
 
-        if not self.watch:
-            self.rest.delete(f'{self.APIV1}user/watch/content', page_id)
+        # perform any required post-page update actions
+        self._post_page_actions(page_id)
 
         return page_id
 
@@ -1263,6 +1262,20 @@ class ConfluencePublisher:
             }
 
         return page
+
+    def _post_page_actions(self, page_id):
+        """
+        post page actions
+
+        Perform additional actions needed after creating or updating a page.
+
+        Args:
+            page_id: the identifier of the new/updated page
+        """
+
+        # ensure remove any watch flags on the update if watching is disabled
+        if not self.watch:
+            self.rest.delete(f'{self.APIV1}user/watch/content', page_id)
 
     def _update_page(self, page, page_name, data, parent_id=None):
         """

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1181,7 +1181,7 @@ class ConfluencePublisher:
 
         Registers the provided set of ancestors from being used when page
         updates will move the location of a page. This is a pre-check update
-        requests so that a page cannot be flagged as a descendant of itsel
+        requests so that a page cannot be flagged as a descendant of itself
         (where Confluence self-hosted instances may not report an ideal error
         message).
 

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1169,7 +1169,7 @@ class ConfluencePublisher:
         else:
             page = self.rest.get(f'{self.APIV1}content/{page_id}', None)
         try:
-            self.rest.put('space', self.space_key, {
+            self.rest.put(f'{self.APIV1}space', self.space_key, {
                 'key': self.space_key,
                 'name': self.space_display_name,
                 'homepage': page,

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -253,11 +253,17 @@ class ConfluencePublisher:
         assert page_id
         ancestors = set()
 
-        _, page = self.get_page_by_id(page_id, 'ancestors')
+        if self.api_mode == 'v2':
+            rsp = self.rest.get(f'{self.APIV2}pages/{page_id}/ancestors')
 
-        if 'ancestors' in page:
-            for ancestor in page['ancestors']:
-                ancestors.add(ancestor['id'])
+            for result in rsp['results']:
+                ancestors.add(result['id'])
+        else:
+            _, page = self.get_page_by_id(page_id, 'ancestors')
+
+            if 'ancestors' in page:
+                for ancestor in page['ancestors']:
+                    ancestors.add(ancestor['id'])
 
         return ancestors
 

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1107,7 +1107,10 @@ class ConfluencePublisher:
             self._onlynew('attachment removal restricted', id_)
             return
 
-        delete_path = f'{self.APIV1}content'
+        if self.api_mode == 'v2':
+            delete_path = f'{self.APIV2}attachments'
+        else:
+            delete_path = f'{self.APIV1}content'
 
         try:
             try:
@@ -1138,9 +1141,14 @@ class ConfluencePublisher:
             self._onlynew('page removal restricted', page_id)
             return
 
+        if self.api_mode == 'v2':
+            delete_path = f'{self.APIV2}pages'
+        else:
+            delete_path = f'{self.APIV1}content'
+
         try:
             try:
-                self.rest.delete(f'{self.APIV1}content', page_id)
+                self.rest.delete(delete_path, page_id)
             except ConfluenceBadApiError as ex:
                 if str(ex).find('Transaction rolled back') == -1:
                     raise
@@ -1149,7 +1157,7 @@ class ConfluencePublisher:
                     logger.warn('delete failed; retrying...')
                 time.sleep(3)
 
-                self.rest.delete(f'{self.APIV1}content', page_id)
+                self.rest.delete(delete_path, page_id)
 
         except ConfluenceBadApiError as ex:
             # Check if Confluence reports that this content does not exist. If

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -277,6 +277,7 @@ class ConfluencePublisher:
         if not self.parent_ref:
             return base_page_id
 
+        # fetching a base page by a numerical identifier
         if isinstance(self.parent_ref, int):
             base_page_id, page = self.get_page_by_id(self.parent_ref)
 
@@ -286,20 +287,17 @@ class ConfluencePublisher:
 
             return base_page_id
 
-        rsp = self.rest.get(f'{self.APIV1}content', {
-            'type': 'page',
-            'spaceKey': self.space_key,
-            'title': self.parent_ref,
-            'status': 'current',
-        })
-        if not rsp['results']:
+        # fetching a base page by a page-name identifier
+        base_page_id, page = self.get_page(self.parent_ref)
+
+        if not page:
             msg = 'Configured parent page name does not exist.'
             raise ConfluenceConfigError(msg)
-        page = rsp['results'][0]
-        if self.parent_id and page['id'] != str(self.parent_id):
+
+        if self.parent_id and base_page_id != str(self.parent_id):
             msg = 'Configured parent page ID and name do not match.'
             raise ConfluenceConfigError(msg)
-        base_page_id = page['id']
+
         self._name_cache[base_page_id] = self.parent_ref
 
         if not base_page_id and self.parent_id:

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -16,7 +16,6 @@ from sphinxcontrib.confluencebuilder.exceptions import ConfluenceSeraphAuthentic
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceSslError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceTimeoutError
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
-from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
 from sphinxcontrib.confluencebuilder.std.confluence import NOCHECK
 from sphinxcontrib.confluencebuilder.std.confluence import RSP_HEADER_RETRY_AFTER
 from requests.adapters import HTTPAdapter
@@ -164,7 +163,6 @@ class Rest:
     CONFLUENCE_DEFAULT_ENCODING = 'utf-8'
 
     def __init__(self, config):
-        self.bind_path = API_REST_BIND_PATH
         self.config = config
         self.last_retry = 1
         self.next_delay = None
@@ -175,9 +173,6 @@ class Rest:
         self._reported_large_delay = False
 
         self.session = self._setup_session(config)
-
-        if config.confluence_publish_disable_api_prefix:
-            self.bind_path = ''
 
     def __del__(self):
         if self.session:
@@ -320,7 +315,7 @@ class Rest:
         err = ""
         err += f"REQ: {rsp.request.method}\n"
         err += "RSP: " + str(rsp.status_code) + "\n"
-        err += "URL: " + self.url + self.bind_path + "\n"
+        err += "URL: " + self.url + "\n"
         err += "API: " + path + "\n"
         try:
             err += f'DATA: {json.dumps(rsp.json(), indent=2)}'
@@ -331,7 +326,7 @@ class Rest:
     def _process_request(self, method, path, *args, **kwargs):
         dump = PublishDebug.headers in self.config.confluence_publish_debug
 
-        rest_url = f'{self.url}{self.bind_path}/{path}'
+        rest_url = f'{self.url}{path}'
         base_req = requests.Request(method, rest_url, *args, **kwargs)
         req = self.session.prepare_request(base_req)
 

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -4,8 +4,8 @@
 from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_HIGHLIGHT_STYLE
 import os
 
-# confluence trailing bind path for rest api
-API_REST_BIND_PATH = 'rest/api'
+# prefix for all api path requests to a confluence instance (v1 api)
+API_REST_V1 = 'rest/api'
 
 # default width for a table (v2 editor)
 #

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -7,6 +7,15 @@ import os
 # prefix for all api path requests to a confluence instance (v1 api)
 API_REST_V1 = 'rest/api'
 
+# prefix for all api path requests to a confluence instance (v2 api)
+API_REST_V2 = 'api/v2'
+
+# list of supported api modes to operate with
+API_MODES = {
+    'v1',
+    'v2',
+}
+
 # default width for a table (v2 editor)
 #
 # It has been observed that when attempting to fix specific column widths on

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -3,7 +3,7 @@
 
 from contextlib import contextmanager
 from pathlib import Path
-from sphinxcontrib.confluencebuilder.std.confluence import API_REST_BIND_PATH
+from sphinxcontrib.confluencebuilder.std.confluence import API_REST_V1
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_SIZE
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_X_HEIGHT
 from hashlib import sha256
@@ -77,9 +77,9 @@ class ConfluenceUtil:
             # removing any trailing forward slash user provided
             if url.endswith('/'):
                 url = url[:-1]
-            # check for rest bind path; strip and return if found
-            if url.endswith(API_REST_BIND_PATH):
-                url = url[:-len(API_REST_BIND_PATH)]
+            # check for rest api prefix; strip and return if found
+            if url.endswith(API_REST_V1):
+                url = url[:-len(API_REST_V1)]
             # restore trailing forward flash
             elif not url.endswith('/'):
                 url += '/'

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -40,6 +40,7 @@ class TestConfluenceValidation(unittest.TestCase):
         cls.config['confluence_parent_page'] = None
         cls.config['confluence_prev_next_buttons_location'] = 'both'
         cls.config['confluence_publish'] = True
+        cls.config['confluence_publish_debug'] = 'deprecated'
         cls.config['confluence_server_pass'] = os.getenv(AUTH_ENV_KEY)
         cls.config['confluence_server_url'] = DEFAULT_TEST_URL
         cls.config['confluence_server_user'] = DEFAULT_TEST_USER

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -831,6 +831,22 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         with self.assertRaises(ConfluenceConfigError):
             self._try_config()
 
+    def test_config_check_publish_override_api_prefix(self):
+        self.config['confluence_publish_override_api_prefix'] = {}
+        self._try_config()
+
+        self.config['confluence_publish_override_api_prefix'] = {
+            'v1': 'override1/',
+            'v2': 'override2/',
+        }
+        self._try_config()
+
+        self.config['confluence_publish_override_api_prefix'] = {
+            'v2': None,
+        }
+        with self.assertRaises(ConfluenceConfigError):
+            self._try_config()
+
     def test_config_check_publish_postfix(self):
         self.config['confluence_publish_postfix'] = ''
         self._try_config()

--- a/tests/unit-tests/test_publisher_api_prefix.py
+++ b/tests/unit-tests/test_publisher_api_prefix.py
@@ -8,7 +8,7 @@ from tests.lib import prepare_conf_publisher
 import unittest
 
 
-class TestConfluencePublisherApiBindPath(unittest.TestCase):
+class TestConfluencePublisherApiPrefix(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.config = prepare_conf_publisher()
@@ -21,8 +21,14 @@ class TestConfluencePublisherApiBindPath(unittest.TestCase):
             'type': 'global',
         }
 
-    def test_publisher_api_bind_path_default(self):
-        """validate publisher includes api bind path"""
+        cls.std_spaces_connect_rsp = {
+            'results': [
+                cls.std_space_connect_rsp,
+            ],
+        }
+
+    def test_publisher_api_prefix_default(self):
+        """validate publisher includes an api prefix"""
         #
         # Verify that a publisher will perform requests which target the
         # `/rest/api` endpoint.
@@ -40,14 +46,17 @@ class TestConfluencePublisherApiBindPath(unittest.TestCase):
             req_path, _ = connect_req
             self.assertTrue('/rest/api/' in req_path)
 
-    def test_publisher_api_bind_path_disabled(self):
-        """validate publisher can disable api bind path"""
+    def test_publisher_api_prefix_override_v1(self):
+        """validate publisher can disable a v1 api prefix"""
         #
         # Verify that a publisher can perform requests disables the use of
-        # the `/rest/api` endpoint.
+        # the `rest/api` prefix.
 
         config = self.config.clone()
-        config.confluence_publish_disable_api_prefix = True
+        config.confluence_api_mode = 'v1'
+        config.confluence_publish_override_api_prefix = {
+            'v1': 'my-custom-v1/',
+        }
 
         with mock_confluence_instance(config) as daemon, \
                 autocleanup_publisher(ConfluencePublisher) as publisher:
@@ -60,4 +69,31 @@ class TestConfluencePublisherApiBindPath(unittest.TestCase):
             connect_req = daemon.pop_get_request()
             self.assertIsNotNone(connect_req)
             req_path, _ = connect_req
-            self.assertTrue('/rest/api/' not in req_path)
+            self.assertFalse('/rest/api/' in req_path)
+            self.assertTrue('/my-custom-v1/' in req_path)
+
+    def test_publisher_api_prefix_override_v2(self):
+        """validate publisher can disable a v2 api prefix"""
+        #
+        # Verify that a publisher can perform requests disables the use of
+        # the `api/v2` prefix.
+
+        config = self.config.clone()
+        config.confluence_api_mode = 'v2'
+        config.confluence_publish_override_api_prefix = {
+            'v2': 'my-custom-v2/',
+        }
+
+        with mock_confluence_instance(config) as daemon, \
+                autocleanup_publisher(ConfluencePublisher) as publisher:
+            daemon.register_get_rsp(200, self.std_spaces_connect_rsp)
+
+            publisher.init(config)
+            publisher.connect()
+
+            # connect request
+            connect_req = daemon.pop_get_request()
+            self.assertIsNotNone(connect_req)
+            req_path, _ = connect_req
+            self.assertFalse('/api/v2/' in req_path)
+            self.assertTrue('/my-custom-v2/' in req_path)

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -2,6 +2,7 @@
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
 from collections import defaultdict
+from sphinxcontrib.confluencebuilder.publisher import CB_PROP_KEY
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from tests.lib import autocleanup_publisher
 from tests.lib import mock_confluence_instance
@@ -56,8 +57,30 @@ class TestConfluencePublisherPage(unittest.TestCase):
             }
             daemon.register_get_rsp(200, page_fetch_rsp)
 
+            # prepare response for properties fetch
+            scb_fetch_props_rsp = {
+                'id': '1234',
+                'key': CB_PROP_KEY,
+                'value': {},
+                'version': {
+                    'number': '1',
+                },
+            }
+            daemon.register_get_rsp(200, scb_fetch_props_rsp)
+
             # prepare response for update event
             daemon.register_put_rsp(200, dict(page_fetch_rsp))
+
+            # prepare response for updated properties
+            scb_updated_props_rsp = {
+                'id': '1234',
+                'key': CB_PROP_KEY,
+                'value': {},
+                'version': {
+                    'number': '2',
+                },
+            }
+            daemon.register_put_rsp(200, scb_updated_props_rsp)
 
             # perform page update request
             data = defaultdict(str)
@@ -79,6 +102,16 @@ class TestConfluencePublisherPage(unittest.TestCase):
             # check that an update request is processed
             update_req = daemon.pop_put_request()
             self.assertIsNotNone(update_req)
+
+            # check that the property request on the page was done
+            props_fetch_req = daemon.pop_get_request()
+            self.assertIsNotNone(props_fetch_req)
+
+            # check that the page property (e.g. hash update) was made
+            update_req = daemon.pop_put_request()
+            self.assertIsNotNone(update_req)
+            req_path, _ = update_req
+            self.assertTrue(req_path.endswith(CB_PROP_KEY))
 
             # verify that no other request was made
             daemon.check_unhandled_requests()
@@ -114,8 +147,30 @@ class TestConfluencePublisherPage(unittest.TestCase):
             }
             daemon.register_get_rsp(200, page_fetch_rsp)
 
+            # prepare response for properties fetch
+            scb_fetch_props_rsp = {
+                'id': '1234',
+                'key': CB_PROP_KEY,
+                'value': {},
+                'version': {
+                    'number': '1',
+                },
+            }
+            daemon.register_get_rsp(200, scb_fetch_props_rsp)
+
             # prepare response for update event
             daemon.register_put_rsp(200, dict(page_fetch_rsp))
+
+            # prepare response for updated properties
+            scb_updated_props_rsp = {
+                'id': '1234',
+                'key': CB_PROP_KEY,
+                'value': {},
+                'version': {
+                    'number': '2',
+                },
+            }
+            daemon.register_put_rsp(200, scb_updated_props_rsp)
 
             # prepare response for unwatch event
             daemon.register_delete_rsp(200)
@@ -140,6 +195,16 @@ class TestConfluencePublisherPage(unittest.TestCase):
             # check that an update request is processed
             update_req = daemon.pop_put_request()
             self.assertIsNotNone(update_req)
+
+            # check that the property request on the page was done
+            props_fetch_req = daemon.pop_get_request()
+            self.assertIsNotNone(props_fetch_req)
+
+            # check that the page property (e.g. hash update) was made
+            update_req = daemon.pop_put_request()
+            self.assertIsNotNone(update_req)
+            req_path, _ = update_req
+            self.assertTrue(req_path.endswith(CB_PROP_KEY))
 
             # check that the page is unwatched
             unwatch_req = daemon.pop_delete_request()


### PR DESCRIPTION
Providing support for Confluence Cloud REST v2 APIs.

- This moves the API path prefix logic from a `Rest` class into a `Publisher` class.
- Introduces a new configuration option `confluence_api_mode` to configure which mode to use; otherwise it defaults to using `v2` for Confluence Cloud variants, or `v1` for everything else.
- The option `confluence_publish_disable_api_prefix` has been deprecated over a new option `confluence_publish_override_api_prefix`, allowing API version-specific prefix overrides.
- Updating a series of deprecated API calls with their new v2 compatible calls.