### PR TITLE
README.md: consistent em dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python -m pip install sphinxcontrib-confluencebuilder
 
 For a more in-depth installation information, see also:
 
-> Atlassian Confluence Builder for Sphinx - Installation \
+> Atlassian Confluence Builder for Sphinx — Installation \
 > https://sphinxcontrib-confluencebuilder.readthedocs.io/install
 
 ## Usage


### PR DESCRIPTION
Some links use a single dash where some uses an em dash; updating all to use em dashes to be consistent.