### PR TITLE
config: add auth value quote checks

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -100,3 +100,27 @@ def warnings(validator):
     # confluence_publish_debug should be using the new string values
     if isinstance(config.confluence_publish_debug, bool):
         logger.warn('confluence_publish_debug using deprecated bool value')
+
+    # check if password/token are wrapped in quotes; these values may be
+    # passed in through arguments/etc. (i.e. not defined in `conf.py`); there
+    # could be a risk of a shell/CI passed value which a user accidentally
+    # quotes a password/token value -- provide a warning if we believe that
+    # has been detected
+    quote_wrap_check = [
+        'confluence_publish_token',
+        'confluence_server_pass',
+    ]
+
+    quote_values = [
+        '"',
+        "'",
+    ]
+
+    for option in quote_wrap_check:
+        value = getattr(config, option)
+        if not value:
+            continue
+
+        for quote_value in quote_values:
+            if value.startswith(quote_value) and value.endswith(quote_value):
+                logger.warn(f'{option} is wrapped in quotes')

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -884,6 +884,15 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_publish_token'] = 'dummy'  # noqa: S105
         self._try_config()
 
+    def test_config_check_quote_wrapped_auth(self):
+        self.config['confluence_publish_token'] = '"test"'  # noqa: S105
+        with self.assertRaises(SphinxWarning):
+            self._try_config()
+
+        self.config['confluence_server_pass'] = "'test'"  # noqa: S105
+        with self.assertRaises(SphinxWarning):
+            self._try_config()
+
     def test_config_check_secnumber_suffix(self):
         self.config['confluence_secnumber_suffix'] = ''
         self._try_config()


### PR DESCRIPTION
Adding configuration checks that will throw a warning if a password or token value is detected to be wrapped in quotes. This is to help inform users who may be passing in password/token values through shell scripts, environment variables or more; which may have a risk of being nested in quotes by accident.