### PR TITLE
correct editor check for index pages

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/index.py
+++ b/sphinxcontrib/confluencebuilder/storage/index.py
@@ -43,7 +43,7 @@ def generate_storage_format_domainindex(builder, docname, f):
                     docname=doctitle, anchor=anchor_value)
 
     # fetch raw template data
-    if builder.config.confluence_editor:
+    if builder.config.confluence_editor == 'v2':
         domainindex_fname = 'domainindex_v2.html'
     else:
         domainindex_fname = 'domainindex.html'
@@ -91,7 +91,7 @@ def generate_storage_format_genindex(builder, docname, f):
                         ismain, process_doclink(builder.config, link))
 
     # fetch raw template data
-    if builder.config.confluence_editor:
+    if builder.config.confluence_editor == 'v2':
         genindex_fname = 'genindex_v2.html'
     else:
         genindex_fname = 'genindex.html'


### PR DESCRIPTION
Index pages should be using a specific template based on whether a version one or version two editor is used. The conditional check to determine this is incorrect, and would always default to `v2` when an editor was configured. Updating to explicit check for the `v2` value.