### PR TITLE
Update linters

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,6 +2,11 @@ lint.select = [
     'ALL',
 ]
 
+lint.exclude = [
+    # exclude any hello/sample scripts
+    'Hello.py',
+]
+
 lint.ignore = [
     # we do not type annotate everything at this time
     'ANN',

--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -82,7 +82,7 @@ class ConfluenceAssetManager:
         Returns:
             the key, document name and path
         """
-        logger.verbose('adding manual attachment: %s' % path)
+        logger.verbose(f'adding manual attachment: {path}')
         abs_path = find_env_abspath(self.env, self.out_dir, path)
         return self._handle_entry(abs_path, docname, standalone=True)
 
@@ -219,7 +219,7 @@ class ConfluenceAssetManager:
 
         target = node['reftarget']
         if target.find('://') == -1:
-            logger.verbose('process file node: %s' % target)
+            logger.verbose(f'process file node: {target}')
             path = self._interpret_asset_path(node)
             if path:
                 return self._handle_entry(path, docname, standalone)
@@ -245,7 +245,7 @@ class ConfluenceAssetManager:
 
         uri = str(node['uri'])
         if not uri.startswith('data:') and uri.find('://') == -1:
-            logger.verbose('process image node: %s' % uri)
+            logger.verbose(f'process image node: {uri}')
             path = self._interpret_asset_path(node)
             if path:
                 return self._handle_entry(path, docname, standalone)
@@ -344,7 +344,7 @@ class ConfluenceAssetManager:
         abs_path = find_env_abspath(self.env, self.out_dir, path)
 
         if not abs_path:
-            logger.verbose('failed to find path: %s' % path)
+            logger.verbose(f'failed to find path: {path}')
 
         return abs_path
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -513,7 +513,7 @@ def validate_configuration(builder):
     # ##################################################################
 
     # confluence_publish_debug
-    opts = PublishDebug._member_names_  # noqa: SLF001 pylint: disable=no-member
+    opts = PublishDebug._member_names_  # pylint: disable=no-member
     try:
         validator.conf('confluence_publish_debug').bool()  # deprecated
     except ConfluenceConfigError:

--- a/sphinxcontrib/confluencebuilder/config/env.py
+++ b/sphinxcontrib/confluencebuilder/config/env.py
@@ -31,7 +31,7 @@ def apply_env_overrides(builder):
         env_key = key.upper()
         env_val = os.getenv(env_key)
         if env_val:
-            logger.verbose('accepting configuration from env: %s' % env_val)
+            logger.verbose(f'accepting configuration from env: {env_val}')
 
             if key in config_manager.options_bool:
                 conf[key] = str2bool(env_val)

--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -121,8 +121,8 @@ class ConfluenceLogger:
         try:
             trace_file = Path('trace.log')
             with trace_file.open('a', encoding='utf-8') as file:
-                file.write('[%s]\n' % container)
+                file.write(f'[{container}]\n')
                 file.write(data)
                 file.write('\n')
         except OSError as err:
-            ConfluenceLogger.warn('unable to trace: %s' % err)
+            ConfluenceLogger.warn(f'unable to trace: {err}')

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -199,7 +199,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
         secnumbers = self.env.toc_secnumbers.get(self.config.root_doc, {})
 
         docref_set = False
-        doc_anchorname = '%s/' % docname
+        doc_anchorname = f'{docname}/'
         root_section = None
         title_node = self._find_title_element(doctree)
         if title_node:
@@ -216,7 +216,7 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
 
                         anchorname = f'{docname}/#{id_}'
                         if anchorname not in secnumbers:
-                            anchorname = '%s/' % id_
+                            anchorname = f'{id_}/'
 
                         if self.add_secnumbers:
                             secnumber = secnumbers.get(anchorname)

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -92,9 +92,9 @@ class ConfluenceState:
             base_tail += postfix
 
         if len(title) + len(base_tail) > try_max:
-            warning = 'document title has been trimmed due to length: %s' % title
+            warning = f'document title has been trimmed due to length: {title}'
             if len(base_tail) > 0:
-                warning += '; With postfix: %s' % base_tail
+                warning += f'; With postfix: {base_tail}'
             logger.warn(warning)
             title = title[0:try_max - len(base_tail)]
 

--- a/sphinxcontrib/confluencebuilder/svg.py
+++ b/sphinxcontrib/confluencebuilder/svg.py
@@ -73,7 +73,7 @@ def confluence_supported_svg(builder, node):
         with abs_path.open('rb') as f:
             svg_data = f.read()
     except OSError as err:
-        builder.warn('error reading svg: %s' % err)
+        builder.warn(f'error reading svg: {err}')
         return
 
     modified = False
@@ -196,7 +196,7 @@ def confluence_supported_svg(builder, node):
 
     # write the new svg file (if needed)
     if not out_file.is_file():
-        logger.verbose('generating compatible svg of: %s' % uri)
+        logger.verbose(f'generating compatible svg of: {uri}')
         logger.verbose(f'generating compatible svg to: {out_file}')
 
         out_file.parent.mkdir(parents=True, exist_ok=True)
@@ -204,7 +204,7 @@ def confluence_supported_svg(builder, node):
             with out_file.open('wb') as f:
                 f.write(svg_data)
         except OSError as err:
-            builder.warn('error writing svg: %s' % err)
+            builder.warn(f'error writing svg: {err}')
             return
 
     # replace the required node attributes

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -272,7 +272,7 @@ def replace_inheritance_diagram(builder, doctree):
         graph = node['graph']
 
         graph_hash = inheritance_diagram.get_graph_hash(node)
-        name = 'inheritance%s' % graph_hash
+        name = f'inheritance{graph_hash}'
 
         dotcode = graph.generate_dot(name, {}, env=builder.env)
 

--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
+from contextlib import suppress
 from docutils import nodes
 from sphinx.util.math import wrap_displaymath
 from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
@@ -32,11 +33,10 @@ except ImportError:
     imgmath = None
 
 # load inheritance_diagram extension if available to handle node pre-processing
+inheritance_diagram = None
 if graphviz:
-    try:
+    with suppress(ImportError):
         from sphinx.ext import inheritance_diagram
-    except ImportError:
-        inheritance_diagram = None
 
 
 def doctree_transmute(builder, doctree):

--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_diagrams.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_diagrams.py
@@ -67,6 +67,5 @@ def replace_sphinx_diagrams_nodes(builder, doctree):
 
             node.replace_self(new_container)
         except DiagramsError as exc:
-            ConfluenceLogger.warn(
-                'diagrams code %r: ' % node['code'] + str(exc))
+            ConfluenceLogger.warn('diagrams code %r: %s', node['code'], exc)
             node.parent.remove(node)

--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinxcontrib_mermaid.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinxcontrib_mermaid.py
@@ -67,5 +67,5 @@ def replace_sphinxcontrib_mermaid_nodes(builder, doctree):
                 new_node['align'] = node['align']
             node.replace_self(new_node)
         except MermaidError as exc:
-            ConfluenceLogger.warn('mermaid code %r: ' % node['code'] + str(exc))
+            ConfluenceLogger.warn('mermaid code %r: %s', node['code'], exc)
             node.parent.remove(node)

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ usedevelop = false
 [testenv:pylint]
 deps =
     {[testenv]deps}
-    pylint
+    pylint: pylint==3.2.3
 commands =
     pylint \
     sphinxcontrib \
@@ -58,7 +58,7 @@ commands =
 [testenv:ruff]
 deps =
     {[testenv]deps}
-    ruff: ruff==0.3.4
+    ruff: ruff==0.4.8
 setenv =
     {[testenv]setenv}
     RUFF_CACHE_DIR={toxworkdir}/.ruff_cache


### PR DESCRIPTION
- tox: bump linter versions
- drop use of older percent format
- remove no longer required sfl001 check
- transmute: ensure inheritance_diagram is set
- lint: exclude example/test assets in ruff