### PR TITLE
publisher: force delay on new-page properties update on cloud

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1106,6 +1106,13 @@ class ConfluencePublisher:
 
                     uploaded_page_id = rsp['id']
 
+                    # always wait a little moment before updating properies on
+                    # cloud -- it seems to take a moment to complete creating
+                    # initial properties after we build a new page, and we want
+                    # to avoid a conflict (409) if possible
+                    if self.cloud:
+                        time.sleep(0.5)
+
                     # we have properties we would like to apply, but we cannot
                     # just create new ones if Confluence already created ones
                     # implicitly in the new page update -- we will need to


### PR DESCRIPTION
In almost every medium/large documentation sets publishing on Confluence Cloud reports a properties publish error every tens/hundreds of published documents. While retries exist to help publishers, it would be nice to avoid having these situations. To help prevent this error state from occurring, always add a 1/2 second delay on new Confluence Cloud page updates. This appears to help reduce the error state (based on limited testing).