### PR TITLE
publisher: correct v2 page updates with unset metadata

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1518,8 +1518,8 @@ class ConfluencePublisher:
         pending_new_labels = []
         pending_prop_requests = []
         if self.api_mode == 'v2':
-            orig_metadata = page.get('metadata', None)
-            update_metadata = update_page.pop('metadata', None)
+            orig_metadata = page.get('metadata', {})
+            update_metadata = update_page.pop('metadata', {})
 
             # configure parent page for this page update
             #


### PR DESCRIPTION
Correcting v2 API implementation recently introduced that incorrectly prepared metadata objects when Confluence does not report any metadata information for a page (which in turn results in `AttributeError` exceptions).