### PR TITLE
Initial Python 3.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Documentation',
     'Topic :: Documentation :: Sphinx',
     'Topic :: Utilities',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     pylint
     py38-sphinx71
     py39-sphinx{71,72,73,74}
-    py{310,311,312}-sphinx{71,72,73,74,80}
+    py{310,311,312,313}-sphinx{71,72,73,74,80}
     mypy
 
 [testenv]


### PR DESCRIPTION
Updating the default tox configuration to test with Python v3.13.

Not yet included in CI as the latest images do not yet include support yet.