### PR TITLE
provide advanced option for cloud mode override

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -243,6 +243,8 @@ def setup(app):
     # (configuration - undocumented)
     # Enablement for bulk archiving of packages (for premium environments).
     cm.add_conf_bool('confluence_adv_bulk_archiving')
+    # Force override for detected Cloud state.
+    cm.add_conf_bool('confluence_adv_cloud')
     # Disable workaround for: https://jira.atlassian.com/browse/CONFCLOUD-74698
     cm.add_conf_bool('confluence_adv_disable_confcloud_74698')
     # Disable any attempts to initialize this extension's custom entities.

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -140,8 +140,10 @@ class ConfluenceBuilder(Builder):
             self.warn(f'normalizing confluence url from {old_url} to {new_url}')
             self.config.confluence_server_url = new_url
 
-        # detect if Confluence Cloud if using the Atlassian domain
-        if new_url:
+        # track if operating with a Confluence Cloud target
+        if self.config.confluence_adv_cloud is not None:
+            self.cloud = self.config.confluence_adv_cloud
+        else:
             self.cloud = detect_cloud(new_url)
 
         self.assets = ConfluenceAssetManager(config, self.env, self.out_dir)

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -70,7 +70,10 @@ class ConfluencePublisher:
         # if a default cloud value is provided, attempt to detect the cloud
         # type
         if cloud is None:
-            self.cloud = detect_cloud(config.confluence_server_url)
+            if config.confluence_adv_cloud is not None:
+                self.cloud = config.confluence_adv_cloud
+            else:
+                self.cloud = detect_cloud(config.confluence_server_url)
 
         # determine api mode to use
         # - if an explicit api mode is configured, use it


### PR DESCRIPTION
While Cloud detection is handled through an Atlassian-detected site value, adding a hidden option to allow forcing the Cloud mode for a run. This is to be proactive, just in case the check does not operate as expected and users need a workaround for a corner case.