### PR TITLE
Provide means to disable env options

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -293,6 +293,20 @@ Generic configuration
 
         confluence_default_alignment = 'left'
 
+.. confval:: confluence_disable_env_conf
+
+    .. versionadded:: 2.7
+
+    A boolean value to configure whether to ignore environment-provided
+    configuration options. This extension will fallback on environment
+    variables if an option is not set in a configuration file or on the
+    command line. If a user never wants to pull options from the environment,
+    this option can be set to ``True``.
+
+    .. code-block:: python
+
+        confluence_disable_env_conf = True
+
 .. confval:: confluence_domain_indices
 
     .. versionadded:: 1.7

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -93,6 +93,8 @@ def setup(app):
     cm.add_conf('confluence_code_block_theme', 'confluence')
     # Default alignment for tables, figures, etc.
     cm.add_conf('confluence_default_alignment', 'confluence')
+    # Do not attempt to pull configuration values from the environment.
+    cm.add_conf_bool('confluence_disable_env_conf')
     # Enablement of a generated domain index documents
     cm.add_conf('confluence_domain_indices', 'confluence')
     # Confluence editor to target for publication.

--- a/sphinxcontrib/confluencebuilder/config/env.py
+++ b/sphinxcontrib/confluencebuilder/config/env.py
@@ -23,6 +23,10 @@ def apply_env_overrides(builder):
     conf = builder.config
     config_manager = builder.app.config_manager_
 
+    # check if the configuration has disabled environment options
+    if conf.confluence_disable_env_conf:
+        return
+
     for key in sorted(config_manager.options):
         # skip over options that have been already set
         if getattr(conf, key) is not None:

--- a/tests/unit-tests/test_config_env.py
+++ b/tests/unit-tests/test_config_env.py
@@ -47,6 +47,23 @@ class TestConfluenceConfigEnvironment(unittest.TestCase):
         self.assertTrue('CONFLUENCE_PUBLISH_FORCE' in os.environ)
         self.assertEqual(os.environ['CONFLUENCE_PUBLISH_FORCE'], '1')
 
+    def test_config_env_disabled(self):
+        # default unset
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertIsNone(app.config.confluence_publish_force)
+
+        # configure option from environment
+        os.environ['CONFLUENCE_PUBLISH_FORCE'] = '1'
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertTrue(app.config.confluence_publish_force)
+
+        # disable environment options
+        self.config['confluence_disable_env_conf'] = True
+        with prepare_sphinx(self.dataset, config=self.config) as app:
+            self.assertFalse(app.config.confluence_publish_force)
+        self.assertTrue('CONFLUENCE_PUBLISH_FORCE' in os.environ)
+        self.assertEqual(os.environ['CONFLUENCE_PUBLISH_FORCE'], '1')
+
     def test_config_env_int(self):
         # default unset
         with prepare_sphinx(self.dataset, config=self.config) as app:


### PR DESCRIPTION
Introducing a new option `confluence_disable_env_conf` which allows a user to ignore environment options for unset configuration options.