### PR TITLE
.github: bump python version for sphinx-dev check

### DIFF
--- a/.github/workflows/sphinx-dev-check.yml
+++ b/.github/workflows/sphinx-dev-check.yml
@@ -11,7 +11,7 @@ on:
       python:
         description: 'Python interpreter'
         required: true
-        default: '3.11'
+        default: '3.12'
       sphinx:
         description: 'Sphinx Revision'
         required: true


### PR DESCRIPTION
Bumping the version of the default Python used for a Sphinx development check to Python v3.12 (to use the newest version by default).