### PR TITLE
rest: only attempt to json-dump json data

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -434,10 +434,14 @@ class Rest:
 
             if dump_body and req.body:
                 print('(debug) Request data]')
-                try:
-                    json_data = json.dumps(json.loads(req.body), indent=2)
-                    print(json_data)
-                except TypeError:
+                content_type = req.headers.get('Content-Type') or ''
+                if content_type == 'application/json;charset=utf-8':
+                    try:
+                        json_data = json.dumps(json.loads(req.body), indent=2)
+                        print(json_data)
+                    except TypeError:
+                        print('(bad-json)')
+                else:
                     print('(non-json)')
                 print('', flush=True)
 


### PR DESCRIPTION
When configured to dump request body data, the log attempt may fail when trying to process non-JSON data (e.g. attachments). Adjust the debugging call to verify that the request is JSON data before attempting to print.