### PR TITLE
lint: update ruff to v0.8.1

### DIFF
--- a/tests/unit-tests/test_util.py
+++ b/tests/unit-tests/test_util.py
@@ -18,5 +18,5 @@ class TestConfluenceUtil(unittest.TestCase):
 'https://intranet-wiki.example.com/rest/api/':    'https://intranet-wiki.example.com/',
 'http://example.atlassian.net/wiki':              'http://example.atlassian.net/wiki/',
         }
-        for key in data:
-            self.assertEqual(ConfluenceUtil.normalize_base_url(key), data[key])
+        for key, val in data.items():
+            self.assertEqual(ConfluenceUtil.normalize_base_url(key), val)

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
 [testenv:ruff]
 deps =
     {[testenv]deps}
-    ruff: ruff==0.6.9
+    ruff: ruff==0.8.1
 setenv =
     {[testenv]setenv}
     RUFF_CACHE_DIR={toxworkdir}/.ruff_cache


### PR DESCRIPTION
Update the fixed ruff version to its most recent.

In addition, correct new linter warnings.