### PR TITLE
support: adding more latex packages to documentation container

### DIFF
--- a/.github/workflows/test-docker-publish.yml
+++ b/.github/workflows/test-docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.4.0
+        uses: sigstore/cosign-installer@v3.7.0
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
@@ -59,7 +59,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./support/docker/Dockerfile

--- a/support/docker/Dockerfile
+++ b/support/docker/Dockerfile
@@ -26,8 +26,11 @@ RUN apt-get update && apt-get install --assume-yes \
     python3-pip \
     # Allow preparing a virtual environment
     python3-venv \
-    # TeX Live extra for LaTeX/PDF support
+    # TeX Live extra/fonts for LaTeX/PDF support
+    texlive-fonts-extra \
+    texlive-fonts-recommended \
     texlive-latex-extra \
+    texlive-latex-recommended \
     # Tool used for select tests
     tox \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Sphinx's documentation promotes the use of additional LaTeX packages not included in this extension's doc-helper image. Adding the missing packages for the best experience.