### PR TITLE
Test against Sphinx 7.3.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,35 +39,34 @@ jobs:
       matrix:
         include:
             # test each python/sphinx pair supported
-            - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx61, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx62, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx70, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.8", toxenv:  py38-sphinx71, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx61, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx62, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx70, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx71, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx72, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx61, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python:  "3.9", toxenv:  py39-sphinx73, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx62, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx70, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx71, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx72, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx61, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx73, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx62, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx70, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx71, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx72, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx61, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx73, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx62, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx70, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx71, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx72, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx73, cache: ~/.cache/pip }
 
             # other OSes
             #  - test against all other supported OSes, using most recent interpreter/sphinx
-            - { os:   macos-latest, python: "3.12", toxenv: py312-sphinx72, cache: ~/Library/Caches/pip }
-            - { os: windows-latest, python: "3.12", toxenv: py312-sphinx72, cache: ~\AppData\Local\pip\Cache }
+            - { os:   macos-latest, python: "3.12", toxenv: py312-sphinx73, cache: ~/Library/Caches/pip }
+            - { os: windows-latest, python: "3.12", toxenv: py312-sphinx73, cache: ~\AppData\Local\pip\Cache }
 
             # linting
             #  - any OS, using most recent interpreter

--- a/tox.ini
+++ b/tox.ini
@@ -2,17 +2,17 @@
 envlist =
     ruff
     pylint
-    py38-sphinx{61,62,70,71}
-    py{39,310,311,312}-sphinx{61,62,70,71,72}
+    py38-sphinx{62,70,71}
+    py{39,310,311,312}-sphinx{62,70,71,72,73}
 
 [testenv]
 deps =
     -r{toxinidir}/requirements_dev.txt
-    sphinx61: sphinx>=6.1,<6.2
     sphinx62: sphinx>=6.2,<6.3
     sphinx70: sphinx>=7.0,<7.1
     sphinx71: sphinx>=7.1,<7.2
     sphinx72: sphinx>=7.2,<7.3
+    sphinx73: sphinx>=7.3,<7.4
 commands =
     {envpython} -m tests {posargs}
 setenv =


### PR DESCRIPTION
Sphinx provides a stable v7.3.x series; adjusting the tox configuration to support the new revision. Following maintenance guidelines, this allows a series of legacy Sphinx revisions to be dropped as well.

In addition, adjusting the automated building to invoke these accordingly.