### PR TITLE
doc: avoid link breaks in table links

### DIFF
--- a/doc/_themes/sphinx13b/static/sphinx13b.css
+++ b/doc/_themes/sphinx13b/static/sphinx13b.css
@@ -303,6 +303,10 @@ table.deprecated code.literal {
     word-break: break-all;
 }
 
+table.no-wrap-links a {
+    white-space: nowrap;
+}
+
 tt {
     background-color: #f2f2f2;
     border: 1px solid #ddd;

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -16,6 +16,8 @@ reStructuredText markup
 
     .. tabularcolumns:: |p{4cm}|p{12cm}|
 
+.. rst-class:: no-wrap-links
+
 ======================= =====
 Type                    Notes
 ======================= =====
@@ -76,6 +78,8 @@ Sphinx markup
 .. only:: latex
 
     .. tabularcolumns:: |p{4cm}|p{12cm}|
+
+.. rst-class:: no-wrap-links
 
 ======================= =====
 Type                    Notes
@@ -139,6 +143,8 @@ each of these extensions:
 .. only:: latex
 
     .. tabularcolumns:: |p{5cm}|p{11cm}|
+
+.. rst-class:: no-wrap-links
 
 ================================= =====
 Type                              Notes
@@ -221,6 +227,8 @@ interacting with this extension:
 .. only:: latex
 
     .. tabularcolumns:: |p{5cm}|p{11cm}|
+
+.. rst-class:: no-wrap-links
 
 ================================= =====
 Type                              Notes


### PR DESCRIPTION
When presenting features, avoid breaking the link to certain features or extensions. This should help avoid select elements from splitting the name of a capability/extension that is best served on a single line.