### PR TITLE
center align generated search page

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/search.py
+++ b/sphinxcontrib/confluencebuilder/storage/search.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 from sphinxcontrib.confluencebuilder.locale import L as sccb_translation  # noqa: N811
+from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_WIDTH
 import pkgutil
 
 
@@ -23,12 +24,18 @@ def generate_storage_format_search(builder, docname, f):
     space_key = builder.config.confluence_space_key
 
     # fetch raw template data
-    search_template = Path('templates', 'search.html')
+    if builder.config.confluence_editor == 'v2':
+        search_fname = 'search_v2.html'
+    else:
+        search_fname = 'search.html'
+
+    search_template = Path('templates', search_fname)
     template_data = pkgutil.get_data(__name__, str(search_template))
 
     # process the template with the generated index
     ctx = {
         'L': sccb_translation,
+        'maxwidth': CONFLUENCE_MAX_WIDTH,
         'pagegen_notice': builder.config.confluence_page_generation_notice,
         'space': space_key,
     }

--- a/sphinxcontrib/confluencebuilder/storage/templates/search_v2.html
+++ b/sphinxcontrib/confluencebuilder/storage/templates/search_v2.html
@@ -17,7 +17,7 @@ Template for a storage-format search document.
     <hr style="clear: both; padding-top: 10px; margin-bottom: 30px" />
 {%- endif %}
 
-<div style="max-width: {{ maxwidth }}; margin: 0 auto">
+<ac:layout><ac:layout-section ac:type="fixed-width"><ac:layout-cell>
 
 <ac:structured-macro ac:name="livesearch">
     <ac:parameter ac:name="additional">page excerpt</ac:parameter>
@@ -28,4 +28,4 @@ Template for a storage-format search document.
     <ac:parameter ac:name="type">page</ac:parameter>
 </ac:structured-macro>
 
-</div>
+</ac:layout-cell></ac:layout-section></ac:layout>


### PR DESCRIPTION
Adjusts the generated search page template to support center-aligning the search box. This is subjectively a nicer presentation.