### PR TITLE
babel: allow fuzzy compiling

### DIFF
--- a/babel
+++ b/babel
@@ -18,6 +18,7 @@ case $action in
 compile)
     args+=("--domain=sphinxcontrib.confluencebuilder")
     args+=("--directory=sphinxcontrib/confluencebuilder/locale/")
+    args+=("--use-fuzzy")
     ;;
 extract)
     args+=("--keyword=C")


### PR DESCRIPTION
Adjust the babel helper script to compile fuzzy translations by default. Messages for this extension are not that strict to block, and there appears to be some false-positive flagging of fuzziness in some environments.