### PR TITLE
singlebuilder: print newline after progress events in verbose mode

### DIFF
--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -75,6 +75,9 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
             return
 
         with progress_message(C('assembling single confluence document')):
+            if self.app.verbosity:
+                print()
+
             # assemble toc section/figure numbers
             #
             # Both the environment's `toc_secnumbers` and `toc_fignumbers`
@@ -104,6 +107,9 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
             self.assets.process_document(doctree, self.config.root_doc)
 
         with progress_message(C('writing single confluence document')):
+            if self.app.verbosity:
+                print()
+
             self.write_doc_serialized(self.config.root_doc, doctree)
             self.write_doc(self.config.root_doc, doctree)
 


### PR DESCRIPTION
Add a newline after starting a progress message when in verbose mode. This helps avoid stacking a verbose message after the initial progress message is generated.