### PR TITLE
ignore document overrides in a singleconfluence mode

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -605,7 +605,7 @@ class ConfluenceBuilder(Builder):
         metadata = self.metadata[docname]
 
         # apply editor override (if any)
-        if 'editor' in metadata:
+        if 'editor' in metadata and self.name != 'singleconfluence':
             data['editor'] = metadata['editor']
 
         # determine appearance
@@ -613,7 +613,7 @@ class ConfluenceBuilder(Builder):
         # Note: we do not have an "OFF" for v1 editor since an
         # appearance hint is ignored; width management in this
         # case is managed in the translator
-        if 'fullWidth' in metadata:
+        if 'fullWidth' in metadata and self.name != 'singleconfluence':
             confluence_full_width = (metadata['fullWidth'] == 'true')
         else:
             confluence_full_width = self.config.confluence_full_width

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -124,12 +124,12 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         # override editor if the document specifies another
         editor_override = metadata.get('editor')
-        if editor_override:
+        if editor_override and self.builder.name != 'singleconfluence':
             self.editor = editor_override
 
         # override full-width option if the document hints to override
         fw_override = metadata.get('fullWidth')
-        if fw_override:
+        if fw_override and self.builder.name != 'singleconfluence':
             self.confluence_full_width = (fw_override == 'true')
 
         # helper to track a v2 editor


### PR DESCRIPTION
When using the `singleconfluence` builder, do not take into consideration document-specific hints to the editor and full-width values. The page-specific hints can mix up content and could adjust the publish editor type depending on what pages are used.