### PR TITLE
util: strip api v2 url

### DIFF
--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -4,6 +4,7 @@
 from contextlib import contextmanager
 from pathlib import Path
 from sphinxcontrib.confluencebuilder.std.confluence import API_REST_V1
+from sphinxcontrib.confluencebuilder.std.confluence import API_REST_V2
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_SIZE
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_X_HEIGHT
 from hashlib import sha256
@@ -80,6 +81,8 @@ class ConfluenceUtil:
             # check for rest api prefix; strip and return if found
             if url.endswith(API_REST_V1):
                 url = url[:-len(API_REST_V1)]
+            if url.endswith(API_REST_V2):
+                url = url[:-len(API_REST_V2)]
             # restore trailing forward flash
             elif not url.endswith('/'):
                 url += '/'


### PR DESCRIPTION
When a URL is defined by a user, this extension will help strip off the API sub-folder path commonly used by Confluence. This is since this extension manages which API version to call (and also allows users to override). While we strip the v1 API post-fix, we do not do the same if an API v2 post-fix was added. Updating the logic to strip both v1 and v2 API path entries.