### PR TITLE
tests: updating various bs4 calls

### DIFF
--- a/tests/unit-tests/test_config_header_footer.py
+++ b/tests/unit-tests/test_config_header_footer.py
@@ -28,10 +28,10 @@ class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
             self.assertIsNotNone(body)
             self.assertEqual(body.text, 'body content')
 
-            header_data = body.previousSibling.strip()
+            header_data = body.previous_sibling.strip()
             self.assertEqual(header_data, 'header content')
 
-            footer_data = body.nextSibling.strip()
+            footer_data = body.next_sibling.strip()
             self.assertEqual(footer_data, 'footer content')
 
     @setup_builder('confluence')
@@ -47,10 +47,10 @@ class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
             self.assertIsNotNone(body)
             self.assertEqual(body.text, 'body content')
 
-            header_data = body.previousSibling.strip()
+            header_data = body.previous_sibling.strip()
             self.assertEqual(header_data, 'header content')
 
-            footer_data = body.nextSibling.strip()
+            footer_data = body.next_sibling.strip()
             self.assertEqual(footer_data, 'footer content')
 
     @setup_builder('confluence')
@@ -72,8 +72,8 @@ class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
             self.assertIsNotNone(body)
             self.assertEqual(body.text, 'body content')
 
-            header_data = body.previousSibling.strip()
+            header_data = body.previous_sibling.strip()
             self.assertEqual(header_data, 'header content header_value')
 
-            footer_data = body.nextSibling.strip()
+            footer_data = body.next_sibling.strip()
             self.assertEqual(footer_data, 'footer content footer_value')

--- a/tests/unit-tests/test_rst_attribution.py
+++ b/tests/unit-tests/test_rst_attribution.py
@@ -28,5 +28,5 @@ class TestConfluenceRstAttribution(ConfluenceTestCase):
             quote_sep = quote.find('br')
             self.assertIsNotNone(quote_sep)
 
-            quote_source = quote_sep.nextSibling.strip()
+            quote_source = quote_sep.next_sibling.strip()
             self.assertEqual(quote_source, '— source')

--- a/tests/unit-tests/test_rst_citations.py
+++ b/tests/unit-tests/test_rst_citations.py
@@ -38,9 +38,8 @@ class TestConfluenceRstCitations(ConfluenceTestCase):
             self.assertEqual(link_body.text, '[CIT01]')
 
             # leader anchor back to this citation a
-            anchor_tag = container.find_previous_sibling()
+            anchor_tag = container.find_previous_sibling('ac:structured-macro')
             self.assertIsNotNone(anchor_tag)
-            self.assertEqual(anchor_tag.name, 'ac:structured-macro')
             self.assertTrue(anchor_tag.has_attr('ac:name'))
             self.assertEqual(anchor_tag['ac:name'], 'anchor')
 
@@ -61,9 +60,8 @@ class TestConfluenceRstCitations(ConfluenceTestCase):
             self.assertEqual(link_body.text, '[CIT02]')
 
             # leader anchor back to this citation b
-            anchor_tag = container.find_previous_sibling()
+            anchor_tag = container.find_previous_sibling('ac:structured-macro')
             self.assertIsNotNone(anchor_tag)
-            self.assertEqual(anchor_tag.name, 'ac:structured-macro')
             self.assertTrue(anchor_tag.has_attr('ac:name'))
             self.assertEqual(anchor_tag['ac:name'], 'anchor')
 

--- a/tests/unit-tests/test_rst_epigraph.py
+++ b/tests/unit-tests/test_rst_epigraph.py
@@ -28,5 +28,5 @@ class TestConfluenceRstEpigraph(ConfluenceTestCase):
             quote_sep = quote.find('br')
             self.assertIsNotNone(quote_sep)
 
-            quote_source = quote_sep.nextSibling.strip()
+            quote_source = quote_sep.next_sibling.strip()
             self.assertEqual(quote_source, '— source')

--- a/tests/unit-tests/test_rst_figure.py
+++ b/tests/unit-tests/test_rst_figure.py
@@ -159,9 +159,12 @@ class TestConfluenceRstFigure(ConfluenceTestCase):
             # trailing caption/etc. is aligned under the figure's image
             images = data.find_all('ac:image')
             for image in images:
-                next_tag = image.find_next_sibling()
+                # captaion paragraph with a float hint
+                next_tag = image.find_next_sibling('p')
+
+                # or, a trailing div with a float hint
                 if not next_tag:
-                    next_tag = image.parent.find_next_sibling()
+                    next_tag = image.parent.find_next_sibling('div')
 
                 self.assertIsNotNone(next_tag)
                 self.assertTrue(next_tag.has_attr('style'))

--- a/tests/unit-tests/test_rst_footnotes.py
+++ b/tests/unit-tests/test_rst_footnotes.py
@@ -38,9 +38,8 @@ class TestConfluenceRstFootnotes(ConfluenceTestCase):
             self.assertEqual(link_body.text, '[1]')
 
             # leader anchor back to this footnote a
-            anchor_tag = container.find_previous_sibling()
+            anchor_tag = container.find_previous_sibling('ac:structured-macro')
             self.assertIsNotNone(anchor_tag)
-            self.assertEqual(anchor_tag.name, 'ac:structured-macro')
             self.assertTrue(anchor_tag.has_attr('ac:name'))
             self.assertEqual(anchor_tag['ac:name'], 'anchor')
 
@@ -61,9 +60,8 @@ class TestConfluenceRstFootnotes(ConfluenceTestCase):
             self.assertEqual(link_body.text, '[3]')  # 3 since 2 was used
 
             # leader anchor back to this footnote b
-            anchor_tag = container.find_previous_sibling()
+            anchor_tag = container.find_previous_sibling('ac:structured-macro')
             self.assertIsNotNone(anchor_tag)
-            self.assertEqual(anchor_tag.name, 'ac:structured-macro')
             self.assertTrue(anchor_tag.has_attr('ac:name'))
             self.assertEqual(anchor_tag['ac:name'], 'anchor')
 
@@ -84,9 +82,8 @@ class TestConfluenceRstFootnotes(ConfluenceTestCase):
             self.assertEqual(link_body.text, '[2]')
 
             # leader anchor back to this footnote 3
-            anchor_tag = container.find_previous_sibling()
+            anchor_tag = container.find_previous_sibling('ac:structured-macro')
             self.assertIsNotNone(anchor_tag)
-            self.assertEqual(anchor_tag.name, 'ac:structured-macro')
             self.assertTrue(anchor_tag.has_attr('ac:name'))
             self.assertEqual(anchor_tag['ac:name'], 'anchor')
 

--- a/tests/unit-tests/test_rst_highlights.py
+++ b/tests/unit-tests/test_rst_highlights.py
@@ -28,5 +28,5 @@ class TestConfluenceRstHighlights(ConfluenceTestCase):
             quote_sep = quote.find('br')
             self.assertIsNotNone(quote_sep)
 
-            quote_source = quote_sep.nextSibling.strip()
+            quote_source = quote_sep.next_sibling.strip()
             self.assertEqual(quote_source, '— source')

--- a/tests/unit-tests/test_rst_pull_quote.py
+++ b/tests/unit-tests/test_rst_pull_quote.py
@@ -28,5 +28,5 @@ class TestConfluenceConfigHeaderFooter(ConfluenceTestCase):
             quote_sep = quote.find('br')
             self.assertIsNotNone(quote_sep)
 
-            quote_source = quote_sep.nextSibling.strip()
+            quote_source = quote_sep.next_sibling.strip()
             self.assertEqual(quote_source, '— source')

--- a/tests/unit-tests/test_rst_targets.py
+++ b/tests/unit-tests/test_rst_targets.py
@@ -30,10 +30,10 @@ class TestConfluenceRstTargets(ConfluenceTestCase):
             self.assertEqual(anchor_param.text, 'inline-target')
 
             # before and after text
-            before_data = anchor_tag.previousSibling.strip()
+            before_data = anchor_tag.previous_sibling.strip()
             self.assertEqual(before_data, 'An')
 
-            trailing_data = anchor_tag.nextSibling.strip()
+            trailing_data = anchor_tag.next_sibling .strip()
             self.assertEqual(trailing_data, 'inline target example.')
 
     @setup_builder('confluence')
@@ -53,5 +53,5 @@ class TestConfluenceRstTargets(ConfluenceTestCase):
             self.assertEqual(anchor_param.text, 'inline-target')
 
             # before text
-            before_data = anchor_tag.previousSibling.strip()
+            before_data = anchor_tag.previous_sibling.strip()
             self.assertEqual(before_data, 'An')

--- a/tests/unit-tests/test_sdoc_genindex.py
+++ b/tests/unit-tests/test_sdoc_genindex.py
@@ -96,10 +96,12 @@ class TestSdocGenindex(ConfluenceTestCase):
         out_dir = self.build(dataset, config=config)
 
         with parse('genindex', out_dir) as data:
-            header_data = data.find().previousSibling.strip()
+            self.assertIsNotNone(data.contents)
+
+            header_data = data.contents[0].strip()
             self.assertEqual(header_data, 'header content')
 
-            footer_data = data.find_all(recursive=False)[-1].nextSibling.strip()
+            footer_data = data.contents[-1].strip()
             self.assertEqual(footer_data, 'footer content')
 
     @setup_builder('confluence')

--- a/tests/unit-tests/test_sdoc_modindex.py
+++ b/tests/unit-tests/test_sdoc_modindex.py
@@ -106,8 +106,10 @@ class TestSdocModindex(ConfluenceTestCase):
         out_dir = self.build(dataset, config=config)
 
         with parse('py-modindex', out_dir) as data:
-            header_data = data.find().previousSibling.strip()
+            self.assertIsNotNone(data.contents)
+
+            header_data = data.contents[0].strip()
             self.assertEqual(header_data, 'header content')
 
-            footer_data = data.find_all(recursive=False)[-1].nextSibling.strip()
+            footer_data = data.contents[-1].strip()
             self.assertEqual(footer_data, 'footer content')

--- a/tests/unit-tests/test_sdoc_search.py
+++ b/tests/unit-tests/test_sdoc_search.py
@@ -74,10 +74,12 @@ class TestSdocSearch(ConfluenceTestCase):
         out_dir = self.build(dataset, config=config)
 
         with parse('search', out_dir) as data:
-            header_data = data.find().previousSibling.strip()
+            self.assertIsNotNone(data.contents)
+
+            header_data = data.contents[0].strip()
             self.assertEqual(header_data, 'header content')
 
-            footer_data = data.find_all(recursive=False)[-1].nextSibling.strip()
+            footer_data = data.contents[-1].strip()
             self.assertEqual(footer_data, 'footer content')
 
     @setup_builder('confluence')

--- a/tests/unit-tests/test_sphinx_toctree.py
+++ b/tests/unit-tests/test_sphinx_toctree.py
@@ -16,7 +16,7 @@ class TestConfluenceSphinxToctree(ConfluenceTestCase):
             root_toc = data.find('ul', recursive=False)
             self.assertIsNotNone(root_toc)
 
-            caption = root_toc.findPrevious()
+            caption = root_toc.find_previous_sibling('p')
             self.assertIsNotNone(caption)
             self.assertEqual(caption.text, 'toctree caption')
 


### PR DESCRIPTION
Beautiful Soup had deprecated various next/previous calls for some time. For example, switching from `nextSibling` to `next_sibling`. This commit drops the use of various deprecated calls for new ones.

In addition, there are cases where calls like `find_previous_sibling` appear to have changed between recent versions. These calls will find the next tag or navigable string, although some older use cases look to not detect a navigable string compared to new versions. Updating these calls to be a bit more explicit in tag searching, as well as relying on alternative means to inspect content.