### PR TITLE
Improve reference tracking

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,1 +1,2 @@
 beautifulsoup4
+myst_parser

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -248,6 +248,8 @@ def setup(app):
     cm.add_conf_bool('confluence_adv_cloud')
     # Disable workaround for: https://jira.atlassian.com/browse/CONFCLOUD-74698
     cm.add_conf_bool('confluence_adv_disable_confcloud_74698')
+    # Disable workaround for inline-extension anchor injection
+    cm.add_conf_bool('confluence_adv_disable_confcloud_ieaj')
     # Disable any attempts to initialize this extension's custom entities.
     cm.add_conf_bool('confluence_adv_disable_init')
     # Flag to permit the use of embedded certificates from requests.

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -1223,13 +1223,8 @@ class ConfluenceBuilder(Builder):
             # if a title "test" exists twice, the first header entry will have
             # an anchor of "test" and the second will have an entry of
             # "test.1".
-            title_name = node.astext()
-            if editor == 'v2':
-                # In v2, targets with dashes look to get dash-wrapped. Tweak
-                # the target to perform the same type of manipulation.
-                title_name = title_name.replace('-', '---')
             sep = '-' if editor == 'v2' else ''
-            title_name = sep.join(title_name.split())
+            title_name = sep.join(node.astext().split())
 
             # Check to see if this title will have a section number added to
             # it (e.g. "test" becoming named "1. test"). It is assumed here
@@ -1314,10 +1309,8 @@ class ConfluenceBuilder(Builder):
                 # Confluence prefixing these identifiers with two copies of
                 # `[inlineExtension]`. Cannot explain why, so if this situation
                 # occurs, just add the prefix data to help ensure links work.
-                #
-                # Dash wrapping also seem to need inlineExtension as well.
                 if not self.config.confluence_adv_disable_confcloud_ieaj:
-                    if new_target != target or '---' in target:
+                    if new_target != target:
                         new_target = 2 * '[inlineExtension]' + new_target
 
                 target = new_target

--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -327,8 +327,8 @@ class ConfluenceBuilder(Builder):
             # post-prepare a ready doctree
             self._prepare_doctree_writing(docname, doctree)
 
-            # register title targets for references
-            self._register_doctree_title_targets(docname, doctree)
+            # register targets for references
+            self._register_doctree_targets(docname, doctree)
 
         # register titles for special documents (if needed); if a title is not
         # already set from a placeholder document, configure a default title
@@ -1167,60 +1167,171 @@ class ConfluenceBuilder(Builder):
 
         return True
 
-    def _register_doctree_title_targets(self, docname, doctree):
+    def _register_doctree_targets(self, docname, doctree, title_track=None):
         """
-        register title targets for a doctree
+        register targets for a doctree
 
-        Compiles a list of title targets which references can link against. This
+        Compiles a list of targets which references can link against. This
         tracked expected targets for sections which are automatically generated
         in a rendered Confluence instance.
 
         Args:
             docname: the docname of the doctree
             doctree: the doctree to search for targets
+            title_track (optional): database for tracking unique titles
         """
 
-        doc_used_names = {}
-        secnumbers = self.env.toc_secnumbers.get(docname, {})
+        singleconfluence = self.name == 'singleconfluence'
+        root_doc = self.config.root_doc if singleconfluence else docname
+        secnumbers = self.env.toc_secnumbers.get(root_doc, {})
 
+        # Determine the editor by checking if the metadata for a document
+        # specifies a specific editor override or fallback to the global
+        # configuration if one is set. In singleconfluence, we always use
+        # the global configuration.
         metadata = self.metadata.get(docname, {})
-        editor = metadata.get('editor', self.config.confluence_editor)
+        editor = metadata.get('editor')
+        if not editor or singleconfluence:
+            editor = self.config.confluence_editor
 
+        # Prepare a database to track titles if one is not already provided.
+        # (i.e. not all callers care about unique targets between multiple
+        # documents)
+        title_track = title_track if title_track else {}
+
+        # Find the first section of this document page. It will be used to
+        # create "base" line to a specific page embedded in the single
+        # document generated. This only applies to single-document generation.
+        root_section = None
+        if singleconfluence:
+            title_node = self._find_title_element(doctree)
+            if title_node and isinstance(title_node.parent, nodes.section):
+                root_section = title_node.parent
+
+        # Process all section-owned titles for "title"/heading elements to
+        # register.
         for node in findall(doctree, nodes.title):
-            if isinstance(node.parent, nodes.section):
-                section_node = node.parent
-                if 'ids' in section_node:
-                    # sections on v2 pages will replace spaces with dashes
-                    # for anchors, where older editors will strip out spaces
-                    sep = '-' if editor == 'v2' else ''
-                    target = sep.join(node.astext().split())
+            section_node = node.parent
+            if not isinstance(section_node, nodes.section):
+                continue
 
-                    if self.add_secnumbers:
-                        anchorname = '#' + section_node['ids'][0]
-                        if anchorname not in secnumbers:
-                            anchorname = ''
+            # Extract the "title" for this section to be used when referencing
+            # this heading. In Confluence, the anchor name matches that of the
+            # title (side from things such as spaces removed). Although, for
+            # repeated titles, there will be a ".<n>" postfix for any title
+            # entry that has the same name starting with ".1". For example,
+            # if a title "test" exists twice, the first header entry will have
+            # an anchor of "test" and the second will have an entry of
+            # "test.1".
+            title_name = node.astext()
+            if editor == 'v2':
+                # In v2, targets with dashes look to get dash-wrapped. Tweak
+                # the target to perform the same type of manipulation.
+                title_name = title_name.replace('-', '---')
+            sep = '-' if editor == 'v2' else ''
+            title_name = sep.join(title_name.split())
 
-                        secnumber = secnumbers.get(anchorname)
-                        if secnumber:
-                            target = ('.'.join(map(str, secnumber)) +
-                                self.secnumber_suffix + target)
+            # Check to see if this title will have a section number added to
+            # it (e.g. "test" becoming named "1. test"). It is assumed here
+            # that any ID of a section node when passed into the environment's
+            # section number tracking will result in the same section number
+            # being returned.
+            if self.add_secnumbers and 'ids' in section_node:
+                first_id = first(section_node['ids'])
 
-                    section_id = doc_used_names.get(target, 0)
-                    doc_used_names[target] = section_id + 1
-                    if section_id > 0:
-                        target = f'{target}.{section_id}'
+                anchorname = f'{docname}/#{first_id}'
+                if anchorname not in secnumbers:
+                    anchorname = f'{first_id}/'
 
-                    # v2 editor does not link anchors with select characters;
-                    # provide a workaround that url encodes targets
-                    #
-                    # See: https://jira.atlassian.com/browse/CONFCLOUD-7469
-                    if not self.config.confluence_adv_disable_confcloud_74698:
-                        if editor == 'v2':
-                            target = quote(target)
+                secnumber = secnumbers.get(anchorname)
+                if secnumber:
+                    title_name = ('.'.join(map(str, secnumber)) +
+                        self.secnumber_suffix + title_name)
 
-                    for raw_id in section_node['ids']:
-                        full_id = f'{docname}#{raw_id}'
-                        self.state.register_target(full_id, target)
+            # Determine the "final" target name of this title. Check if this
+            # title has been used before. If so, append a new postfix to it.
+            title_target = title_name
+            last_title_postfix = title_track.get(title_target, 0)
+            title_track[title_target] = last_title_postfix + 1
+            if last_title_postfix > 0:
+                title_target = f'{title_target}.{last_title_postfix}'
+
+            # If this section is the (first) root section, register a target
+            # for a "root" anchor point. This is important for references that
+            # link to documents (e.g. `:doc:<>`). For example, if "page-a"
+            # has a document link to "page-b" (e.g. `:doc:<page-b>`), we want
+            # an anchor to jump to after the document is merged. We use the
+            # first detected title in a page as the main target for the
+            # document's "top" link.
+            if singleconfluence and section_node == root_section:
+                root_anchorname = f'/#{docname}'
+                self._register_target(editor, root_anchorname, title_target)
+
+            # For each identified assigned to the section, ensure we register
+            # a target anchor for each one.
+            if 'ids' in section_node:
+                for id_ in section_node['ids']:
+                    anchorname = f'{docname}/#{id_}'
+                    self._register_target(editor, anchorname, title_target)
+
+            # For each global name assigned to the section, ensure we register
+            # a target anchor for each one.
+            if 'names' in section_node:
+                for name in section_node['names']:
+                    anchorname = f'/#{name}'
+                    self._register_target(editor, anchorname, title_target)
+
+        # Process all targets except for entries associated with a section
+        # (as those were processed above).
+        for node in findall(doctree, nodes.target):
+            node_refid = node.get('refid')
+            if not node_refid:
+                continue
+
+            next_sibling = first(findall(node,
+                include_self=False, descend=False, siblings=True))
+            if isinstance(next_sibling, nodes.section):
+                continue
+
+            full_id = f'{docname}/#{node_refid}'
+            self._register_target(editor, full_id, node_refid)
+
+    def _register_target(self, editor, refid, target):
+        # v2 editor does not link anchors with select characters;
+        # provide a workaround that url encodes targets
+        #
+        # See: https://jira.atlassian.com/browse/CONFCLOUD-74698
+        if not self.config.confluence_adv_disable_confcloud_74698:
+            if editor == 'v2':
+                new_target = quote(target)
+
+                # So... related to CONFCLOUD-74698, something about anchors
+                # with special characters will cause some pain for links.
+                # This has been observed in the past, was removed after
+                # thinking it was not an issue but is now being added again.
+                # It appears that when a header is generated an identifier in
+                # Confluence Cloud that has special characters, we can observe
+                # Confluence prefixing these identifiers with two copies of
+                # `[inlineExtension]`. Cannot explain why, so if this situation
+                # occurs, just add the prefix data to help ensure links work.
+                #
+                # Dash wrapping also seem to need inlineExtension as well.
+                if not self.config.confluence_adv_disable_confcloud_ieaj:
+                    if new_target != target or '---' in target:
+                        new_target = 2 * '[inlineExtension]' + new_target
+
+                target = new_target
+
+        self.state.register_target(refid, target)
+
+        # For singleconfluence, register global fallbacks for targets
+        # to ensure merged targets from other documents can be linked to
+        # from other doctrees.
+        if self.name == 'singleconfluence':
+            _, refid_part = refid.split('/', 1)
+            fallback_refid = f'/{refid_part}'
+            if fallback_refid != refid:
+                self.state.register_target(fallback_refid, target)
 
     def _top_ref_check(self, node):
         """

--- a/sphinxcontrib/confluencebuilder/state.py
+++ b/sphinxcontrib/confluencebuilder/state.py
@@ -41,7 +41,7 @@ class ConfluenceState:
         logger.verbose(f'setting parent of {docname} to: {parent_docname}')
 
     @staticmethod
-    def register_target(refid, target):
+    def register_target(refid, target, overwrite=False):
         """
         register a reference to a specific (anchor) target
 
@@ -53,8 +53,13 @@ class ConfluenceState:
         to track the target value to use for a provided reference (so that a
         writer can properly prepare a link; see also `target`).
         """
-        ConfluenceState.refid2target[refid] = target
-        logger.verbose(f'mapping {refid} to target: {target}')
+        exists = refid in ConfluenceState.refid2target
+        if exists and not overwrite:
+            logger.verbose(f'ignore mapping {refid} to target: {target}')
+        else:
+            ConfluenceState.refid2target[refid] = target
+            postfix = ' [OVERWRITE]' if exists else ''
+            logger.verbose(f'mapping {refid} to target: {target}{postfix}')
 
     @staticmethod
     def register_title(docname, title, config):

--- a/tests/unit-tests/datasets/references/index.rst
+++ b/tests/unit-tests/datasets/references/index.rst
@@ -1,0 +1,14 @@
+Index
+=====
+
+.. toctree::
+    :maxdepth: 1
+
+    rst-v1-first
+    rst-v1-second
+    rst-v2-first
+    rst-v2-second
+    md-v1-first
+    md-v1-second
+    md-v2-first
+    md-v2-second

--- a/tests/unit-tests/datasets/references/md-v1-first.md
+++ b/tests/unit-tests/datasets/references/md-v1-first.md
@@ -1,0 +1,7 @@
+:::{confluence_metadata}
+:editor: v1
+:::
+
+# Markdown v1 First
+
+## Markdown v1 First sub-heading

--- a/tests/unit-tests/datasets/references/md-v1-second.md
+++ b/tests/unit-tests/datasets/references/md-v1-second.md
@@ -1,0 +1,23 @@
+:::{confluence_metadata}
+:editor: v1
+:::
+
+# Markdown v1 Second
+
+## Markdown v1 Second sub-heading
+
+## Markdown v1 Second sub-heading [(jump above)](#markdown-v1-second-sub-heading)
+
+[](#markdown-v1-second)
+
+[](#markdown-v1-second-sub-heading)
+
+[](#markdown-v1-second-sub-heading-jump-above)
+
+[link text 1](./md-v1-first.md#markdown-v1-first)
+
+[link text 2](./md-v1-first.md#markdown-v1-first-sub-heading)
+
+[link text 3](./md-v2-first.md#markdown-v2-first)
+
+[link text 4](./md-v2-first.md#markdown-v2-first-sub-heading)

--- a/tests/unit-tests/datasets/references/md-v2-first.md
+++ b/tests/unit-tests/datasets/references/md-v2-first.md
@@ -1,0 +1,7 @@
+:::{confluence_metadata}
+:editor: v2
+:::
+
+# Markdown v2 First
+
+## Markdown v2 First sub-heading

--- a/tests/unit-tests/datasets/references/md-v2-second.md
+++ b/tests/unit-tests/datasets/references/md-v2-second.md
@@ -1,0 +1,23 @@
+:::{confluence_metadata}
+:editor: v2
+:::
+
+# Markdown v2 Second
+
+## Markdown v2 Second sub-heading
+
+## Markdown v2 Second sub-heading [(jump above)](#markdown-v2-second-sub-heading)
+
+[](#markdown-v2-second)
+
+[](#markdown-v2-second-sub-heading)
+
+[](#markdown-v2-second-sub-heading-jump-above)
+
+[link text a](./md-v2-first.md#markdown-v2-first)
+
+[link text b](./md-v2-first.md#markdown-v2-first-sub-heading)
+
+[link text c](./md-v1-first.md#markdown-v1-first)
+
+[link text d](./md-v1-first.md#markdown-v1-first-sub-heading)

--- a/tests/unit-tests/datasets/references/rst-v1-first.rst
+++ b/tests/unit-tests/datasets/references/rst-v1-first.rst
@@ -1,0 +1,34 @@
+.. confluence_metadata::
+    :editor: v1
+
+.. _main-rst-v1:
+
+reStructuredText v1 First 
+=========================
+
+.. contents::
+    :local:
+
+.. _main-rst-v1-extra:
+
+An Extra Header
+---------------
+
+pre-content
+
+.. _main-rst-v1-subcontent:
+
+post-content
+
+.. _main-rst-v1-extra2:
+
+An Extra Header
+---------------
+
+:ref:`main-rst-v1`
+
+:ref:`main-rst-v1-extra`
+
+:ref:`content <main-rst-v1-subcontent>`
+
+:ref:`main-rst-v1-extra2`

--- a/tests/unit-tests/datasets/references/rst-v1-second.rst
+++ b/tests/unit-tests/datasets/references/rst-v1-second.rst
@@ -1,0 +1,21 @@
+.. confluence_metadata::
+    :editor: v1
+
+reStructuredText v1 Second 
+==========================
+
+:ref:`main-rst-v1`
+
+:ref:`main-rst-v1-extra`
+
+:ref:`content 1 <main-rst-v1-subcontent>`
+
+:ref:`main-rst-v1-extra2`
+
+:ref:`main-rst-v2`
+
+:ref:`main-rst-v2-extra`
+
+:ref:`content 2 <main-rst-v2-subcontent>`
+
+:ref:`main-rst-v2-extra2`

--- a/tests/unit-tests/datasets/references/rst-v2-first.rst
+++ b/tests/unit-tests/datasets/references/rst-v2-first.rst
@@ -1,0 +1,34 @@
+.. confluence_metadata::
+    :editor: v2
+
+.. _main-rst-v2:
+
+reStructuredText v2 First 
+=========================
+
+.. contents::
+    :local:
+
+.. _main-rst-v2-extra:
+
+An Extra Header
+---------------
+
+pre-content
+
+.. _main-rst-v2-subcontent:
+
+post-content
+
+.. _main-rst-v2-extra2:
+
+An Extra Header
+---------------
+
+:ref:`main-rst-v2`
+
+:ref:`main-rst-v2-extra`
+
+:ref:`content <main-rst-v2-subcontent>`
+
+:ref:`main-rst-v2-extra2`

--- a/tests/unit-tests/datasets/references/rst-v2-second.rst
+++ b/tests/unit-tests/datasets/references/rst-v2-second.rst
@@ -1,0 +1,21 @@
+.. confluence_metadata::
+    :editor: v2
+
+reStructuredText v2 Second 
+==========================
+
+:ref:`main-rst-v1`
+
+:ref:`main-rst-v1-extra`
+
+:ref:`content a <main-rst-v1-subcontent>`
+
+:ref:`main-rst-v1-extra2`
+
+:ref:`main-rst-v2`
+
+:ref:`main-rst-v2-extra`
+
+:ref:`content b <main-rst-v2-subcontent>`
+
+:ref:`main-rst-v2-extra2`

--- a/tests/unit-tests/test_references_confluence.py
+++ b/tests/unit-tests/test_references_confluence.py
@@ -1,0 +1,704 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from tests.lib.parse import parse
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+
+
+class TestConfluenceReferencesConfluence(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.config['extensions'].append('myst_parser')
+        cls.dataset = cls.datasets / 'references'
+
+        # disable any anchor workarounds for testing
+        cls.config['confluence_adv_disable_confcloud_74698'] = True
+
+        # markdown headers
+        cls.config['myst_enable_extensions'] = [
+            'colon_fence',
+        ]
+        cls.config['myst_heading_anchors'] = 7
+
+    @setup_builder('confluence')
+    def test_storage_references_confluence(self):
+        out_dir = self.build(self.dataset)
+
+        # expected page names
+        rst_v1_first_name = 'reStructuredText v1 First'
+        rst_v1_second_name = 'reStructuredText v1 Second'
+        rst_v2_first_name = 'reStructuredText v2 First'
+        rst_v2_second_name = 'reStructuredText v2 Second'
+        md_v1_first_name = 'Markdown v1 First'
+        md_v1_second_name = 'Markdown v1 Second'
+        md_v2_first_name = 'Markdown v2 First'
+        md_v2_second_name = 'Markdown v2 Second'
+
+        # initial checks -- verifying toc renders sane links to other pages
+        with parse('index', out_dir) as data:
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 8)
+
+            expected_pages = [
+                rst_v1_first_name,
+                rst_v1_second_name,
+                rst_v2_first_name,
+                rst_v2_second_name,
+                md_v1_first_name,
+                md_v1_second_name,
+                md_v2_first_name,
+                md_v2_second_name,
+            ]
+
+            for (ac_link, page_name) in zip(ac_links, expected_pages):
+                link_page = ac_link.find('ri:page')
+                self.assertTrue(link_page.has_attr('ri:content-title'))
+                self.assertEqual(link_page['ri:content-title'], page_name)
+
+                link_body = ac_link.find('ac:link-body')
+                self.assertIsNotNone(link_body)
+                self.assertEqual(link_body.text, page_name)
+
+        # rst-v1-first]
+        # should have eight links:
+        # - local-toc pointing to two headers
+        # - each header pointing back to local-toc
+        # - one href-link to top of page
+        # - three link macros to internal points
+        with parse('rst-v1-first', out_dir) as data:
+            # ##########################################################
+            # extract all anchors
+            #  - 2x, anchor points on local-tocs
+            #  - 1x, anchor in content
+            # ##########################################################
+            local_toc_entries = data.find_all('li')
+            self.assertEqual(len(local_toc_entries), 2)
+
+            # anchor in local-toc
+            ltoc_entry = local_toc_entries.pop(0)
+            ltoc_anchor = ltoc_entry.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(ltoc_anchor)
+            anchor_param = ltoc_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_01_id = anchor_param.text
+
+            # anchor in local-toc
+            ltoc_entry = local_toc_entries.pop(0)
+            ltoc_anchor = ltoc_entry.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(ltoc_anchor)
+            anchor_param = ltoc_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_02_id = anchor_param.text
+
+            # anchor after pre-content
+            content_element = data.find('p', text='pre-content')
+            self.assertIsNotNone(content_element)
+            anchor_container = content_element.next_sibling
+            ltoc_anchor = anchor_container.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(ltoc_anchor)
+            anchor_param = ltoc_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_03_id = anchor_param.text
+
+            # ##########################################################
+            # find the expected ac:link macros
+            # ##########################################################
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 7)
+
+            # local-toc link down to a header
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'AnExtraHeader')
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # local-toc link down to a header
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'AnExtraHeader.1')
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # header link to a local-toc entry
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], anchor_01_id)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # header link to a local-toc entry
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], anchor_02_id)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # body link to sub-header on this page
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'AnExtraHeader')
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # body link to mid-way in the content section
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], anchor_03_id)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'content')
+
+            # body link to second sub-header on this page
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'AnExtraHeader.1')
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # ##########################################################
+            # find the link a-href link to the top
+            # ##########################################################
+            top_link = data.find('a')
+            self.assertIsNotNone(top_link)
+            self.assertTrue(top_link.has_attr('href'))
+            self.assertEqual(top_link['href'], '#top')
+            self.assertEqual(top_link.text, rst_v1_first_name)
+
+        # rst-v1-second]
+        # should have eight links
+        with parse('rst-v1-second', out_dir) as data:
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 8)
+
+            # link to the very top of the main page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'reStructuredTextv1First')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, rst_v1_first_name)
+
+            # link to the sub-header on the main page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'AnExtraHeader')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # link mid-way in the content section on the main page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'main-rst-v1-subcontent')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'content 1')
+
+            # link to the second sub-header on the main page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'AnExtraHeader.1')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # link to the very top of the main page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'reStructuredText-v2-First')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, rst_v2_first_name)
+
+            # link to the sub-header on the main page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'An-Extra-Header')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # link mid-way in the content section on the main page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'main-rst-v2-subcontent')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'content 2')
+
+            # link to the second sub-header on the main page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'An-Extra-Header.1')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+        # rst-v2-first]
+        # should have eight links:
+        # - local-toc pointing to two headers
+        # - each header pointing back to local-toc
+        # - one href-link to top of page
+        # - three link macros to internal points
+        with parse('rst-v2-first', out_dir) as data:
+            # ##########################################################
+            # extract all anchors
+            #  - 2x, anchor points on local-tocs
+            #  - 1x, anchor in content
+            # ##########################################################
+            local_toc_entries = data.find_all('li')
+            self.assertEqual(len(local_toc_entries), 2)
+
+            # anchor in local-toc
+            ltoc_entry = local_toc_entries.pop(0)
+            ltoc_anchor = ltoc_entry.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(ltoc_anchor)
+            anchor_param = ltoc_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_01_id = anchor_param.text
+
+            # anchor in local-toc
+            ltoc_entry = local_toc_entries.pop(0)
+            ltoc_anchor = ltoc_entry.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(ltoc_anchor)
+            anchor_param = ltoc_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_02_id = anchor_param.text
+
+            # anchor after pre-content
+            content_element = data.find('p', text='pre-content')
+            self.assertIsNotNone(content_element)
+            anchor_container = content_element.next_sibling
+            ltoc_anchor = anchor_container.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(ltoc_anchor)
+            anchor_param = ltoc_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_03_id = anchor_param.text
+
+            # ##########################################################
+            # find the expected ac:link macros
+            # ##########################################################
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 2)
+
+            # header link to a local-toc entry
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], anchor_01_id)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # header link to a local-toc entry
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], anchor_02_id)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # ##########################################################
+            # find the expected a-href links
+            # ##########################################################
+            a_hrefs = data.find_all('a')
+            self.assertEqual(len(a_hrefs), 6)
+
+            # local-toc link down to a header
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'], '#An-Extra-Header')
+            self.assertEqual(a_href.text, 'An Extra Header')
+
+            # local-toc link down to a header
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'], '#An-Extra-Header.1')
+            self.assertEqual(a_href.text, 'An Extra Header')
+
+            # body link to top on this page
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'], '#top')
+            self.assertEqual(a_href.text, rst_v2_first_name)
+
+            # body link to sub-header on this page
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'], '#An-Extra-Header')
+            self.assertEqual(a_href.text, 'An Extra Header')
+
+            # body link to mid-way in the content section
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'], f'#{anchor_03_id}')
+            self.assertEqual(a_href.text, 'content')
+
+            # body link to second sub-header on this page
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'], '#An-Extra-Header.1')
+            self.assertEqual(a_href.text, 'An Extra Header')
+
+        # rst-v2-second]
+        # should have eight links
+        with parse('rst-v2-second', out_dir) as data:
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 8)
+
+            # link to the very top of the main page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'reStructuredTextv1First')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, rst_v1_first_name)
+
+            # link to the sub-header on the main page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'AnExtraHeader')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # link mid-way in the content section on the main page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'main-rst-v1-subcontent')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'content a')
+
+            # link to the second sub-header on the main page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'AnExtraHeader.1')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # link to the very top of the main page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'reStructuredText-v2-First')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, rst_v2_first_name)
+
+            # link to the sub-header on the main page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'An-Extra-Header')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+            # link mid-way in the content section on the main page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'main-rst-v2-subcontent')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'content b')
+
+            # link to the second sub-header on the main page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'An-Extra-Header.1')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], rst_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'An Extra Header')
+
+        # md-v1-second]
+        with parse('md-v1-second', out_dir) as data:
+            # ##########################################################
+            # extract all anchors
+            #  - 2x, anchors in headers
+            # ##########################################################
+            header_entries = data.find_all('h2')
+            self.assertEqual(len(header_entries), 2)
+
+            # anchor in first header
+            header_entry = header_entries.pop(0)
+            header_anchor = header_entry.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(header_anchor)
+            anchor_param = header_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_01_id = anchor_param.text
+
+            # anchor in second header
+            header_entry = header_entries.pop(0)
+            header_anchor = header_entry.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(header_anchor)
+            anchor_param = header_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_02_id = anchor_param.text
+
+            # ##########################################################
+            # find the expected ac:link macros
+            # ##########################################################
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 7)
+
+            # heading jump to other heading
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], anchor_01_id)
+            link_page = ac_link.find('ri:page')
+            self.assertIsNone(link_page)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, '(jump above)')
+
+            # link to the sub-heading on this page
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], anchor_01_id)
+            link_page = ac_link.find('ri:page')
+            self.assertIsNone(link_page)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text,
+                'Markdown v1 Second sub-heading')
+
+            # link to the second sub-heading on this page
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], anchor_02_id)
+            link_page = ac_link.find('ri:page')
+            self.assertIsNone(link_page)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text,
+                'Markdown v1 Second sub-heading (jump above)')
+
+            # link to the top of the second page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'Markdownv1First')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], md_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'link text 1')
+
+            # link to the second page's (v1) sub-heading
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'Markdownv1Firstsub-heading')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], md_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'link text 2')
+
+            # link to the top of the second page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'Markdown-v2-First')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], md_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'link text 3')
+
+            # link to the second page's (v2) sub-heading
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'],
+                'Markdown-v2-First-sub-heading')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], md_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'link text 4')
+
+        # md-v2-second]
+        with parse('md-v2-second', out_dir) as data:
+            # ##########################################################
+            # extract all anchors
+            #  - 2x, anchors in headers
+            # ##########################################################
+            header_entries = data.find_all('h2')
+            self.assertEqual(len(header_entries), 2)
+
+            # anchor in first header
+            header_entry = header_entries.pop(0)
+            header_anchor = header_entry.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(header_anchor)
+            anchor_param = header_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_01_id = anchor_param.text
+
+            # anchor in second header
+            header_entry = header_entries.pop(0)
+            header_anchor = header_entry.find(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertIsNotNone(header_anchor)
+            anchor_param = header_anchor.find('ac:parameter')
+            self.assertIsNotNone(anchor_param)
+            anchor_02_id = anchor_param.text
+
+            # ##########################################################
+            # find the expected ac:link macros
+            # ##########################################################
+            ac_links = data.find_all('ac:link')
+            self.assertEqual(len(ac_links), 4)
+
+            # link to the top of the second page (v1)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'Markdown-v2-First')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], md_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'link text a')
+
+            # link to the second page's (v1) sub-heading
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'],
+                'Markdown-v2-First-sub-heading')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], md_v2_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'link text b')
+
+            # link to the top of the second page (v2)
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'Markdownv1First')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], md_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'link text c')
+
+            # link to the second page's (v2) sub-heading
+            ac_link = ac_links.pop(0)
+            self.assertTrue(ac_link.has_attr('ac:anchor'))
+            self.assertEqual(ac_link['ac:anchor'], 'Markdownv1Firstsub-heading')
+            link_page = ac_link.find('ri:page')
+            self.assertTrue(link_page.has_attr('ri:content-title'))
+            self.assertEqual(link_page['ri:content-title'], md_v1_first_name)
+            ac_link_body = ac_link.find('ac:link-body')
+            self.assertIsNotNone(ac_link_body)
+            self.assertEqual(ac_link_body.text, 'link text d')
+
+            # ##########################################################
+            # find the expected a-href links
+            # ##########################################################
+            a_hrefs = data.find_all('a')
+            self.assertEqual(len(a_hrefs), 4)
+
+            # heading jump to other heading
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'], '#Markdown-v2-Second-sub-heading')
+            self.assertEqual(a_href.text, '(jump above)')
+
+            # link to the top of this page
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'], '#top')
+            self.assertEqual(a_href.text, md_v2_second_name)
+
+            # link to the sub-heading on this page
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'], '#Markdown-v2-Second-sub-heading')
+            self.assertEqual(a_href.text, 'Markdown v2 Second sub-heading')
+
+            # link to the second sub-heading on this page
+            a_href = a_hrefs.pop(0)
+            self.assertIsNotNone(a_href)
+            self.assertTrue(a_href.has_attr('href'))
+            self.assertEqual(a_href['href'],
+                '#Markdown-v2-Second-sub-heading-(jump-above)')
+            self.assertEqual(a_href.text,
+                'Markdown v2 Second sub-heading (jump above)')


### PR DESCRIPTION
This performs another rework of tracking targets for references in this extension. It is another attempt to improve the state of building proper links no matter what builder type is selected. This update was primarily driven some limitations observed when using the `singleconfluence` builder. In some scenarios, links to headers would not point to proper anchor points in both editor versions. In addition, special anchor processing in v2 only worked for a subset of links.

We moved all target registration into the main builder and added conditions for when using different builder types. This has helped remove some duplication related to building anchors. Corrections towards tracking duplicate headers addressed some broken links observed in a singleconfluence mode. In addition, this also corrects scenarios where this extension incorrectly applies duplicate header index postfixing for headers which have multiple reference identifiers.

Cannot say reference management is perfect. There are still some scenarios where nodes have identifiers where this extension may not generate an anchor or attempt to find a Confluence-generated identifier link (e.g. terms), but these can be improved on over time and as more test scenarios are created.