### PR TITLE
rest: include extension version in user agent

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -27,6 +27,7 @@ import json
 import math
 import random
 import requests
+import sphinxcontrib.confluencebuilder
 import ssl
 import time
 
@@ -238,6 +239,7 @@ class Rest:
         self.last_retry = 1
         self.next_delay = None
         self.url = config.confluence_server_url
+        self.scb_version = sphinxcontrib.confluencebuilder.__version__
         self.session = None
         self.timeout = config.confluence_timeout
         self.verbosity = config.sphinx_verbosity
@@ -253,7 +255,7 @@ class Rest:
         session = requests.Session()
         session.headers.update({
             'Accept': 'application/json; charset=utf-8',
-            'User-Agent': 'Sphinx Confluence Builder',
+            'User-Agent': f'SphinxConfluenceBuilder/{self.scb_version}',
             'X-Atlassian-Token': NOCHECK,
         })
 


### PR DESCRIPTION
Include the version of this extension in the `User-Agent` field in REST calls. This is to allow Confluence instances and reverse proxies to manage requests from this extension based on the version, if ever needed.