### PR TITLE
Handle non-defined property updates

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -601,7 +601,9 @@ class ConfluencePublisher:
                 props_to_fetch.append('editor')
 
             for prop_key in props_to_fetch:
-                prop_entry = self.get_page_property(page_id, prop_key)
+                prop_entry = self.get_page_property(page_id, prop_key, {
+                    'value': None,
+                })
                 meta_props[prop_key] = prop_entry
 
         return page_id, page
@@ -700,9 +702,7 @@ class ConfluencePublisher:
             the property value
         """
 
-        props = {
-            'value': default,
-        }
+        props = default
 
         if page_id:
             try:
@@ -930,7 +930,9 @@ class ConfluencePublisher:
 
         # fetch known properties (associated with this extension) from the page
         page_id = page['id'] if page else None
-        cb_props = self.get_page_property(page_id, CB_PROP_KEY, {})
+        cb_props = self.get_page_property(page_id, CB_PROP_KEY, {
+            'value': {},
+        })
 
         # calculate the hash for a page; we will first use this to check if
         # there is a update to apply, and if we do need to update, we will
@@ -986,8 +988,8 @@ class ConfluencePublisher:
 
         # if we are not force uploading, check if the new page hash matches
         # the remote hash; if so, do not publish
-        if cb_props and not force_publish:
-            remote_hash = cb_props.get('value', {}).get('hash')
+        if not force_publish:
+            remote_hash = cb_props['value'].get('hash')
             if new_page_hash == remote_hash:
                 logger.verbose(f'no changes in page: {page_name}')
                 return page['id']
@@ -1148,7 +1150,9 @@ class ConfluencePublisher:
             raise ConfluenceMissingPageIdError(self.space_key, page_id) from ex
 
         # fetch known properties (associated with this extension) from the page
-        cb_props = self.get_page_property(page_id, CB_PROP_KEY, {})
+        cb_props = self.get_page_property(page_id, CB_PROP_KEY, {
+            'value': {},
+        })
 
         # calculate the hash for a page; we will first use this to check if
         # there is a update to apply, and if we do need to update, we will
@@ -1157,8 +1161,8 @@ class ConfluencePublisher:
 
         # if we are not force uploading, check if the new page hash matches
         # the remote hash; if so, do not publish
-        if cb_props and not self.config.confluence_publish_force:
-            remote_hash = cb_props.get('value', {}).get('hash')
+        if not self.config.confluence_publish_force:
+            remote_hash = cb_props['value'].get('hash')
             if new_page_hash == remote_hash:
                 logger.verbose(f'no changes in page: {page_name}')
                 return page_id
@@ -1208,7 +1212,9 @@ class ConfluencePublisher:
             attempt = 1
             while attempt <= MAX_ATTEMPTS_TO_UPDATE_PROPERTY:
                 prop_key = prop['key']
-                prop_entry = self.get_page_property(page_id, prop_key)
+                prop_entry = self.get_page_property(page_id, prop_key, {
+                    'value': None,
+                })
 
                 # ignore if the property already matches the desired
                 # value

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1555,7 +1555,13 @@ class ConfluencePublisher:
                 }
 
                 orig_entry = orig_meta_props.get(prop_key, None)
-                if orig_entry:
+
+                # if an original entry exists, make sure we bump the version
+                # number for this property; note that the value may be set to
+                # `None`, where this extension requested information about
+                # a property, but Confluence does not have one defined for
+                # a page (i.e. so we treat it as new; no version bump)
+                if orig_entry and orig_entry.get('value') is not None:
                     if orig_entry['value'] == entry['value']:
                         continue
 


### PR DESCRIPTION
### publisher: rework page property processing

Calls to `get_page_property` should return `None` for non-entries on a page. This was the original intent with the implementation, but final tweaks for initial APIv2 support made the default result a partially populated property instance. This commit cleans up this to restore the original intent to have undefined properties return `None`, as well as updates various locations to use a default property value for each applicable section. Specifically:

- `CB_PROP_KEY` returns a prepared empty value dictionary, since the requests will push up a new property change
- Property fetching for v2 will return a `None` populated value to explicitly indicate that the requests should support this type of metadata, as well as that Confluence has reported no value exists
- Update events will populate with a fallback value `None`, which will be updated with the provided property value for the expected change to the property value.

### publisher: skip property version bumps for non-populated entries

This extension tracks certain property entries as an indication that a property is supported for this instance (e.g. on Confluence Cloud, a content width property exists, but not on Confluence Server (at this time?)). However, even if we track support, it does not mean that Confluence has reported the property has been defined for a page.

When we publish property updates for a page, we perform a version bump to indicate to Confluence the property is being updated. Although, for non-defined property entries, the value is set to `None` with no version entries. This causes the implementation to fail since there is no version value to bump. This commit corrects this by checking that the previous value does exist before attempting any version bump; otherwise, it treats the property update event as if it was created a new property entry.