### PR TITLE
translator: support newer sphinxcontrib-video sources

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2854,7 +2854,11 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         autoplay = node.get('autoplay')
         height, hu = extract_length(node.get('height'))
         width, wu = extract_length(node.get('width'))
-        source_path, _ = node.get('primary_src') or (None, None)
+        if 'sources' in node:  # v0.2.1+
+            sources = node.get('sources', [])
+            source_path, _, _ = first(sources) or (None, None, None)
+        else:
+            source_path, _ = node.get('primary_src') or (None, None)
 
         if height:
             height = convert_length(height, hu)


### PR DESCRIPTION
Updating the translator to support sphinxcontrib-video's newer source tracking in a node (as of v0.2.1; [1]). For now, we will grab the first entry in the sources list as the source to use. This can be reworked later if a use case arises.

\[1\]: https://github.com/sphinx-contrib/video/commit/959aeff41240ddb75955137fda45c9cce9d0bb8f