### PR TITLE
Refactor Cloud detection logic

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -36,6 +36,7 @@ from sphinxcontrib.confluencebuilder.storage.search import generate_storage_form
 from sphinxcontrib.confluencebuilder.storage.translator import ConfluenceStorageFormatTranslator
 from sphinxcontrib.confluencebuilder.transmute import doctree_transmute
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
+from sphinxcontrib.confluencebuilder.util import detect_cloud
 from sphinxcontrib.confluencebuilder.util import extract_strings_from_file
 from sphinxcontrib.confluencebuilder.util import first
 from sphinxcontrib.confluencebuilder.util import handle_cli_file_subset
@@ -141,7 +142,7 @@ class ConfluenceBuilder(Builder):
 
         # detect if Confluence Cloud if using the Atlassian domain
         if new_url:
-            self.cloud = new_url.endswith('.atlassian.net/wiki/')
+            self.cloud = detect_cloud(new_url)
 
         self.assets = ConfluenceAssetManager(config, self.env, self.out_dir)
         self.writer = ConfluenceWriter(self)

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -24,6 +24,7 @@ from sphinxcontrib.confluencebuilder.rest import Rest
 from sphinxcontrib.confluencebuilder.std.confluence import API_REST_V1
 from sphinxcontrib.confluencebuilder.std.confluence import API_REST_V2
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
+from sphinxcontrib.confluencebuilder.util import detect_cloud
 import json
 import logging
 import time
@@ -65,6 +66,11 @@ class ConfluencePublisher:
         prefix_overrides = config.confluence_publish_override_api_prefix or {}
         self.APIV1 = prefix_overrides.get('v1', f'{API_REST_V1}/')
         self.APIV2 = prefix_overrides.get('v2', f'{API_REST_V2}/')
+
+        # if a default cloud value is provided, attempt to detect the cloud
+        # type
+        if cloud is None:
+            self.cloud = detect_cloud(config.confluence_server_url)
 
         # determine api mode to use
         # - if an explicit api mode is configured, use it

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -8,6 +8,7 @@ from sphinxcontrib.confluencebuilder.std.confluence import API_REST_V2
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_SIZE
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_X_HEIGHT
 from hashlib import sha256
+from urllib.parse import urlparse
 import getpass
 import os
 import re
@@ -137,6 +138,33 @@ def convert_length(value, unit, pct=True):
         return None
 
     return int(round(fvalue))
+
+
+def detect_cloud(site):
+    """
+    attempt to detect if the site is a cloud or data center instance
+
+    Returns whether the provided site is most likely either a Confluence
+    Cloud or Confluence Data Server instance.
+
+    Args:
+        site: the configured site value
+
+    Returns:
+        whether it is believed the site is a cloud instance
+    """
+
+    is_cloud = False
+
+    try:
+        parsed = urlparse(site)
+    except ValueError:
+        pass
+    else:
+        if parsed.hostname and parsed.hostname.endswith('atlassian.net'):
+            is_cloud = True
+
+    return is_cloud
 
 
 def extract_length(value):

--- a/tests/unit-tests/test_util_detect_cloud.py
+++ b/tests/unit-tests/test_util_detect_cloud.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from sphinxcontrib.confluencebuilder.util import detect_cloud
+import unittest
+
+
+class TestConfluenceUtilDetectCloud(unittest.TestCase):
+    def test_util_detect_cloud(self):
+        self.assertTrue(detect_cloud('https://ex.atlassian.net/wiki/'))
+        self.assertTrue(detect_cloud('https://ex.atlassian.net:443/wiki/'))
+        self.assertFalse(detect_cloud('https://www.example.org/wiki/'))
+        self.assertFalse(detect_cloud('https://www.example.org:443/wiki/'))


### PR DESCRIPTION
Refactor the logic related to attempts to detect a Confluence Cloud instance from the configured site URL. Changes improve handling situations if a port was explicitly configured on the instance and also allows Cloud-detection logic to apply to other builds (e.g. the connection test utility).