### PR TITLE
transmute: support sphinx-toolbox collapse node label change

### DIFF
--- a/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
+++ b/sphinxcontrib/confluencebuilder/transmute/ext_sphinx_toolbox.py
@@ -82,7 +82,13 @@ def replace_sphinx_toolbox_nodes(builder, doctree):
         for node in findall(doctree, sphinx_toolbox_CollapseNode):
             new_node = confluence_expand(node.rawsource,
                 *node.children, **node.attributes)
-            new_node.attributes['title'] = node.label
+
+            if hasattr(node, 'label'):
+                new_label = node.label
+            else:
+                new_label = node.get('label', '')
+
+            new_node.attributes['title'] = new_label
             node.replace_self(new_node)
 
     if has_sphinx_toolbox_github_issues:


### PR DESCRIPTION
An update \[1\] has been made to sphinx-toolbox's CollapseNode. Adjusting the transmute logic to support the variant label approaches.

\[1\]: https://github.com/sphinx-toolbox/sphinx-toolbox/commit/ae0ae836268a8e77e36ce58e534131e9ac42a75d