### PR TITLE
doc: drop note about svg issues in v2

### DIFF
--- a/doc/features.rst
+++ b/doc/features.rst
@@ -41,7 +41,7 @@ Type                    Notes
 `images`_               Limited support.
 
                         When using a Confluence v2 editor, images cannot be
-                        inlined and SVGs may not render as expected.
+                        inlined.
 `inline markup`_        Supported
 `list-table`_           Supported
 `literal blocks`_       Supported


### PR DESCRIPTION
Dropping the notice of SVG issues when using the v2 editor. Confluence Cloud appears to have updated their implementation to address previously observed rendering issues.