### PR TITLE
Support upcoming Sphinx warning-error changes

### DIFF
--- a/sphinxcontrib/confluencebuilder/logger.py
+++ b/sphinxcontrib/confluencebuilder/logger.py
@@ -41,6 +41,7 @@ class ConfluenceLogger:
                     self.messagelog = deque(maxlen=10)
                     self.verbosity = 0
                     self.warningiserror = False
+                    self._exception_on_warning = False
                     self._warncount = 0
 
             # fail silently if mocked application is missing something

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -7,7 +7,6 @@ See also:
     https://docs.atlassian.com/confluence/REST/latest/
 """
 
-from sphinx.util.logging import skip_warningiserror
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceConfigError
 from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadApiError
@@ -870,8 +869,7 @@ class ConfluencePublisher:
                     # entry was created with corrupted data (i.e. can we query
                     # for an existing attachment). If we find it, re-attempt
                     # to publish the attachment.
-                    with skip_warningiserror():
-                        logger.warn('attachment failure (503); retrying...')
+                    logger.info('attachment failure (503); retrying...')
                     time.sleep(0.5)
                     _, attachment = self.get_attachment(page_id, name)
 
@@ -1282,8 +1280,7 @@ class ConfluencePublisher:
                         raise
 
                     # retry on conflict
-                    with skip_warningiserror():
-                        logger.warn('property update conflict; retrying...')
+                    logger.info('property update conflict; retrying...')
 
                     attempt += 1
                 else:

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -5,7 +5,6 @@ from email.utils import mktime_tz
 from email.utils import parsedate_tz
 from functools import wraps
 from requests.adapters import HTTPAdapter
-from sphinx.util.logging import skip_warningiserror
 from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceAuthenticationFailedUrlError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadApiError
@@ -131,10 +130,9 @@ def confluence_error_retries():
                     delay += random.uniform(0.0, 0.5)  # noqa: S311
 
                     # wait the calculated delay before retrying again
-                    with skip_warningiserror():
-                        reported_delay = math.ceil(delay)
-                        logger.warn('unexpected rest response detected; '
-                                    f'retrying in {reported_delay} seconds...')
+                    reported_delay = math.ceil(delay)
+                    logger.info('unexpected rest response detected; '
+                                f'retrying in {reported_delay} seconds...')
                     time.sleep(delay)
                     attempt += 1
 
@@ -197,9 +195,8 @@ def rate_limited_retries():
                     delay += random.uniform(0.3, 1.3)  # noqa: S311
 
                     # wait the calculated delay before retrying again
-                    with skip_warningiserror():
-                        logger.warn('rate-limit response detected; '
-                                    f'waiting {math.ceil(delay)} seconds...')
+                    logger.info('rate-limit response detected; '
+                                f'waiting {math.ceil(delay)} seconds...')
                     time.sleep(delay)
                     self.last_retry = delay
                     attempt += 1

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from contextlib import suppress
 from copy import deepcopy
 from pathlib import Path
+from sphinx import version_info as sphinx_version_info
 from sphinx.application import Sphinx
 from sphinx.util.console import color_terminal
 from sphinx.util.console import nocolor
@@ -625,6 +626,12 @@ def prepare_sphinx(src_dir, config=None, out_dir=None, extra_config=None,
         'warningiserror': warnerr, # treat warnings as errors
         'verbosity': verbosity,    # verbosity
     }
+
+    # As of Sphinx v8.1.x, warnings will no longer generate exceptions by
+    # default. Force enable them as we rely on these exception events for
+    # various unit tests.
+    if sphinx_version_info >= (8, 1, 0):
+        sphinx_args['exception_on_warning'] = warnerr
 
     with docutils_namespace():
         app = Sphinx(

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -618,18 +618,22 @@ def prepare_sphinx(src_dir, config=None, out_dir=None, extra_config=None,
 
     doctrees_dir = out_dir / '.doctrees'
 
+    sphinx_args = {
+        'confoverrides': conf,     # load provided configuration (volatile)
+        'status': sts,             # status output
+        'warning': sys.stderr,     # warnings output
+        'warningiserror': warnerr, # treat warnings as errors
+        'verbosity': verbosity,    # verbosity
+    }
+
     with docutils_namespace():
         app = Sphinx(
-            str(src_dir),            # output for document sources
-            conf_dir,                # configuration directory
-            str(out_dir),            # output for generated documents
-            str(doctrees_dir),       # output for doctree files
-            builder,                 # builder to execute
-            confoverrides=conf,      # load provided configuration (volatile)
-            status=sts,              # status output
-            warning=sys.stderr,      # warnings output
-            warningiserror=warnerr,  # treat warnings as errors
-            verbosity=verbosity)     # verbosity
+            str(src_dir),      # output for document sources
+            conf_dir,          # configuration directory
+            str(out_dir),      # output for generated documents
+            str(doctrees_dir), # output for doctree files
+            builder,           # builder to execute
+            **sphinx_args)     # verbosity
 
         yield app
 

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -42,11 +42,12 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             'https://intranet-wiki.example.com/'
         self.config['confluence_space_key'] = 'DUMMY'
 
-    def _try_config(self, config=None, edefs=None, dataset=None):
+    def _try_config(self, config=None, edefs=None, relax=None, dataset=None):
         config = config if config else self.minimal_config
         dataset = dataset if dataset else self.dataset
 
-        with prepare_sphinx(dataset, config=config, extra_config=edefs) as app:
+        with prepare_sphinx(dataset,
+                config=config, extra_config=edefs, relax=relax) as app:
             env = BuildEnvironment(app)
             builder = ConfluenceBuilder(app, env)
 
@@ -508,7 +509,8 @@ class TestConfluenceConfigChecks(unittest.TestCase):
             return 'default'
 
         self.config['confluence_lang_overrides'] = mock_transform
-        self._try_config()
+        self._try_config(relax=True)
+        # relax: since using transform is deprecated and will generate a warning
 
         self.config['confluence_lang_overrides'] = 'invalid'
         with self.assertRaises(ConfluenceConfigError):

--- a/tests/unit-tests/test_sphinx_codeblock_highlight.py
+++ b/tests/unit-tests/test_sphinx_codeblock_highlight.py
@@ -146,7 +146,8 @@ class TestConfluenceSphinxCodeblockHighlight(ConfluenceTestCase):
         config['confluence_lang_overrides'] = test_override_lang_method
 
         out_dir = self.build(self.dataset, config=config,
-            filenames=['code-block-highlight'])
+            filenames=['code-block-highlight'], relax=True)
+        # relax: since using transform is deprecated and will generate a warning
 
         with parse('code-block-highlight', out_dir) as data:
             expected = [

--- a/tests/unit-tests/test_titles.py
+++ b/tests/unit-tests/test_titles.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
 
-from sphinx.util.logging import skip_warningiserror
-from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_TITLE_LEN
+from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.state import ConfluenceState
+from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_TITLE_LEN
 from tests.lib import MockedConfig
 import unittest
 
@@ -13,9 +13,12 @@ class TestTitles(unittest.TestCase):
         ConfluenceState.reset()
         self.config = MockedConfig()
 
+        # force (re-)initialize of logger to avoid logger being already
+        # configured with a warning-exception filter in a previous test
+        logger.initialize(preload=True)
+
     def _register_title(self, title):
-        with skip_warningiserror():
-            return ConfluenceState.register_title('mock', title, self.config)
+        return ConfluenceState.register_title('mock', title, self.config)
 
     def test_titles_maximum_checks_default(self):
         t0 = self._register_title('S' * (CONFLUENCE_MAX_TITLE_LEN - 1))

--- a/tests/unit-tests/test_unknown_node.py
+++ b/tests/unit-tests/test_unknown_node.py
@@ -4,7 +4,6 @@
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from sphinx.errors import SphinxWarning
-from sphinx.util.logging import skip_warningiserror
 from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 
@@ -36,11 +35,9 @@ class TestConfluenceUnknownNode(ConfluenceTestCase):
         # node to completion. A document should be built with the missing
         # component, and no errors should result from this attempt.
 
-        with self.prepare(self.dataset) as app:
+        with self.prepare(self.dataset, relax=True) as app:
             self._setup_app(app)
-
-            with skip_warningiserror():
-                app.build()
+            app.build()
 
     @setup_builder('confluence')
     def test_unknown_node_default_warning(self):


### PR DESCRIPTION
A series of retry events when publishing can report certain events as warnings. The prospect Sphinx v8.1.x release reworks how warnings can trigger a fail state and `skip_warningiserror` becomes deprecated with these changes. This can cause issues for users who wish to run with warnings-as-failure but may experience publishing issues that can be recovered on during a run. To prevent issues, updating a series of warning messages to be informational messages.

Sphinx has also updated it's implementation to no longer generate exceptions on an immediate warning by default \[1\]. This is desired for this extension's tests so the Sphinx application will enable this capability. The `skip_warningiserror` call is obsolete. With exception-on-warning enabled, a series of tests need to be updated to operate with a relaxed state; updating.

\[1\]: https://github.com/sphinx-doc/sphinx/pull/12743