### PR TITLE
Add support for logging request/response body data

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1519,6 +1519,10 @@ Advanced publishing configuration
 
         Switched from boolean to string for setting new debugging options.
 
+    .. versionchanged:: 2.6
+
+        Introduce the ``headers_and_data`` option.
+
     .. warning::
 
         Enabling certain debugging options may reveal information such as
@@ -1537,6 +1541,7 @@ Advanced publishing configuration
     - ``deprecated``: Log warnings when a deprecated API call is used
       (*for development purposes*).
     - ``headers``: Log requests and responses, including their headers.
+    - ``headers_and_data``: Log header data along with request/response bodies.
     - ``urllib3``: Enable urllib3 library debugging messages.
 
     An example debugging configuration is as follows:

--- a/sphinxcontrib/confluencebuilder/debug.py
+++ b/sphinxcontrib/confluencebuilder/debug.py
@@ -18,16 +18,20 @@ class PublishDebug(Flag):
 
     # do not perform any logging
     none = auto()
+    # log raw requests/responses in stdout with body data
+    data = auto()
     # logs warnings when confluence reports a deprecated api call
     deprecated = auto()
     # log raw requests/responses in stdout with header data (redacted auth)
     headers = auto()
+    # log both header and body data
+    headers_and_data = headers | data
     # log raw requests/responses in stdout with header data (no redactions)
     _headers_raw = auto()
     headers_raw = headers | _headers_raw
     # log urllib3-supported debug messages
     urllib3 = auto()
     # enable all logging
-    all = headers | urllib3
+    all = data | headers | urllib3
     # enable all developer logging
     developer = deprecated | all


### PR DESCRIPTION
Extend the logging capabilities for publish events to support logging the contents of body data for requests and responses. This adds the `headers_and_data` option to hint to have both headers and their content (if printable content).