### PR TITLE
config: configure notifications to default off

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -883,9 +883,11 @@ Publishing configuration
 
 .. confval:: confluence_disable_notifications
 
+    .. versionchanged:: 2.6 Option is enabled by default.
+
     A boolean value which explicitly disables any page update notifications
     (i.e. treats page updates from a publish request as minor updates). By
-    default, notifications are enabled with a value of ``False``.
+    default, notifications are disabled with a value of ``True``.
 
     .. code-block:: python
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -62,6 +62,9 @@ def apply_defaults(builder):
         if not isinstance(conf.confluence_client_cert, tuple):
             conf.confluence_client_cert = (conf.confluence_client_cert, None)
 
+    if conf.confluence_disable_notifications is None:
+        conf.confluence_disable_notifications = True
+
     if conf.confluence_editor is None:
         conf.confluence_editor = DEFAULT_EDITOR
 


### PR DESCRIPTION
As this extension has evolved over the years, the option `confluence_disable_notifications` was introduced to help suppress multiple notifications generated from publishing events. At the time of introduction, the feature was not enabled by default since it did result in changing page requests made and there was not an immediate desire to change the default state of things.

Consider the common application of this extension, most users may not expect notifications to be generated for automated publish events. To make things easier for installations, we are changing the default mode of this extension to suppress page notifications. Users who prefer to have notification events generated are now recommended to explicitly configure the option.