### PR TITLE
translator: handle new pathlib usage in sphinx-env

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2561,7 +2561,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         uri = PARAMS(node)['url']
 
         docname = self.docname
-        suffix = self.builder.env.doc2path(docname, base=None)[len(docname):]
+        docpath = str(self.builder.env.doc2path(docname, base=None))
+        suffix = docpath[len(docname):]
         uri = uri.format(page=docname, suffix=suffix, **PARAMS(node))
 
         source_text = PARAMS(node).get('text', L('Edit Source'))


### PR DESCRIPTION
Sphinx environment's `doc2path` call now returns a Path \[1\]; updating the source-link logic to handle a string conversion before extracting the suffix.

\[1\]: https://github.com/sphinx-doc/sphinx/commit/de15d61a46daaaa2b0a0e341cdb4e0abe107e012