### PR TITLE
.github: switch to doctest container (docs)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,45 +20,34 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
+    container: ghcr.io/sphinx-contrib/confluencebuilder/doctest:main
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-
-    - name: Cache pip
-      uses: actions/cache@v4
-      id: cache-pip
-      with:
-        path: ~/.cache/pip
-        key: docs-pip
-
-    - name: Install dependencies
+    - name: Install
       run: |
-        sudo apt-get update
-        sudo apt-get install \
-            latexmk \
-            texlive-latex-extra \
-            texlive-latex-recommended \
-            -y
-        sudo python -m pip install --upgrade sphinx
-
-    - name: Install confluencebuilder
-      run: |
-        sudo python -m pip install -e .
+        python -m venv venv
+        . venv/bin/activate
+        pip install -e .
 
     - name: HTML
-      run: make html
-      working-directory: doc
+      run: |
+        . venv/bin/activate
+        cd doc
+        make html
 
     - name: PDF
-      run: make latexpdf
-      working-directory: doc
+      run: |
+        . venv/bin/activate
+        cd doc
+        make latexpdf
 
     - name: Archive generated PDF
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: sphinxcontrib-confluencebuilder.pdf
         path: doc/_build/latex/sphinxconfluencebuilder.pdf


### PR DESCRIPTION
With a new container prepared to help speed up testing, use it for the document testing workflow.