### PR TITLE
translator: support inlined images in v2 editor

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1853,6 +1853,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             attribs['ac:align'] = alignment
             if alignment == 'right':
                 attribs['ac:style'] = 'float: right;'
+        elif self.v2:
+            attribs['ac:inline'] = 'true'
 
         if 'alt' in node:
             alt = node['alt']

--- a/tests/validation-sets/restructuredtext/images.rst
+++ b/tests/validation-sets/restructuredtext/images.rst
@@ -9,7 +9,6 @@ Images
 
             Limitations using the Fabric (``v2``) editor:
 
-            - Images cannot be inlined (`CONFCLOUD-68501`_).
             - SVGs may not render properly (`CONFCLOUD-1762`_).
 
 reStructuredText defines a series of `image-based directives`_. Example markup


### PR DESCRIPTION
When no explicit alignment is configured for an image, apply an inline flag for an image. Confluence Cloud recently added support for inline images (CONFCLOUD-68501) and configuring these images as inlined by default should provide a consistent viewing experience between v1/v2 editors and similar rendering styles in other builders.