### PR TITLE
translator: print additional unknown-node feedback

### DIFF
--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -165,7 +165,12 @@ class ConfluenceBaseTranslator(BaseTranslator):
             handler[node_name](self, node)
             raise nodes.SkipNode
 
-        self.warn('unknown node: ' + node_name)
+        if node.source:
+            lpf = f'#{node.line}' if node.line else ''
+            self.warn(f'unknown node {node_name}: {node.source}{lpf}')
+        else:
+            self.warn(f'unknown node {node_name}: {self.docname}')
+
         raise nodes.SkipNode
 
     # ---------


### PR DESCRIPTION
When an unknown node is detected by this extension, attempt to print the document as well as the line number where the issue has occurred. This should provide users a better understanding where the origin of an unknown node occurs.