### PR TITLE
assets: ensure forced-standalone handles new-and-matches images

### DIFF
--- a/sphinxcontrib/confluencebuilder/assets.py
+++ b/sphinxcontrib/confluencebuilder/assets.py
@@ -148,7 +148,16 @@ class ConfluenceAssetManager:
                     if self.force_standalone:
                         docname = canon_path(
                             self.env.path2doc(node.document['source']))
-                        assert docname in asset.docnames
+
+                        # check if the expected document name is found in the
+                        # asset's document list; if not and standalone, this
+                        # if just an indication that this is a new/dynamic
+                        # image entry on a document that already exists in
+                        # another document -- for now, indicate the key does
+                        # not exist so that the translator can process the
+                        # image node as something new
+                        if docname not in asset.docnames:
+                            key = None
                     else:
                         if len(asset.docnames) > 1:
                             docname = self.root_doc
@@ -307,7 +316,7 @@ class ConfluenceAssetManager:
                 # duplicate asset detected; build an asset alias
                 asset = self.hash2asset[hash_]
                 self.path2asset[path] = asset
-        else:
+        elif not standalone:
             assert (self.hash2asset[asset.hash] == asset)
 
         # track (if not already) that this document uses this asset


### PR DESCRIPTION
When forcing assets in standalone (e.g. images that are dynamically generated after the pre-processing stage), it will assume a found asset entry is an indication that the asset was generated by another dynamic image on the same document. However, this not guaranteed to be the case. For example, "page a" may generate a standalone image and register it into the asset manager. A few moments later, "page b" may generate its own standalone image instance that results in the same physical file, but the asset message indicates its origin is "page a". With the original implementation, this would generate an assert.

Since the assert is wrong in this case, instead of asserting the document name maps in the asset name, if it does not map, do not consider the cached asset as the asset to use. Instead, we clear the key which allows a translator to rework the asset reference. This in turn should register a reference of this new document in the asset.