### PR TITLE
redact authorization header in debug bumps

### DIFF
--- a/sphinxcontrib/confluencebuilder/debug.py
+++ b/sphinxcontrib/confluencebuilder/debug.py
@@ -20,8 +20,11 @@ class PublishDebug(Flag):
     none = auto()
     # logs warnings when confluence reports a deprecated api call
     deprecated = auto()
-    # log raw requests/responses in stdout with header data
+    # log raw requests/responses in stdout with header data (redacted auth)
     headers = auto()
+    # log raw requests/responses in stdout with header data (no redactions)
+    _headers_raw = auto()
+    headers_raw = headers | _headers_raw
     # log urllib3-supported debug messages
     urllib3 = auto()
     # enable all logging


### PR DESCRIPTION
When a user has configured logging for `headers`, this will print a series of raw headers to the configured standard output stream. This is primarily to help aid in debugging and development scenarios. To help avoid situations where users may want to share the authorization header, force redact the header's value when printing.

This commit also introduces the option `headers_raw` to allow advanced users to dump the raw header value with no redaction, if ever needed.