### PR TITLE
Cleanup requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ files and optionally publish them to a Confluence instance.
 
 * [Confluence][confluence] Cloud or Data Center / Server 7.18+
 * [Python][python] 3.8+
-* [Requests][requests] 2.14.0+
+* [Requests][requests] 2.25.0+
 * [Sphinx][sphinx] 6.1+
 
 ## Installing

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,1 @@
 beautifulsoup4
-requests>=2.14.0
-sphinx


### PR DESCRIPTION
### remove sphinx/requests from development requirements

There is no need to explicitly include Sphinx or Requests in the development requirements, since this project (`pyproject.toml`) defines these dependencies.

### README.md: update requests version

This extension enforces a Requests v2.25 release. However, the README indicates v2.14; correcting.
