### PR TITLE
translator: correct navnode check for reference building

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1352,7 +1352,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         anchor_value = intern_uri_anchor_value(docname, node['refuri'])
 
-        navnode = getattr(node, '_navnode', False)
+        navnode = getattr(node, 'cbe_navnode', False)
 
         if navnode:
             if self.v2:

--- a/tests/sample-sets/next-prev/conf.py
+++ b/tests/sample-sets/next-prev/conf.py
@@ -1,0 +1,5 @@
+extensions = [
+    'sphinxcontrib.confluencebuilder',
+]
+
+confluence_prev_next_buttons_location = 'both'

--- a/tests/sample-sets/next-prev/index.rst
+++ b/tests/sample-sets/next-prev/index.rst
@@ -1,0 +1,9 @@
+main
+====
+
+.. toctree::
+    :maxdepth: 1
+
+    page-1
+    page-2
+    page-3

--- a/tests/sample-sets/next-prev/page-1.rst
+++ b/tests/sample-sets/next-prev/page-1.rst
@@ -1,0 +1,48 @@
+page-1
+======
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas ornare
+elementum consequat. Suspendisse cursus efficitur nunc, in faucibus magna
+tristique sed. Phasellus id venenatis diam. Aenean suscipit finibus venenatis.
+Aenean in ligula at neque commodo blandit. Donec euismod dolor sed sagittis
+faucibus. Etiam pellentesque erat lectus, eu vulputate lectus consequat id.
+Integer ut odio cursus enim ullamcorper ullamcorper in ac turpis. Ut elementum
+sapien non enim porttitor ultrices. Donec eget ornare purus, nec tristique sem.
+Nullam vulputate placerat vehicula. Maecenas est turpis, viverra a arcu eu,
+interdum mattis turpis. Proin condimentum neque at mi dapibus, at semper ante
+tristique.
+
+Morbi id elementum tortor, eu dapibus turpis. Aliquam auctor blandit massa
+quis venenatis. Suspendisse non convallis lectus. Etiam libero augue, posuere
+sit amet tempus at, ullamcorper scelerisque mauris. Aliquam nec congue ligula.
+Sed pharetra consequat pellentesque. Donec tincidunt ipsum tortor, sit amet
+aliquam tortor molestie quis. Suspendisse non ipsum quis sem fringilla
+malesuada id vitae purus. Phasellus eu metus convallis, luctus ex vitae,
+finibus nibh. Ut quam eros, fringilla tincidunt euismod nec, tempor in massa.
+Orci varius natoque penatibus et magnis dis parturient montes, nascetur
+ridiculus mus.
+
+Aenean volutpat libero et est cursus, tincidunt tincidunt dui dapibus. Aenean
+sollicitudin efficitur ullamcorper. Pellentesque id dui leo. Phasellus rhoncus
+urna metus. Aliquam aliquam eros ut nulla aliquam, quis semper sapien sagittis.
+Fusce consectetur vitae nulla vitae sodales. Integer vestibulum porta
+imperdiet.
+
+Aliquam erat volutpat. Nam eget scelerisque nulla. Donec ornare elit eget urna
+fringilla vulputate sed tristique mauris. Sed sit amet dui dictum, fringilla
+velit eget, sollicitudin ante. Phasellus eget convallis metus, id congue
+turpis. Duis vitae mauris molestie sem finibus sollicitudin. Aenean congue
+ccumsan ante et blandit. Nulla facilisi. Nunc rutrum, dolor quis vestibulum
+lobortis, odio lectus commodo nibh, eget semper magna est in risus. Fusce nisl
+augue, imperdiet vel pharetra a, feugiat sed felis. Vivamus nec finibus felis.
+Nunc a sagittis odio, sed posuere sem. Mauris vel bibendum nisi.
+
+Morbi vel erat pellentesque, dictum risus in, lacinia turpis. Suspendisse
+vitae iaculis elit. Cras quis mollis dolor, a dapibus neque. In dignissim
+congue turpis vitae varius. Etiam euismod porta pretium. Nulla ut bibendum
+erat. Ut vitae nisl eu nulla faucibus sodales et commodo leo. Mauris
+consectetur erat leo, at venenatis sapien imperdiet vel. Donec sed est nec
+risus efficitur commodo sed quis neque. Aenean nunc metus, cursus viverra mi
+eu, commodo dignissim ante. Praesent cursus fringilla lacus, at eleifend felis
+laoreet ut. Integer dictum odio nec tincidunt hendrerit. Phasellus commodo nunc
+in magna feugiat porttitor. Phasellus eget accumsan felis.

--- a/tests/sample-sets/next-prev/page-2.rst
+++ b/tests/sample-sets/next-prev/page-2.rst
@@ -1,0 +1,51 @@
+.. confluence_metadata::
+    :editor: v2
+
+page-2
+======
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam mattis
+gravida lacus ut molestie. Cras metus nisl, commodo ac aliquet et, interdum
+ac justo. Vivamus ut feugiat mi, nec scelerisque nisi. Lorem ipsum dolor sit
+amet, consectetur adipiscing elit. Suspendisse ac gravida mauris, at elementum
+metus. Ut vehicula sit amet sem id ornare. Pellentesque augue lacus, viverra
+ut sagittis ut, scelerisque vitae lorem. Proin eu rutrum justo. Mauris metus
+sem, egestas in risus at, condimentum venenatis tellus. Aliquam dictum luctus
+scelerisque.
+
+In id ipsum odio. Ut ac semper risus. Proin porttitor lorem libero, id
+tincidunt sapien rhoncus a. Proin hendrerit mauris diam, sit amet venenatis
+libero fermentum vel. Praesent lectus quam, pellentesque at pretium nec,
+condimentum sed nisi. Aenean consectetur, ante ac molestie varius, neque ante
+ullamcorper risus, vel consectetur eros nibh ut libero. Donec tempor tempus
+purus, sit amet tristique massa congue id. Nunc elit erat, pretium sit amet
+magna nec, tincidunt mattis ligula. Quisque tristique urna orci, nec porttitor
+turpis ultricies id. Aenean commodo efficitur sapien, sit amet dignissim
+ligula mattis at.
+
+Sed eu ligula scelerisque, egestas orci non, rhoncus lorem. Nullam consequat
+dui non justo rhoncus, sed hendrerit tellus accumsan. Nunc leo sem, condimentum
+et venenatis a, ornare sit amet risus. Duis imperdiet molestie luctus. Nunc id
+dui erat. Sed finibus dui dolor, sit amet pharetra neque consequat vitae.
+Curabitur in diam finibus, euismod ex eget, egestas diam. Phasellus molestie
+at neque ac ullamcorper. Quisque porttitor erat risus, a feugiat justo auctor
+at. Nullam accumsan finibus nibh, dictum feugiat nisi. Mauris vel consectetur
+libero, sed lobortis erat. Fusce ut viverra ante. Maecenas porta erat vitae
+velit efficitur efficitur.
+
+Nam quis dignissim tortor, non posuere nisl. Suspendisse ullamcorper, neque
+ullamcorper euismod ullamcorper, nunc justo tincidunt elit, ac lobortis elit
+ante quis leo. Duis nec libero elementum, sagittis purus vitae, dictum mauris.
+Nullam finibus, neque pretium tristique semper, lorem ipsum cursus arcu, vitae
+volutpat metus lorem eu sem. Aliquam sagittis nunc ut lacus pulvinar, vel
+vestibulum urna luctus. Nullam commodo sapien tortor, et euismod nunc luctus
+vel. Nulla cursus venenatis nulla vitae suscipit. Etiam pharetra nibh eu
+facilisis malesuada. Proin mattis magna ac nibh cursus sodales. Aliquam massa
+dolor, laoreet non lobortis vel, ultrices convallis nunc.
+
+Phasellus eros leo, pellentesque vitae porttitor eu, fermentum vitae nunc.
+Donec cursus elit quis lorem tristique aliquam. Etiam efficitur ultrices eros
+ut sollicitudin. Nullam gravida vitae dui vitae tempus. Etiam pharetra felis
+ut velit accumsan condimentum. Quisque a porta magna. Vivamus sollicitudin,
+magna ac tristique dapibus, ligula odio venenatis risus, vitae scelerisque
+magna dolor suscipit augue. Integer gravida nisi vehicula varius aliquam.

--- a/tests/sample-sets/next-prev/page-3.rst
+++ b/tests/sample-sets/next-prev/page-3.rst
@@ -1,0 +1,47 @@
+page-3
+======
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus quis
+vulputate enim, a tristique urna. Ut sollicitudin nisl ex, non dapibus enim
+tempor quis. Donec tempus risus felis, tempor bibendum urna tempus facilisis.
+Nam eu pellentesque ipsum. Maecenas tempor ac lacus nec cursus. In hac
+abitasse platea dictumst. Duis sollicitudin mattis urna, at finibus quam
+malesuada in. Aliquam nec quam congue felis bibendum lobortis. In ac vehicula
+libero, sit amet cursus nisi. Proin vel commodo nisl. Maecenas in nisl at ante
+hendrerit volutpat et ac neque.
+
+In non pulvinar tellus. Pellentesque volutpat euismod viverra. Maecenas maximus
+commodo nulla, et semper justo commodo id. Maecenas mollis, nunc sit amet
+liquet fringilla, dui arcu semper mi, ac consectetur purus velit quis nisi.
+Aliquam vitae fermentum velit, quis faucibus ex. Nullam molestie porttitor
+finibus. Maecenas eget vehicula risus, in tristique libero. Etiam porttitor
+orttitor luctus. Quisque hendrerit quam id accumsan ullamcorper.
+
+Donec malesuada, nulla gravida hendrerit congue, libero nulla fringilla nulla,
+eu ornare massa libero sit amet enim. In cursus lectus ut ligula eleifend, sit
+amet vestibulum justo feugiat. Donec id eleifend elit. Curabitur varius
+volutpat ipsum, vitae pellentesque odio dignissim et. Maecenas nunc risus,
+molestie vitae rutrum sed, porttitor at purus. Sed efficitur, sem vitae gravida
+semper, orci urna malesuada sapien, id placerat felis magna ac arcu. Morbi sed
+lacus sollicitudin, tristique sem sit amet, vestibulum elit. Nam maximus mattis
+suscipit. Pellentesque habitant morbi tristique senectus et netus et malesuada
+ames ac turpis egestas. Interdum et malesuada fames ac ante ipsum primis in
+faucibus. In malesuada quam purus, tempor consequat ex porta vitae. Cras at
+dui egestas neque pulvinar convallis eu at ligula.
+
+Etiam ligula neque, imperdiet ut magna nec, pellentesque placerat velit. In non
+venenatis nunc, ut ultricies dui. Suspendisse potenti. Vestibulum porta ipsum
+sed egestas bibendum. Curabitur auctor mi sed mattis rutrum. Vestibulum dolor
+tellus, vulputate ac porta ac, semper at ex. Sed sollicitudin gravida metus,
+in dignissim lacus elementum a. Praesent malesuada convallis condimentum. Duis
+vehicula, enim ut tincidunt efficitur, felis tortor malesuada nunc, et rutrum
+isi elit a ligula. Curabitur nec ante metus. Vivamus dignissim a leo nec
+incidunt. Nam dictum turpis sed ultrices tincidunt.
+
+Vestibulum pulvinar mauris et lacus convallis, ornare eleifend turpis mattis.
+Nunc euismod tempus justo, sit amet ullamcorper elit tempus non. Vestibulum
+aliquam, lorem sed euismod ultrices, neque lorem ultricies felis, at
+onsectetur ligula risus quis arcu. Interdum et malesuada fames ac ante ipsum
+primis in faucibus. Nulla varius nunc dolor. Ut in sapien quis urna egestas
+finibus eu et mauris. Morbi sit amet placerat sem. Pellentesque sagittis nisi
+at nisl consequat feugiat.

--- a/tests/sample-sets/next-prev/tox.ini
+++ b/tests/sample-sets/next-prev/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+package_root={toxinidir}{/}..{/}..{/}..
+
+[testenv]
+commands =
+    {envpython} -m tests.test_sample {posargs}
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+    TOX_INI_DIR={toxinidir}
+passenv = *
+use_develop = true


### PR DESCRIPTION
A previous maintenance update \[1\] broke a nav-node check used to help
form proper header/footer sections; correcting.

\[1\]: f033d213885a21685af5b67b3b221a81073ac16a