### PR TITLE
drop str-casts for mimetype requests

### DIFF
--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -273,8 +273,7 @@ class ConfluenceAssetManager:
 
         if path not in self.path2asset:
             hash_ = ConfluenceUtil.hash_asset(path)
-            # str-cast for sphinx-6.1
-            type_ = guess_mimetype(str(path), default=DEFAULT_CONTENT_TYPE)
+            type_ = guess_mimetype(path, default=DEFAULT_CONTENT_TYPE)
         else:
             hash_ = self.path2asset[path].hash
             type_ = self.path2asset[path].type

--- a/sphinxcontrib/confluencebuilder/svg.py
+++ b/sphinxcontrib/confluencebuilder/svg.py
@@ -65,7 +65,7 @@ def confluence_supported_svg(builder, node):
         return
 
     # ignore non-svgs
-    mimetype = guess_mimetype(str(abs_path))  # cast for sphinx-6.1
+    mimetype = guess_mimetype(abs_path)
     if mimetype != 'image/svg+xml':
         return
 


### PR DESCRIPTION
Paths pushed into `guess_mimetype` were casted to strings to support Sphinx-6.1 and older versions. Since we no longer support these versions, dropping these casts.