### PR TITLE
translator: avoid creating duplicate anchors

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -211,6 +211,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
     def visit_title(self, node):
         if isinstance(node.parent, (nodes.section, nodes.topic)):
+            new_targets = []
+
             self.body.append(
                 self.start_tag(node, f'h{self._title_level}'))
 
@@ -226,8 +228,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
                 for anchor in node.parent['names']:
                     target_name = f'{self.docname}#{anchor}'
                     target = self.state.target(target_name)
-                    if target:
+                    if target and target not in new_targets:
                         self._build_anchor(node, target)
+                        new_targets.append(target)
 
             # For MyST sections with an auto-generated slug, we will use this
             # slug to build an anchor target for anchor links defined in a
@@ -236,8 +239,9 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if slug:
                 target_name = f'{self.docname}#{slug}'
                 target = self.state.target(target_name)
-                if target:
+                if target and target not in new_targets:
                     self._build_anchor(node, target)
+                    new_targets.append(target)
 
             self.add_secnumber(node)
             self.add_fignumber(node.parent)


### PR DESCRIPTION
When building title anchors, the title node will look at assigned name references to build anchors. Before building an anchor, the target will be resolved for the case of special targets (e.g. references to headers which use a Confluence-generated anchor target). In some scenarios, a resolved reference may repeat the same target anchor to create. This commit tweaks the process to avoid creating additional anchors of the same name, if an anchor was already created for the title node.