### PR TITLE
support custom page generation notice

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -397,14 +397,23 @@ Generic configuration
 .. confval:: confluence_page_generation_notice
 
     .. versionadded:: 1.7
+    .. versionchanged:: 2.5 Accept a string for custom notice.
 
-    A boolean value to whether or not to generate a message at the top of each
-    document that the page has been automatically generated. By default, this
-    notice is disabled with a value of ``False``.
+    This option can be set with a boolean value to whether or not to generate
+    a message at the top of each document that the page has been
+    automatically generated.
 
     .. code-block:: python
 
         confluence_page_generation_notice = True
+
+    Alternatively, users may set a custom message to display.
+
+    .. code-block:: python
+
+        confluence_page_generation_notice = 'My awesome message.'
+
+    By default, this notice is disabled with a value of ``False``.
 
 .. confval:: confluence_page_hierarchy
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -100,7 +100,7 @@ def setup(app):
     # Enablement of a generated search documents
     cm.add_conf_bool('confluence_include_search', 'confluence')
     # Enablement of a "page generated" notice.
-    cm.add_conf_bool('confluence_page_generation_notice', 'confluence')
+    cm.add_conf('confluence_page_generation_notice', 'confluence')
     # Enablement of publishing pages into a hierarchy from a root toctree.
     cm.add_conf_bool('confluence_page_hierarchy', 'confluence')
     # Show previous/next buttons (bottom, top, both, None).

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -16,6 +16,7 @@ from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceHeaderFi
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceJiraServersConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceLatexMacroInvalidConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceLatexMacroMissingKeysConfigError
+from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePageGenerationNoticeConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceParentPageConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePermitRawHtmlConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePrevNextButtonsLocationConfigError
@@ -444,8 +445,13 @@ def validate_configuration(builder):
     # ##################################################################
 
     # confluence_page_generation_notice
-    validator.conf('confluence_page_generation_notice') \
-             .bool()
+    try:
+        validator.conf('confluence_page_generation_notice').bool()
+    except ConfluenceConfigError:
+        try:
+            validator.conf('confluence_page_generation_notice').string()
+        except ConfluenceConfigError as ex:
+            raise ConfluencePageGenerationNoticeConfigError from ex
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/config/exceptions.py
@@ -154,6 +154,18 @@ The following keys are required:
 ''')
 
 
+class ConfluencePageGenerationNoticeConfigError(ConfluenceConfigError):
+    def __init__(self):
+        super().__init__('''\
+confluence_page_generation_notice is not a boolean or a string
+
+The option 'confluence_page_generation_notice' has been provided to
+indicate that a notice should be added at the top of each page about
+pages being generated. This value can either be set to `True` or
+configured with the message to inform users.
+''')
+
+
 class ConfluenceParentPageConfigError(ConfluenceConfigError):
     def __init__(self):
         super().__init__('''\

--- a/sphinxcontrib/confluencebuilder/storage/templates/domainindex.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/domainindex.html
@@ -8,7 +8,11 @@ Template for a storage-format domainindex document.
 
 {%- if pagegen_notice -%}
     <div style="color: #707070; font-size: 12px;">
-        {{ L('This page has been automatically generated.') }}
+        {%- if pagegen_notice is sameas true -%}
+            {{ L('This page has been automatically generated.') }}
+        {%- else -%}
+            {{ L(pagegen_notice|e)}}
+        {%- endif %}
     </div>
 
     <hr style="clear: both; padding-top: 10px" />

--- a/sphinxcontrib/confluencebuilder/storage/templates/domainindex_v2.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/domainindex_v2.html
@@ -8,7 +8,11 @@ Template for a storage-format domainindex document.
 
 {%- if pagegen_notice -%}
     <div style="color: #707070; font-size: 12px;">
-        {{ L('This page has been automatically generated.') }}
+        {%- if pagegen_notice is sameas true -%}
+            {{ L('This page has been automatically generated.') }}
+        {%- else -%}
+            {{ L(pagegen_notice|e)}}
+        {%- endif %}
     </div>
 
     <hr style="clear: both; padding-top: 10px" />

--- a/sphinxcontrib/confluencebuilder/storage/templates/genindex.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/genindex.html
@@ -34,7 +34,11 @@ Template for a storage-format genindex document.
 
 {%- if pagegen_notice -%}
     <div style="color: #707070; font-size: 12px;">
-        {{ L('This page has been automatically generated.') }}
+        {%- if pagegen_notice is sameas true -%}
+            {{ L('This page has been automatically generated.') }}
+        {%- else -%}
+            {{ L(pagegen_notice|e)}}
+        {%- endif %}
     </div>
 
     <hr style="clear: both; padding-top: 10px" />

--- a/sphinxcontrib/confluencebuilder/storage/templates/genindex_v2.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/genindex_v2.html
@@ -34,7 +34,11 @@ Template for a storage-format genindex document.
 
 {%- if pagegen_notice -%}
     <div style="color: #707070; font-size: 12px;">
-        {{ L('This page has been automatically generated.') }}
+        {%- if pagegen_notice is sameas true -%}
+            {{ L('This page has been automatically generated.') }}
+        {%- else -%}
+            {{ L(pagegen_notice|e)}}
+        {%- endif %}
     </div>
 
     <hr style="clear: both; padding-top: 10px" />

--- a/sphinxcontrib/confluencebuilder/storage/templates/search.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/search.html
@@ -7,7 +7,11 @@ Template for a storage-format search document.
 
 {%- if pagegen_notice -%}
     <div style="color: #707070; font-size: 12px;">
-        {{ L('This page has been automatically generated.') }}
+        {%- if pagegen_notice is sameas true -%}
+            {{ L('This page has been automatically generated.') }}
+        {%- else -%}
+            {{ L(pagegen_notice|e)}}
+        {%- endif %}
     </div>
 
     <hr style="clear: both; padding-top: 10px; margin-bottom: 30px" />

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2433,8 +2433,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 'style': 'color: #707070; font-size: 12px;',
             }))
 
-        self.body.append(self.encode(
-            L('This page has been automatically generated.')))
+        if self.builder.config.confluence_page_generation_notice is True:
+            notice_msg = 'This page has been automatically generated.'
+        else:
+            notice_msg = self.builder.config.confluence_page_generation_notice
+
+        self.body.append(self.encode(L(notice_msg)))
 
         if self.v2:
             self.body.append(self._end_tag(node, suffix=''))  # sup

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -8,6 +8,7 @@ from sphinx.environment import BuildEnvironment
 from sphinx.errors import SphinxWarning
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceConfigError
+from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePageGenerationNoticeConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePermitRawHtmlConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePublishCleanupConflictConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceSourcelinkTypeConfigError
@@ -577,6 +578,23 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             'key': 123,
         }
         with self.assertRaises(ConfluenceConfigError):
+            self._try_config()
+
+    def test_config_check_page_generation_notice(self):
+        self.config['confluence_page_generation_notice'] = True
+        self._try_config()
+
+        self.config['confluence_page_generation_notice'] = False
+        self._try_config()
+
+        self.config['confluence_page_generation_notice'] = ''
+        self._try_config()
+
+        self.config['confluence_page_generation_notice'] = 'message'
+        self._try_config()
+
+        self.config['confluence_page_generation_notice'] = [1, 2, 3]
+        with self.assertRaises(ConfluencePageGenerationNoticeConfigError):
             self._try_config()
 
     def test_config_check_parent_page(self):


### PR DESCRIPTION
Allows a user to configure `confluence_page_generation_notice` with a custom message, which can be used instead of the embedded string for the added "page is generated" message.