### PR TITLE
builder: improve workaround for v2 editor anchor links

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -40,6 +40,7 @@ from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import first
 from sphinxcontrib.confluencebuilder.util import handle_cli_file_subset
 from sphinxcontrib.confluencebuilder.writer import ConfluenceWriter
+from urllib.parse import quote
 import os
 import tempfile
 
@@ -1168,16 +1169,13 @@ class ConfluenceBuilder(Builder):
                     if section_id > 0:
                         target = f'{target}.{section_id}'
 
-                    # v2 editor does not link anchors with parenthesis
-                    # gracefully; inject a workaround
+                    # v2 editor does not link anchors with select characters;
+                    # provide a workaround that url encodes targets
                     #
                     # See: https://jira.atlassian.com/browse/CONFCLOUD-7469
                     if not self.config.confluence_adv_disable_confcloud_74698:
                         if editor == 'v2':
-                            if any(x in target for x in ['(', ')']):
-                                target = 2*'[inlineExtension]' + target
-                                target = target.replace('(', '%28')
-                                target = target.replace(')', '%29')
+                            target = quote(target)
 
                     for raw_id in section_node['ids']:
                         full_id = f'{docname}#{raw_id}'


### PR DESCRIPTION
Select anchor links for a v2 editor are manipulated when published (e.g. when links contain parenthesis). A workaround for specifically parenthesis was previously added \[1]\, but additional characters exhibit the same issue (https://github.com/sphinx-contrib/confluencebuilder/issues/908). An improved approach appears to work if the entire target is URL encoded.

\[1\]: 41a099e35d7bc91f83b0ca9222b567c2696fdb46