### PR TITLE
#975 - Replace /content? endpoint by /content/scan?

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -655,7 +655,8 @@ class ConfluencePublisher:
             params["cursor"] = cursor
 
         if self.api_mode == 'v2':
-            raise NotImplementedError("get_page_by_page_name is not supported in v2 API")
+            msg = "get_page_by_page_name is not supported in v2 API"
+            raise NotImplementedError(msg)
         rsp = self.rest.get(f'{self.APIV1}content/scan', params)
 
         if rsp['size'] != 0:
@@ -667,7 +668,7 @@ class ConfluencePublisher:
 
         if "nextCursor" in rsp:
             return self.get_page_by_page_name(
-                page_name=page_name, expand=expand, status=status, page_size=page_size, cursor=rsp["nextCursor"]
+                page_name=page_name, expand=expand, status=status, page_size=page_size, cursor=rsp["nextCursor"],
             )
         return None, None
 

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -550,13 +550,9 @@ class ConfluencePublisher:
                 'title': page_name,
             })
         else:
-            rsp = self.rest.get(f'{self.APIV1}content', {
-                'type': 'page',
-                'spaceKey': self.space_key,
-                'title': page_name,
-                'status': status,
-                'expand': expand,
-            })
+            # Workaround for https://jira.atlassian.com/browse/CONFSERVER-57639:
+            # Hitting the base Content API endpoint can cause performance problem for large instances
+            return self.get_page_by_page_name(page_name=page_name, expand=expand, status=status)
 
         if rsp['results']:
             page = rsp['results'][0]
@@ -638,6 +634,42 @@ class ConfluencePublisher:
             self._name_cache[page_id] = page['title']
 
         return page_id, page
+
+    def get_page_by_page_name(self, page_name, expand='version', status='current', page_size=3, cursor=None):
+        """
+        Workaround for https://jira.atlassian.com/browse/CONFSERVER-57639:
+        Hitting the base Content API endpoint can cause performance problem for large instances
+
+        For some companies the GET /content endpoint is blocked by IT, so we need to use /content/scan.
+        But scan does not support filtering by title, so we have to iterate through all the pages (with paging)
+        and find the page brute force.
+        """
+        params = {
+            'type': 'page',
+            'spaceKey': self.space_key,
+            'status': status,
+            'expand': expand,
+            'limit': page_size,
+        }
+        if cursor:
+            params["cursor"] = cursor
+
+        if self.api_mode == 'v2':
+            raise NotImplementedError("get_page_by_page_name is not supported in v2 API")
+        rsp = self.rest.get(f'{self.APIV1}content/scan', params)
+
+        if rsp['size'] != 0:
+            for page in rsp["results"]:
+                page_id = page['id']
+                self._name_cache[page_id] = page["title"]
+                if page["title"] == page_name:
+                    return page_id, page
+
+        if "nextCursor" in rsp:
+            return self.get_page_by_page_name(
+                page_name=page_name, expand=expand, status=status, page_size=page_size, cursor=rsp["nextCursor"]
+            )
+        return None, None
 
     def get_page_case_insensitive(self, page_name):
         """

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1279,6 +1279,13 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         # identifier value instead
         target = self.state.target(anchorname)
         if target:
+            # Johannes Loibl: If multiple anchors are generated for the same reference (e.g. when an explicit reference
+            # is placed directly before a heading, Sphinx will generate two anchors and increase the suffix counter,
+            # e.g. HEADING, HEADING.1, HEADING.2, ... . This leads to a wrong naming of the final anchor link,
+            # since the heading can only be accessed via the root name (HEADING in this case).
+            # So we have to strip off the number suffix
+            if "." in target:
+                target = target.split(".")[0]
             anchor_value = target
             anchor_value = self.encode(anchor_value)
         else:


### PR DESCRIPTION
Background: /content GET endpoint was blocked by our IT because it was causing a bug. Workaround: Use the /content/scan endpoint for searching pages. Since /scan does not support filtering for a page title, all pages have to be searched with pagination (sub-optimal, but our only option). See https://jira.atlassian.com/browse/CONFSERVER-57639

See issue #975