### PR TITLE
exceptions: do not wrap "is-set" with angle brackets

### DIFF
--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -270,8 +270,8 @@ the exception message above this message.
 class ConfluenceUnknownInstanceError(ConfluenceError):
     def __init__(self, server_url, space_key, uname, pw_set, token_set):
         uname_value = uname if uname else '(empty)'
-        pw_value = '<set>' if pw_set else '(empty)'
-        token_value = '<set>' if token_set else '(empty)'
+        pw_value = '(set)' if pw_set else '(empty)'
+        token_value = '(set)' if token_set else '(empty)'
         super().__init__(f'''
 ---
 Unknown Confluence URL or invalid/restricted space detected


### PR DESCRIPTION
Switching the unknown-instance exception to wrap `set` values with parenthesis over angle brackets. This is to prevent masking these values if a user attempts to post the output in a GitLab issue without wrapping in a code block.