### PR TITLE
.github: move linting jobs into their own workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,9 @@ on:
       - '.github/workflows/build.yml'
       - 'sphinxcontrib/**'
       - 'tests/**'
-      - '.pylintrc'
       - 'MANIFEST.in'
       - 'pyproject.toml'
       - 'requirements_dev.txt'
-      - 'ruff.toml'
       - 'tox.ini'
   pull_request:
     branches:
@@ -24,11 +22,9 @@ on:
       - '.github/workflows/build.yml'
       - 'sphinxcontrib/**'
       - 'tests/**'
-      - '.pylintrc'
       - 'MANIFEST.in'
       - 'pyproject.toml'
       - 'requirements_dev.txt'
-      - 'ruff.toml'
       - 'tox.ini'
 
 jobs:
@@ -62,12 +58,6 @@ jobs:
             #  - test against all other supported OSes, using most recent interpreter/sphinx
             - { os:   macos-latest, python: "3.12", toxenv: py312-sphinx81, cache: ~/Library/Caches/pip }
             - { os: windows-latest, python: "3.12", toxenv: py312-sphinx81, cache: ~\AppData\Local\pip\Cache }
-
-            # linting/other
-            #  - any OS, using most recent interpreter
-            - { os: ubuntu-latest, python: "3.12", toxenv:   ruff, cache: ~/.cache/pip }
-            - { os: ubuntu-latest, python: "3.12", toxenv: pylint, cache: ~/.cache/pip }
-            - { os: ubuntu-latest, python: "3.12", toxenv:   mypy, cache: ~/.cache/pip }
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,63 @@
+# Action which lints the implementation of this extension.
+
+name: Lint
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - '.github/workflows/lint.yml'
+      - 'doc/conf.py'
+      - 'sphinxcontrib/**'
+      - 'tests/**'
+      - '.pylintrc'
+      - 'requirements_dev.txt'
+      - 'ruff.toml'
+      - 'tox.ini'
+  pull_request:
+    branches:
+    - main
+    paths:
+      - '.github/workflows/lint.yml'
+      - 'sphinxcontrib/**'
+      - 'tests/**'
+      - '.pylintrc'
+      - 'requirements_dev.txt'
+      - 'ruff.toml'
+      - 'tox.ini'
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: ${{ matrix.toxenv }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+            - { toxenv:   ruff }
+            - { toxenv: pylint }
+            - { toxenv:   mypy }
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3"
+
+    - name: Cache pip
+      uses: actions/cache@v4
+      id: cache-pip
+      with:
+        path: ~/.cache/pip
+        key: lint-pip-${{ matrix.toxenv }}
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade tox
+
+    - name: tox
+      env:
+        TOXENV: ${{ matrix.toxenv }}
+      run: tox

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -108,7 +108,7 @@ latex_elements = {
     # disable hyphenatation
     # disable justified text
     # remove italics from links
-    # new page for each section 
+    # new page for each section
     # minimize spacing between admonitions
     'preamble': r'''
         \usepackage{datetime2}


### PR DESCRIPTION
The ruff lint environment was put in a non-passed state since it was run on a previous change set. This is since a change in `doc/conf.py` resulted in a failure and a change on this file only triggered the documentation workflow to run. An update to the workflow trigger events is needed to ensure `doc/conf.py` trigger a lint check. Although, we do not want to force an entire build if the documentation's configuration has just changed. Moving linting into its own workflow handle these scenarios.