### PR TITLE
Bump supported Confluence version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ files and optionally publish them to a Confluence instance.
 
 ## Requirements
 
-* [Confluence][confluence] Cloud or Data Center / Server 7.16+
+* [Confluence][confluence] Cloud or Data Center / Server 7.18+
 * [Python][python] 3.8+
 * [Requests][requests] 2.14.0+
 * [Sphinx][sphinx] 6.1+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,7 @@ author = 'Sphinx Confluence Builder Contributors'
 version = sphinxcontrib.confluencebuilder.__version__
 release = sphinxcontrib.confluencebuilder.__version__
 
-supported_confluence_ver = '7.16+'
+supported_confluence_ver = '7.18+'
 supported_python_ver = '3.8+'
 supported_sphinx_ver = '6.1+'
 


### PR DESCRIPTION
Confluence versions before 7.18 have reached end-of-life and will not be tested in next release cycle system tests; updating to the oldest version supported.