### PR TITLE
builder: add workaround for v2 parenthesis anchor links

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -237,6 +237,8 @@ def setup(app):
     # (configuration - undocumented)
     # Enablement for bulk archiving of packages (for premium environments).
     cm.add_conf_bool('confluence_adv_bulk_archiving')
+    # Disable workaround for: https://jira.atlassian.com/browse/CONFCLOUD-74698
+    cm.add_conf_bool('confluence_adv_disable_confcloud_74698')
     # Flag to permit the use of embedded certificates from requests.
     cm.add_conf_bool('confluence_adv_embedded_certs')
     # List of node types to ignore if no translator support exists.

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -1135,6 +1135,17 @@ class ConfluenceBuilder(Builder):
                     if section_id > 0:
                         target = f'{target}.{section_id}'
 
+                    # v2 editor does not link anchors with parenthesis
+                    # gracefully; inject a workaround
+                    #
+                    # See: https://jira.atlassian.com/browse/CONFCLOUD-7469
+                    if not self.config.confluence_adv_disable_confcloud_74698:
+                        if editor == 'v2':
+                            if any(x in target for x in ['(', ')']):
+                                target = 2*'[inlineExtension]' + target
+                                target = target.replace('(', '%28')
+                                target = target.replace(')', '%29')
+
                     for raw_id in section_node['ids']:
                         full_id = f'{docname}#{raw_id}'
                         self.state.register_target(full_id, target)


### PR DESCRIPTION
When a page is configured to be published with a v2 editor, check if any anchor links contain a parenthesis value. If so, replace the expected target value with a manipulated value which works around an issue (JST-937603) where parenthesis will remove an anchor link.

This change also introduces an internal configuration entry `confluence_adv_disable_confcloud_74698`, which disables this workaround (if the situation arises where Confluence Cloud corrects this issue and this applied workaround breaks user's documentation; a quick method for users of this extension to deal with this until a next release).

See also: https://support.atlassian.com/requests/JST-937603/