### PR TITLE
builder: correct title track database check

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -1192,7 +1192,7 @@ class ConfluenceBuilder(Builder):
         # Prepare a database to track titles if one is not already provided.
         # (i.e. not all callers care about unique targets between multiple
         # documents)
-        title_track = title_track if title_track else {}
+        title_track = title_track if title_track is not None else {}
 
         # Find the first section of this document page. It will be used to
         # create "base" line to a specific page embedded in the single


### PR DESCRIPTION
When processing doctree targets to track titles across multiple documents, the check for the database would fail to function if the database did not any initial entries. This would properly prevent tracking conflicting title documents when running with a `singleconfluence` builder. Adjusting the check to ignore/suppress if the provided database entry is `None`.