### PR TITLE
workflows: capture output of pdf runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,3 +52,13 @@ jobs:
         name: sphinxcontrib-confluencebuilder.pdf
         path: doc/_build/latex/sphinxconfluencebuilder.pdf
         retention-days: 10
+
+    - name: Archive PDF Raw Output
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: pdf-output
+        path: |
+          doc/_build/latex/sphinxconfluencebuilder.log
+          doc/_build/latex/sphinxconfluencebuilder.tex
+        retention-days: 1


### PR DESCRIPTION
Store the artifacts for the raw tx/log files from a PDF run. This can be useful for inspection if there are issues with the request to generate a PDF.