### PR TITLE
doc: add border style to content entries

### DIFF
--- a/doc/_themes/sphinx13b/static/sphinx13b.css
+++ b/doc/_themes/sphinx13b/static/sphinx13b.css
@@ -530,6 +530,13 @@ p.rubric {
     background-color: #efe9e8 !important;
 }
 
+.rst.directive, .rst.role,
+.std.confval, .std.builderval, .std.event,
+.py.function {
+    border-top: 1px solid #ccc;
+    padding-top: 5px;
+}
+
 @media (max-width: 750px) {
     .quick-links {
         display: none;


### PR DESCRIPTION
When presenting various directives, roles and more; it can a bit hard to make a distinction between each content-section when reading documentation. This help improve the experience, adding a slight border hint at the top of each content-section.