### PR TITLE
builder: replace header spaces with dashes with v2 editor

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -1108,11 +1108,17 @@ class ConfluenceBuilder(Builder):
         doc_used_names = {}
         secnumbers = self.env.toc_secnumbers.get(docname, {})
 
+        metadata = self.metadata.get(docname, {})
+        editor = metadata.get('editor', self.config.confluence_editor)
+
         for node in findall(doctree, nodes.title):
             if isinstance(node.parent, nodes.section):
                 section_node = node.parent
                 if 'ids' in section_node:
-                    target = ''.join(node.astext().split())
+                    # sections on v2 pages will replace spaces with dashes
+                    # for anchors, where older editors will strip out spaces
+                    sep = '-' if editor == 'v2' else ''
+                    target = sep.join(node.astext().split())
 
                     if self.add_secnumbers:
                         anchorname = '#' + section_node['ids'][0]

--- a/tests/unit-tests/datasets/local-toc/index.rst
+++ b/tests/unit-tests/datasets/local-toc/index.rst
@@ -1,0 +1,8 @@
+Index
+=====
+
+.. toctree::
+    :maxdepth: 1
+
+    rst-v1
+    rst-v2

--- a/tests/unit-tests/datasets/local-toc/rst-v1.rst
+++ b/tests/unit-tests/datasets/local-toc/rst-v1.rst
@@ -1,0 +1,13 @@
+.. confluence_metadata::
+    :editor: v1
+
+reStructuredText v1
+===================
+
+.. contents::
+    :local:
+
+An Extra Header
+---------------
+
+content

--- a/tests/unit-tests/datasets/local-toc/rst-v2.rst
+++ b/tests/unit-tests/datasets/local-toc/rst-v2.rst
@@ -1,0 +1,13 @@
+.. confluence_metadata::
+    :editor: v2
+
+reStructuredText v2
+===================
+
+.. contents::
+    :local:
+
+An Extra Header
+---------------
+
+content

--- a/tests/unit-tests/test_local_toc.py
+++ b/tests/unit-tests/test_local_toc.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from tests.lib.parse import parse
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+
+
+class TestConfluenceLocalToc(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.dataset = cls.datasets / 'local-toc'
+
+    @setup_builder('confluence')
+    def test_storage_local_toc(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('rst-v1', out_dir) as data:
+            # for v1, no a-tags
+            a_tags = data.find_all('a')
+            self.assertEqual(len(a_tags), 0)
+
+            # for v2, expect two ac:links:
+            #  - link to section
+            #  - link to toc section entry
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 2)
+
+            # (ac-link 1) link to section
+            #
+            # This check is important since v2 links will have anchors with
+            # no separators.
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'AnExtraHeader')
+
+            # (ac-link 2) link to toc section entry
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertNotEqual(ac_link['ac:anchor'], '')
+
+        with parse('rst-v2', out_dir) as data:
+            # for v1, one a tag linked to section
+            a_tags = data.find_all('a')
+            self.assertEqual(len(a_tags), 1)
+
+            # (a 1) link to section
+            #
+            # This check is important since v2 links will have anchors with
+            # dashes for separators.
+            a_tag = a_tags.pop(0)
+            self.assertTrue(a_tag.has_attr('href'))
+            self.assertEqual(a_tag['href'], '#An-Extra-Header')
+
+            # for v2, one ac:links linked to toc section entry
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 1)
+
+            # (ac-link 1) link to toc section entry
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertNotEqual(ac_link['ac:anchor'], '')


### PR DESCRIPTION
When a page is configured to render a v2 editor content, instead of stripping out spaces for anchor links, replace spaces with dashes. This appears to be the expected ID generation pattern for v2 editor on Confluence Cloud.