### PR TITLE
rest: flush header debug prints

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -341,7 +341,7 @@ class Rest:
             print('(debug) Request]')
             print(f'{req.method} {req.url}')
             print('\n'.join(f'{k}: {v}' for k, v in req.headers.items()))
-            print('')
+            print('', flush=True)
 
         # perform the rest request
         rsp = self.session.send(req, timeout=self.timeout)
@@ -351,7 +351,7 @@ class Rest:
             print('(debug) Response]')
             print(f'Code: {rsp.status_code}')
             print('\n'.join(f'{k}: {v}' for k, v in rsp.headers.items()))
-            print('')
+            print('', flush=True)
 
         # if confluence or a proxy reports a retry-after delay (to pace us),
         # track it to delay the next request made


### PR DESCRIPTION
When dumping header debug prints to standard output, flush this output to prevent standard error events from making the resulting output hard to interpret.