### PR TITLE
Adding confluence publish point event

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+# Copyright 2024 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 
 from docutils import nodes
 from sphinx.domains.std import StandardDomain
 from sphinx.ext.autodoc import cut_lines
 from sphinx.roles import XRefRole
 from sphinx.transforms.post_transforms import SphinxPostTransform
+from sphinx.util.docfields import GroupedField
 import sphinxcontrib.confluencebuilder
 
 project = 'Sphinx Confluence Builder'
@@ -184,10 +186,15 @@ def setup(app):
     app.add_role('lref', LiteralReferenceRole())
 
     # custom directives/roles for documentation
+    fdesc = GroupedField(
+        'parameter', label='Parameters', names=['param'], can_collapse=True)
+
     app.add_object_type('builderval', 'builderval', objname='builders',
-        indextemplate='pair: %s; builder')
+        indextemplate='pair: %s; Builder')
     app.add_object_type('confval', 'confval', objname='configuration value',
-        indextemplate='pair: %s; configuration value')
+        indextemplate='pair: %s; Configuration value')
+    app.add_object_type('event', 'event', objname='events',
+        indextemplate='pair: %s; Event', doc_field_types=[fdesc])
 
     # register post-transformation hook for additional tweaks
     app.add_post_transform(DocumentationPostTransform)

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -25,6 +25,7 @@ Documentation contents
     builders
     directives
     roles
+    events
 
 .. toctree::
     :maxdepth: 2

--- a/doc/events.rst
+++ b/doc/events.rst
@@ -1,0 +1,18 @@
+Events
+======
+
+The following outlines additional `events`_ supported by this extension.
+
+.. event:: confluence-publish-point (app, point_url)
+
+   :param app: :class:`.Sphinx`
+   :param point_url: ``str`` of the publish point URL
+
+   Emitted when this extension prints the "publish point" URL to the
+   standard output stream.
+
+   .. versionadded:: 2.6
+
+.. references ------------------------------------------------------------------
+
+.. _events: https://www.sphinx-doc.org/en/master/extdev/event_callbacks.html

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -57,6 +57,7 @@ def setup(app):
     app.add_builder(ConfluenceBuilder)
     app.add_builder(ConfluenceReportBuilder)
     app.add_builder(SingleConfluenceBuilder)
+    app.add_event('confluence-publish-point')
     app.add_post_transform(ConfluenceHyperlinkCollector)
 
     # register this extension's locale

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -679,14 +679,17 @@ class ConfluenceBuilder(Builder):
                     self.info('done')
 
             if self.cloud:
-                point_url = '{0}spaces/{1}/pages/{2}'
+                point_url_fmt = '{0}spaces/{1}/pages/{2}'
             else:
-                point_url = '{0}pages/viewpage.action?pageId={2}'
+                point_url_fmt = '{0}pages/viewpage.action?pageId={2}'
 
-            self.info('Publish point: ' + point_url.format(
+            point_url = point_url_fmt.format(
                 self.config.confluence_server_url,
                 self.config.confluence_space_key,
-                self.root_doc_page_id))
+                self.root_doc_page_id)
+
+            self.info('Publish point: ' + point_url)
+            self.app.emit('confluence-publish-point', point_url)
 
     def publish_cleanup(self):
         # check if archive cleanup is enabled


### PR DESCRIPTION
Adds an event (`confluence-publish-point`) that is triggered when this extension prints the detected Confluence publish point URL in the standard output stream. This can allow documentations to react to the resulting URL to perform any custom post-actions when the publish point is known.
