### PR TITLE
flag file/link transforms as deprecated

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1819,18 +1819,6 @@ Advanced processing configuration
 
         confluence_file_suffix = '.conf'
 
-    See also |confluence_file_transform|_.
-
-.. |confluence_file_transform| replace:: ``confluence_file_transform``
-.. _confluence_file_transform:
-
-.. confval:: confluence_file_transform
-
-    A function to override the translation of a document name to a filename. The
-    provided function is used to perform translations for both Sphinx's
-    get_outdated_docs_ and write_doc_ methods. The default translation will be
-    the combination of "``docname`` + |confluence_file_suffix|_".
-
 .. index:: Jira; Configuring Jira servers
 
 .. _confluence_jira_servers:
@@ -1959,18 +1947,6 @@ Advanced processing configuration
     .. code-block:: python
 
         confluence_link_suffix = '.conf'
-
-    See also |confluence_link_transform|_.
-
-.. |confluence_link_transform| replace:: ``confluence_link_transform``
-.. _confluence_link_transform:
-
-.. confval:: confluence_link_transform
-
-    A function to override the translation of a document name to a (partial)
-    URI. The provided function is used to perform translations for both Sphinx's
-    get_relative_uri_ method. The default translation will be the combination of
-    "``docname`` + |confluence_link_suffix|_".
 
 .. index:: Mentions; Configuration
 
@@ -2104,11 +2080,29 @@ Other options
 Deprecated options
 ------------------
 
+.. confval:: confluence_file_transform
+
+    .. versionchanged:: 2.6
+
+    A function to override the translation of a document name to a filename. The
+    provided function is used to perform translations for both Sphinx's
+    get_outdated_docs_ and write_doc_ methods. The default translation will be
+    the combination of "``docname`` + |confluence_file_suffix|_".
+
 .. confval:: confluence_lang_transform
 
     .. versionchanged:: 2.6
 
     This option has been replaced by |confluence_lang_overrides|_.
+
+.. confval:: confluence_link_transform
+
+    .. versionchanged:: 2.6
+
+    A function to override the translation of a document name to a (partial)
+    URI. The provided function is used to perform translations for both Sphinx's
+    get_relative_uri_ method. The default translation will be the combination of
+    "``docname`` + |confluence_link_suffix|_".
 
 .. confval:: confluence_master_homepage
 

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -18,6 +18,10 @@ DEPRECATED_CONFIGS = {
         'to be removed in a future version',
     'confluence_adv_writer_no_section_cap':
         'to be removed in a future version',
+    'confluence_file_transform':
+        'capability to be dropped (please report if required)',
+    'confluence_link_transform':
+        'capability to be dropped (please report if required)',
     'confluence_master_homepage':
         'use "confluence_root_homepage" instead',
     'confluence_max_doc_depth':

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -369,6 +369,10 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             self._try_config()
 
     def test_config_check_file_transform(self):
+        self.config['suppress_warnings'] = [
+            'confluence.deprecated',
+        ]
+
         def mock_transform(docname):
             return docname + '.conf'
 
@@ -548,6 +552,10 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self._try_config()
 
     def test_config_check_link_transform(self):
+        self.config['suppress_warnings'] = [
+            'confluence.deprecated',
+        ]
+
         def mock_transform(docname):
             return docname + '.conf'
 


### PR DESCRIPTION
The advanced overrides for tailoring file/link transformations existed since the start of this extension's life, but the options are not entirely useful* for end users. It is unknown if anyone has ever needed to override these options. In addition, setting them make a project's configuration unpicklable.

For now, will mark this options as deprecated. This will give time for users to report if these options are desired before the configuration options are removed from this extension.