### PR TITLE
config: remove empty global labels

### DIFF
--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -69,6 +69,11 @@ def apply_defaults(builder):
         if conf.confluence_file_suffix.endswith('.'):
             conf.confluence_file_suffix = '.conf'
 
+    if conf.confluence_global_labels:
+        # remove empty labels
+        labels = conf.confluence_global_labels
+        conf.confluence_global_labels = [x for x in labels if x]
+
     if conf.confluence_jira_servers is None:
         conf.confluence_jira_servers = {}
 


### PR DESCRIPTION
When processing a user-provided global labels list, strip out any empty label identifiers that may have been added to the list. This can help avoid forming bad requests later during publishing which may not be obvious to a user why this may be happening.