### PR TITLE
.github: switch to doctest container (conf. publish test)

### DIFF
--- a/.github/workflows/confluence-publish-check.yml
+++ b/.github/workflows/confluence-publish-check.yml
@@ -28,7 +28,9 @@ on:
 
 jobs:
   build:
+    name: Generate
     runs-on: ubuntu-latest
+    container: ghcr.io/sphinx-contrib/confluencebuilder/doctest:main
 
     steps:
     - uses: actions/checkout@v4
@@ -37,23 +39,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ github.event.inputs.python }}
-
-    - name: Cache pip
-      uses: actions/cache@v4
-      id: cache-pip
-      with:
-        path: ~/.cache/pip
-        key: ubuntu-latest-${{ github.event.inputs.python }}-pip-
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get install \
-            dvipng \
-            graphviz \
-            texlive-latex-extra \
-            texlive-latex-recommended \
-            -y
-        python -m pip install --upgrade tox
 
     - name: tox
       env:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -58,7 +58,7 @@ class TestConfluenceValidation(unittest.TestCase):
         cls.config['manpages_url'] = 'https://example.org/{path}'
         cls.test_desc = os.getenv(TESTDESC_ENV_KEY, DEFAULT_TEST_DESC)
         cls.test_key = os.getenv(TESTKEY_ENV_KEY, DEFAULT_TEST_KEY)
-        cls.test_version = os.getenv(TESTKEY_ENV_KEY, DEFAULT_TEST_VERSION)
+        cls.test_version = os.getenv(TESTKEY_ENV_VERSION, DEFAULT_TEST_VERSION)
 
         # overrides from user
         try:


### PR DESCRIPTION
With a new container prepared to help speed up testing, use it for the Confluence publish testing workflow.