### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ files and optionally publish them to a Confluence instance.
 
 ## Requirements
 
-* [Confluence][confluence] Cloud or Data Center / Server 7.18+
+* [Confluence][confluence] Cloud or Data Center 7.18+
 * [Python][python] 3.8+
 * [Requests][requests] 2.25.0+
 * [Sphinx][sphinx] 6.1+

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -26,7 +26,7 @@ format) and publish them to a Confluence instance.{%endtrans%}
     <li>{%trans%}License{%endtrans%}: BSD-2-Clause</li>
     <li>
         <a href="{{url_confluence}}">Confluence</a>
-        Cloud / Server {{supported_confluence_ver}}
+        Cloud / Data Center {{supported_confluence_ver}}
     </li>
     <li>
         <a href="{{url_python}}">Python</a>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,11 @@ exclude_patterns = [
     'Thumbs.db',
 ]
 
+suppress_warnings = [
+    # Ignore excluded documents on toctrees (expected for LaTeX custom docs).
+    'toc.excluded',
+]
+
 # -- Options for HTML output ----------------------------------------------
 
 html_theme = 'sphinx13b'
@@ -115,6 +120,8 @@ class DocumentationPostTransform(SphinxPostTransform):
 def setup(app):
     app.require_sphinx('6.0')
 
+    app.connect('builder-inited', builder_inited)
+
     app.add_js_file('jquery-3.6.3.min.js')
     app.add_js_file('version-alert.js')
 
@@ -126,3 +133,11 @@ def setup(app):
 
     # register post-transformation hook for additional tweaks
     app.add_post_transform(DocumentationPostTransform)
+
+
+def builder_inited(app):
+    # "introduction.rst" document is for latex (PDF) only
+    if app.builder.name != 'latex':
+        app.config.exclude_patterns.extend([
+            'introduction.rst',
+        ])

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,11 +18,11 @@ supported_sphinx_ver = '6.1+'
 root_doc = 'contents'
 
 # reStructuredText string included at the end of every source
-rst_epilog = """
-.. |supported_confluence_ver| replace:: {}
-.. |supported_python_ver| replace:: {}
-.. |supported_sphinx_ver| replace:: {}
-""".format(supported_confluence_ver, supported_python_ver, supported_sphinx_ver)
+rst_epilog = f'''
+.. |supported_confluence_ver| replace:: {supported_confluence_ver}
+.. |supported_python_ver| replace:: {supported_python_ver}
+.. |supported_sphinx_ver| replace:: {supported_sphinx_ver}
+'''
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,6 +13,7 @@ release = sphinxcontrib.confluencebuilder.__version__
 
 supported_confluence_ver = '7.18+'
 supported_python_ver = '3.8+'
+supported_requests_ver = '2.25.0+'
 supported_sphinx_ver = '6.1+'
 
 root_doc = 'contents'
@@ -21,6 +22,7 @@ root_doc = 'contents'
 rst_epilog = f'''
 .. |supported_confluence_ver| replace:: {supported_confluence_ver}
 .. |supported_python_ver| replace:: {supported_python_ver}
+.. |supported_requests_ver| replace:: {supported_requests_ver}
 .. |supported_sphinx_ver| replace:: {supported_sphinx_ver}
 '''
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -65,7 +65,7 @@ Essential configuration
 
         confluence_server_url = 'https://example.atlassian.net/wiki/'
 
-    For a Confluence Server instance, an example URL configuration, if the
+    For Confluence Data Center, an example URL configuration, if the
     instance's REST API is ``https://intranet-wiki.example.com/rest/api/``,
     should be as follows:
 
@@ -119,7 +119,7 @@ Essential configuration
 
     The username value used to authenticate with the Confluence instance. If
     using Confluence Cloud, this value will most likely be the account's E-mail
-    address. If using Confluence Server, this value will most likely be the
+    address. If using Confluence Data Center, this value will most likely be the
     username value.
 
     .. code-block:: python
@@ -281,8 +281,8 @@ Generic configuration
         - Confluence's ``v1`` editor provides a larger support for Sphinx
           features than the newer editor. Users can compare the difference
           in editors by inspecting the `online demo`_.
-        - Using the ``v2`` editor with Confluence server may yield unexpected
-          results.
+        - Using the ``v2`` editor with Confluence Data Center may yield
+          unexpected results.
         - If a page is published with a ``v2`` editor, an attempt to re-publish
           with a ``v1`` editor style may be ignored in Confluence Cloud. In
           such situations, users are recommended to delete the pages on
@@ -728,7 +728,7 @@ Publishing configuration
     .. warning::
 
         Only Confluence Cloud identifies support for an archiving API.
-        Attempting to Confluence server with this feature will most
+        Attempting to Confluence Data Center with this feature will most
         likely result in an "Unsupported Confluence API call" error (500).
 
     .. attention::
@@ -1197,7 +1197,7 @@ Advanced publishing configuration
 
     .. warning::
 
-        The ``direct`` search mode may not work on Confluence Server/DC
+        The ``direct`` search mode may not work on Confluence Data Center
         instances. For these cases, Confluence may report the following error:
 
          | *(Not Implemented; 500)*
@@ -1795,7 +1795,7 @@ Advanced publishing configuration
 
     .. note::
 
-        Confluence Server/DC does not support setting a version comment for
+        Confluence Data Center does not support setting a version comment for
         the first/new page revision.
 
     A string value to be added as a comment to Confluence's version history.

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -1,6 +1,13 @@
 Documentation contents
 ======================
 
+.. only:: latex
+
+    .. toctree::
+        :maxdepth: 1
+
+        introduction
+
 .. toctree::
     :maxdepth: 1
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -30,18 +30,6 @@ For new users, the following provides a series of steps to assist in preparing
 a new environment to use this package. For users wishing to use virtualenv,
 please see the instructions in :doc:`install-virtualenv`.
 
-.. note::
-
-    If the installation process fails with the following error "AttributeError:
-    '_NamespacePath' object has no attribute 'sort'", try upgrading the
-    setuptools module:
-
-    .. code-block:: shell
-
-        pip install -U setuptools
-         (or)
-        python -m pip install -U setuptools
-
 .. raw:: latex
 
     \newpage

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -8,7 +8,7 @@ Installing
     * Python_ |supported_python_ver|
     * Requests_ |supported_requests_ver|
     * Sphinx_ |supported_sphinx_ver|
-    * Confluence_ Cloud or Server |supported_confluence_ver|
+    * Confluence_ Cloud / Data Center |supported_confluence_ver|
 
 The recommended method of installing or upgrading is using pip_:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,12 +1,14 @@
 Installing
 ==========
 
-Atlassian Confluence Builder for Sphinx |version| depends on:
+.. only:: html
 
-* Python_ |supported_python_ver|
-* Requests_ |supported_requests_ver|
-* Sphinx_ |supported_sphinx_ver|
-* Confluence_ Cloud or Server |supported_confluence_ver|
+    Atlassian Confluence Builder for Sphinx |version| depends on:
+
+    * Python_ |supported_python_ver|
+    * Requests_ |supported_requests_ver|
+    * Sphinx_ |supported_sphinx_ver|
+    * Confluence_ Cloud or Server |supported_confluence_ver|
 
 The recommended method of installing or upgrading is using pip_:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -4,7 +4,7 @@ Installing
 Atlassian Confluence Builder for Sphinx |version| depends on:
 
 * Python_ |supported_python_ver|
-* Requests_ 2.14.0 or later
+* Requests_ |supported_requests_ver|
 * Sphinx_ |supported_sphinx_ver|
 * Confluence_ Cloud or Server |supported_confluence_ver|
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,0 +1,57 @@
+Introduction
+============
+
+Atlassian® Confluence® Builder for Sphinx is a community provided extension
+to help build Confluence supported format files (e.g. storage format) and
+publish them to a Confluence instance.
+
+.. raw:: latex
+
+    \vspace{2mm}
+
+* License: BSD-2-Clause
+* Confluence Cloud / Data Center |supported_confluence_ver|
+* Python |supported_python_ver|
+* Requests |supported_requests_ver|
+* Sphinx |supported_sphinx_ver|
+
+.. raw:: latex
+
+    \vspace{2mm}
+
+The community and development for this extension can all be found at this
+project's GitHub repository:
+
+    | Atlassian Confluence Builder for Sphinx — GitHub
+    | https://github.com/sphinx-contrib/confluencebuilder
+
+Demonstration
+-------------
+
+Published validation examples can be found on the following Confluence
+instance:
+
+    | Atlassian Confluence Builder for Sphinx — Online Demo on Confluence Cloud
+    | https://sphinxcontrib-confluencebuilder.atlassian.net/
+
+Asking for help
+---------------
+
+Having trouble or concerns using this extension? Do not hesitate to bring
+up an issue:
+
+    | Atlassian Confluence Builder for Confluence — Issues
+    | https://github.com/sphinx-contrib/confluencebuilder/issues
+
+.. raw:: latex
+
+    \vspace*{\fill}
+    {\scriptsize
+
+| Atlassian Confluence Builder for Sphinx project is unaffiliated with Atlassian.
+| Atlassian is a registered trademark of Atlassian Pty Ltd.
+| Confluence is a registered trademark of Atlassian Pty Ltd.
+
+.. raw:: latex
+
+    }

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -96,9 +96,9 @@ generated Confluence documents.
     .. warning::
 
         Confluence Cloud mentions should always use account identifiers; where
-        Confluence Server mentions should use either usernames or user keys.
-        Attempting to use Confluence Cloud account identifiers when
-        publishing to a Confluence server will most likely result in an
+        Confluence Data Center mentions should use either usernames or user
+        keys. Attempting to use Confluence Cloud account identifiers when
+        publishing to a Confluence Data Center will most likely result in an
         "Unsupported Confluence API call" error (500).
 
     The ``confluence_mention`` role allows a user to build inlined mentions.
@@ -109,7 +109,7 @@ generated Confluence documents.
 
         See :confluence_mention:`3c5369:fa8b5c24-17f8-4340-b73e-50d383307c59`.
 
-    For Confluence Server instances, a mention to a specific user can either
+    For Confluence Data Center, a mention to a specific user can either
     be set to the username value, or a user's key value:
 
     .. code-block:: rst

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -82,7 +82,7 @@ Connection troubleshooting
 
 The majority of connection issues reported are typically configuration
 issues. For example, attempting to configure a Confluence Cloud API token
-using a configuration designed for a Confluence Server Personal Access
+using a configuration designed for a Confluence Data Center Personal Access
 Token (PAT).
 
 Users may try to invoke a connection test to help debug connection issues.

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -88,7 +88,7 @@ Next, include a series of publish-related settings to the configuration file:
     # (for Confluence Cloud)
     confluence_server_url = 'https://example.atlassian.net/wiki/'
     confluence_server_user = 'myawesomeuser@example.com'
-    # (or, for Confluence Server)
+    # (or, for Confluence Data Center)
     confluence_server_url = 'https://intranet-wiki.example.com/'
     confluence_server_user = 'myawesomeuser'
 


### PR DESCRIPTION
- doc: drop mention of setuptools error
- doc: cleanup rst_epilog to use f-string
- doc: add requests version management
- doc: add introduction page for pdfs
- doc: drop references to confluence server
- README.md: drop reference to confluence server
