### PR TITLE
Maintenance (2024-03-16)

### DIFF
--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -235,7 +235,7 @@ def report_main(args_parser):
             parsed = urlparse(value)
 
             if parsed.scheme:
-                value = parsed.scheme + '://<removed>'
+                value = parsed.scheme + '://(removed)'
             else:
                 value = '(set; no scheme)'
 

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -753,11 +753,10 @@ class ConfluencePublisher:
             misc = ''
             if parent_id and 'ancestors' in page:
                 if not any(a['id'] == parent_id for a in page['ancestors']):
+                    desc = ''
                     if parent_id in self._name_cache:
-                        misc += '[new parent page {} ({})]'.format(
-                            self._name_cache[parent_id], parent_id)
-                    else:
-                        misc += '[new parent page]'
+                        desc = f': {self._name_cache[parent_id]} ({parent_id})'
+                    misc += f'[new parent page{desc}]'
 
             self._dryrun('updating existing page', page['id'], misc)
             return page['id']

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -169,16 +169,19 @@ class Rest:
         self.last_retry = 1
         self.next_delay = None
         self.url = config.confluence_server_url
-        self.session = self._setup_session(config)
+        self.session = None
         self.timeout = config.confluence_timeout
         self.verbosity = config.sphinx_verbosity
         self._reported_large_delay = False
+
+        self.session = self._setup_session(config)
 
         if config.confluence_publish_disable_api_prefix:
             self.bind_path = ''
 
     def __del__(self):
-        self.session.close()
+        if self.session:
+            self.session.close()
 
     def _setup_session(self, config):
         session = requests.Session()

--- a/tests/unit-tests/test_config_prev_next.py
+++ b/tests/unit-tests/test_config_prev_next.py
@@ -61,6 +61,6 @@ class TestConfluenceConfigPrevNext(ConfluenceTestCase):
             for char, count in expected.items():
                 found = data.count(char)
                 self.assertTrue(data.count(char) == count,
-                    'unexpected character ({}) count (expected: {}, found: {}) '
-                    'in file: {}'.format(
-                        hex(ord(char)), count, found, test_path))
+                    f'unexpected character ({hex(ord(char))}) count '
+                    f'(expected: {count}, found: {found}) '
+                    f'in file: {test_path}')

--- a/tests/validation-sets/sphinx/assets/example.py
+++ b/tests/validation-sets/sphinx/assets/example.py
@@ -1,1 +1,3 @@
+# hello world
+
 print('hello world')

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ commands =
 [testenv:ruff]
 deps =
     {[testenv]deps}
-    ruff: ruff==0.3.0
+    ruff: ruff==0.3.3
 setenv =
     {[testenv]setenv}
     RUFF_CACHE_DIR={toxworkdir}/.ruff_cache


### PR DESCRIPTION
- tests: add leading comment in example
- rest: only close session if it was created
- report: do not wrap url-removed hint with angle brackets
- tox: bump ruff to v0.3.3
- switch to f-strings