### PR TITLE
singlebuilder: unique identifiers for merged doctree

### DIFF
--- a/sphinxcontrib/confluencebuilder/compat.py
+++ b/sphinxcontrib/confluencebuilder/compat.py
@@ -1,13 +1,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright Sphinx Confluence Builder Contributors (AUTHORS)
-# Copyright 2007-2021 by the Sphinx team (sphinx-doc/sphinx#AUTHORS)
 
 from docutils import __version_info__ as docutils_version_info
-from docutils import nodes
-from sphinx import addnodes
-from sphinx.locale import __
-from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
-from typing import cast
 
 
 # use docutil's findall call over traverse (obsolete)
@@ -16,42 +10,3 @@ def docutils_findall(doctree, *args, **kwargs):
         return doctree.findall(*args, **kwargs)
 
     return doctree.traverse(*args, **kwargs)
-
-
-# use this extension's variant of sphinx's inline_all_toctrees which has
-# include support for a `replace` argument
-def inline_all_toctrees(builder, docnameset, docname, tree, colorfunc,
-                        traversed, replace):
-    tree = cast(nodes.document, tree.deepcopy())
-    for toctreenode in list(docutils_findall(tree, addnodes.toctree)):
-        newnodes = []
-        includefiles = map(str, toctreenode['includefiles'])
-        for includefile in includefiles:
-            if includefile not in traversed:
-                try:
-                    traversed.append(includefile)
-                    logger.info(colorfunc(includefile) + " ", nonl=True)
-                    subtree = inline_all_toctrees(
-                        builder, docnameset, includefile,
-                        builder.env.get_doctree(includefile),
-                        colorfunc, traversed, replace)
-                    docnameset.add(includefile)
-                except Exception:  # noqa: BLE001
-                    logger.warn(
-                        __('toctree contains ref to nonexisting file %r'),
-                        includefile, location=docname)
-                else:
-                    sof = addnodes.start_of_file(docname=includefile)
-                    sof.children = subtree.children
-                    for sectionnode in docutils_findall(sof, nodes.section):
-                        if 'docname' not in sectionnode:
-                            sectionnode['docname'] = includefile
-                    newnodes.append(sof)
-
-        if replace:
-            toctreenode.parent.replace(toctreenode, newnodes)
-        else:
-            for node in newnodes:
-                toctreenode.parent.append(node)
-
-    return tree

--- a/tests/sample-sets/single-confluence-refs/conf.py
+++ b/tests/sample-sets/single-confluence-refs/conf.py
@@ -1,0 +1,3 @@
+extensions = [
+    'sphinxcontrib.confluencebuilder',
+]

--- a/tests/sample-sets/single-confluence-refs/index.rst
+++ b/tests/sample-sets/single-confluence-refs/index.rst
@@ -1,0 +1,9 @@
+Index
+=====
+
+.. toctree::
+    :maxdepth: 1
+
+    page-a
+    page-b
+    page-c

--- a/tests/sample-sets/single-confluence-refs/page-a.rst
+++ b/tests/sample-sets/single-confluence-refs/page-a.rst
@@ -1,0 +1,47 @@
+Page A
+======
+
+.. contents::
+    :local:
+
+Section A
+^^^^^^^^^
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam euismod
+non lacus quis rutrum. Aenean ac molestie tortor. Vestibulum varius, tellus
+et dapibus blandit, ex mi rhoncus velit, accumsan porta lectus augue sed
+diam. Integer sit amet elit dui. Quisque nec pellentesque magna. Proin ligula
+lorem, tempor eget lacinia iaculis, congue at massa. Sed ac tristique tellus.
+Sed sagittis diam lacus. Aliquam pretium viverra lacus. Aliquam pellentesque
+viverra bibendum. Sed mattis sapien sem, quis venenatis erat venenatis eu.
+Curabitur consectetur quam non nunc porttitor volutpat. Aliquam mollis dolor
+sit amet semper sollicitudin. Aenean placerat leo mauris, id lobortis leo
+faucibus in. Sed eu purus in nulla fermentum ullamcorper.
+
+Section B
+^^^^^^^^^
+
+Donec tellus sem, varius ac scelerisque eu, molestie eget lacus. Fusce
+imperdiet aliquam nibh dictum luctus. Maecenas sit amet vehicula mi. Nam
+aliquam, turpis nec rhoncus aliquam, orci ex interdum ex, eget condimentum
+orci risus vel neque. Ut id hendrerit nisl, sed rutrum orci. Nullam semper
+dapibus lorem, vehicula cursus mauris ullamcorper pulvinar. Proin at orci
+a erat efficitur interdum. Vivamus in neque eu ante suscipit placerat. In
+sit amet congue est. Nunc malesuada mollis mauris. Vestibulum ac neque in
+odio euismod accumsan. Pellentesque nec ipsum metus. Proin quis ipsum
+bibendum, convallis ex nec, ultricies ante. In condimentum nunc arcu, a
+volutpat enim faucibus et. Aliquam congue congue libero eget vulputate.
+
+Sub-section
+~~~~~~~~~~~
+
+Vivamus eleifend posuere arcu, nec bibendum nibh maximus nec. Mauris leo
+mauris, pellentesque vitae risus ut, rutrum finibus leo. Phasellus a nisi
+quam. Vestibulum ullamcorper commodo dui at interdum. Fusce efficitur vitae
+lectus at lacinia. Sed sagittis, nunc sed congue tristique, dolor metus
+ullamcorper libero, eu efficitur lacus est imperdiet nulla. Ut tempor quam
+eu hendrerit volutpat. Integer vitae nunc non urna pellentesque venenatis.
+In volutpat nunc nec fringilla laoreet. Duis sed ornare sem. Aliquam vel mi
+ac nulla eleifend tempor eget vitae elit. Pellentesque vel purus auctor,
+rutrum sem eu, vulputate sem. Aenean sed sem dignissim, viverra odio a,
+fringilla nisl.

--- a/tests/sample-sets/single-confluence-refs/page-b.rst
+++ b/tests/sample-sets/single-confluence-refs/page-b.rst
@@ -1,0 +1,47 @@
+Page B
+======
+
+.. contents::
+    :local:
+
+Section A
+^^^^^^^^^
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam vestibulum
+aliquet ex, mollis finibus tellus feugiat bibendum. Aenean nec lacus
+cursus ligula euismod porta eu non turpis. Cras ultricies sapien elit, id
+finibus lacus iaculis sit amet. Fusce imperdiet ex et diam tempor euismod.
+Curabitur quis lorem eget mi mattis rhoncus. Etiam luctus dolor quis orci
+interdum, nec mattis massa efficitur. Pellentesque volutpat dui non
+venenatis luctus. Aliquam massa dolor, aliquet eu risus eu, viverra volutpat
+urna. Fusce justo enim, tempus sit amet semper sed, imperdiet eu risus.
+Suspendisse eu metus eu est lobortis pellentesque. Ut metus nunc, egestas
+non tortor quis, rutrum hendrerit orci. Integer sed ornare purus.
+
+Section R
+^^^^^^^^^
+
+Praesent rutrum mattis sapien pellentesque egestas. Nunc finibus sem purus,
+eget dictum felis suscipit tempus. Aliquam pretium neque dapibus ipsum
+sollicitudin, sit amet suscipit arcu porta. Sed ac tortor venenatis, viverra
+urna et, pharetra velit. Nullam ut sapien ipsum. In eu nisl augue. Nam velit
+dui, condimentum sed pulvinar interdum, tempus nec dui. Cras dignissim nisi
+in tellus facilisis ultrices. Sed ornare, dolor semper luctus mattis, massa
+tellus accumsan enim, eget semper nulla diam id felis. Pellentesque at
+tempor sem.
+
+Sub-section
+~~~~~~~~~~~
+
+Donec a ligula at tortor vulputate volutpat nec a diam. Duis porttitor urna
+vitae interdum pellentesque. Donec pretium, nulla at hendrerit pulvinar, nulla
+justo laoreet libero, quis bibendum erat metus id tortor. Donec laoreet urna
+non libero venenatis consectetur. Curabitur ex quam, egestas vitae est in,
+condimentum bibendum arcu. In aliquam tortor consequat porta egestas. Maecenas
+interdum ultrices rhoncus. Nunc enim massa, vulputate sed tincidunt vitae,
+lobortis in lorem. Pellentesque eu dui vitae urna pellentesque condimentum
+id et est. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
+posuere cubilia curae; Proin vel molestie lectus, ut ultrices ligula. Sed in
+sapien vulputate, lacinia lectus et, vulputate leo. Nunc eu leo ultrices
+neque tincidunt dictum ac egestas felis. Cras pharetra consequat tellus.
+Morbi hendrerit tincidunt consectetur. Phasellus in tincidunt lacus.

--- a/tests/sample-sets/single-confluence-refs/page-c.rst
+++ b/tests/sample-sets/single-confluence-refs/page-c.rst
@@ -1,0 +1,42 @@
+Page C
+======
+
+.. contents::
+    :local:
+
+Section R
+^^^^^^^^^
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse diam
+arcu, eleifend eu aliquet eu, dapibus vel nibh. Nulla facilisi. Quisque at
+mi eleifend, vehicula velit sit amet, mollis magna. Maecenas hendrerit nisi
+a leo ultricies, vitae ultricies ex hendrerit. Sed finibus consequat justo,
+id volutpat sapien volutpat vitae. Suspendisse tempus dignissim erat id
+vulputate. Donec congue eleifend dignissim. Class aptent taciti sociosqu
+ad litora torquent per conubia nostra, per inceptos himenaeos. Sed elit
+ante, dignissim et mauris vitae, tristique convallis turpis. Vivamus
+sollicitudin ac arcu sit amet dignissim.
+
+Section Z
+^^^^^^^^^
+
+Vivamus at risus vel ligula auctor ultricies. Duis id blandit nulla. Duis
+ornare, urna condimentum pretium dictum, lectus dolor consequat magna, sed
+auctor massa nulla non odio. Nullam sodales sagittis sapien, ut vestibulum
+tortor sollicitudin vel. Mauris pulvinar, arcu sit amet dictum ultricies,
+velit mi varius nulla, eu pulvinar dui libero ut enim. Quisque semper
+vulputate ex vel finibus. Proin congue non nulla pretium hendrerit. Mauris
+elit metus, congue vel risus eu, tempus luctus neque. Interdum et malesuada
+fames ac ante ipsum primis in faucibus. Nulla vel nibh ut sapien aliquam
+placerat ac ac neque. In hac habitasse platea dictumst.
+
+Sub-section
+~~~~~~~~~~~
+
+Vestibulum blandit justo dui, nec consequat dolor malesuada et. Nulla ut
+neque ac metus feugiat suscipit at quis lorem. Nullam mattis gravida nisi
+tempor malesuada. Fusce rutrum, lacus quis efficitur pretium, turpis ipsum
+mollis lacus, sed tincidunt est mi a sem. Nulla ante purus, euismod sit amet
+posuere quis, vehicula ut ligula. Pellentesque volutpat justo eu justo ornare
+convallis. Curabitur dictum urna at laoreet lacinia. Vestibulum vitae accumsan
+turpis.

--- a/tests/sample-sets/single-confluence-refs/tox.ini
+++ b/tests/sample-sets/single-confluence-refs/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+package_root={toxinidir}{/}..{/}..{/}..
+
+[testenv]
+deps =
+    myst-parser
+commands =
+    {envpython} -m tests.test_sample {posargs}
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+    TOX_INI_DIR={toxinidir}
+passenv = *
+use_develop = true

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -201,6 +201,20 @@ class TestConfluenceValidation(unittest.TestCase):
     def test_240_extensions(self):
         self._test_extensions('v2')
 
+    def test_310_singleconfluence(self):
+        config = self.config.clone()
+        config['confluence_editor'] = 'v1'
+        config['confluence_sourcelink'] = None
+        config['confluence_title_overrides'] = {
+            'index': 'Single Confluence',
+        }
+
+        dataset = self.datasets / 'restructuredtext'
+        doc_dir = prepare_dirs('validation-set-rst-singleconfluence')
+
+        build_sphinx(dataset, config=config, out_dir=doc_dir,
+            builder='singleconfluence')
+
     def _test_restructuredtext(self, editor):
         config = self._prepare_editor(editor)
         config['confluence_sourcelink']['container'] += 'restructuredtext/'
@@ -313,6 +327,9 @@ class TestConfluenceValidation(unittest.TestCase):
                 builder.state.register_title(
                     '_validation_prev', 'Markdown Table (Fabric)', None)
                 docnames.insert(0, '_validation_prev')
+                builder.state.register_title(
+                    '_validation_next', 'Single Confluence', None)
+                docnames.append('_validation_next')
             else:
                 builder.state.register_title(
                     '_validation_prev', 'Markdown Table', None)

--- a/tests/unit-tests/datasets/rst/contents-multipage/index.rst
+++ b/tests/unit-tests/datasets/rst/contents-multipage/index.rst
@@ -1,0 +1,8 @@
+index
+=====
+
+.. toctree::
+    :maxdepth: 1
+
+    page-a
+    page-b

--- a/tests/unit-tests/datasets/rst/contents-multipage/page-a.rst
+++ b/tests/unit-tests/datasets/rst/contents-multipage/page-a.rst
@@ -1,0 +1,20 @@
+page-a
+======
+
+.. contents::
+    :local:
+
+section-a
+^^^^^^^^^
+
+data
+
+section-b
+^^^^^^^^^
+
+data
+
+sub-section
+~~~~~~~~~~~
+
+data

--- a/tests/unit-tests/datasets/rst/contents-multipage/page-b.rst
+++ b/tests/unit-tests/datasets/rst/contents-multipage/page-b.rst
@@ -1,0 +1,20 @@
+page-b
+======
+
+.. contents::
+    :local:
+
+section-b
+^^^^^^^^^
+
+data
+
+section-c
+^^^^^^^^^
+
+data
+
+sub-section
+~~~~~~~~~~~
+
+data

--- a/tests/unit-tests/test_singlepage_unique_refs.py
+++ b/tests/unit-tests/test_singlepage_unique_refs.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from tests.lib.parse import parse
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+
+
+class TestConfluenceSinglepageUniqueReferences(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.dataset = cls.datasets / 'rst' / 'contents-multipage'
+
+    @setup_builder('singleconfluence')
+    def test_storage_singlepage_unique_references(self):
+        """validate single page references are unique (storage)"""
+        #
+        # Ensure when generating a single page that merged pages produce
+        # proper references to their sub-sections.
+
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            # verify that all generated anchors are unique
+            unique_anchors = set()
+            anchor_tags = data.find_all('ac:parameter', {'ac:name': ''})
+            for anchor_tag in anchor_tags:
+                anchor_id = anchor_tag.text
+                self.assertNotIn(anchor_id, unique_anchors)
+                unique_anchors.add(anchor_id)
+
+            # verify that each link we have points to a unique anchor
+            #
+            # Note that will it is possible for documents to have more than
+            # one link target a single anchor, for this test, we check for
+            # uniqueness to ensure that each local TOC reference is pointing
+            # to a specific section title.
+            unique_anchor_targets = set()
+            link_tags = data.find_all('ac:link')
+            for link_tag in link_tags:
+                if link_tag.has_attr('ac:anchor'):
+                    anchor_id = link_tag['ac:anchor']
+                    self.assertNotIn(anchor_id, unique_anchor_targets)
+                    unique_anchor_targets.add(anchor_id)


### PR DESCRIPTION
When merging multiple doctrees into a single one, elements may have conflicting reference identifiers. This can lead to conflicting raw anchors as well as other logic in translators to create unexpected links when running the `singleconfluence` builder.

This commit updates the merging process to replace the identifiers of each doctree element when a conflict is detected. Elements will be given a new identifier value, as well as elements referencing other elements will have their reference identifiers updated as well.