### PR TITLE
translator: replace spaces with dashes when resolving title anchors

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -282,7 +282,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             #    repsective document name) which helps allow `ac:link` macros
             #    properly link when coming from v1 or v2 editor pages.
             if self.v2 and 'names' in node.parent:
-                for anchor in node.parent['names']:
+                for name in node.parent['names']:
+                    anchor = name.replace(' ', '-')
                     target_name = f'{docname}/#{anchor}'
                     target = self.state.target(target_name)
                     if target and target not in new_targets:


### PR DESCRIPTION
When attempting to determine the anchor target for a named title entry, replace any spaces found in a named entry to ensure it can map to an appropriate anchor value (since anchors have no spaces). This should ensure the sanity check for a target lookup help finds the title has a valid target to ensure the anchor is created.