### PR TITLE
disable use of inline images in v2 editor

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -266,6 +266,8 @@ def setup(app):
     cm.add_conf_bool('confluence_adv_embedded_certs')
     # List of node types to ignore if no translator support exists.
     cm.add_conf('confluence_adv_ignore_nodes')
+    # Add the inline attribute for images (v2 editor)
+    cm.add_conf_bool('confluence_adv_inlined_images')
     # Unknown node handler dictionary for advanced integrations.
     cm.add_conf('confluence_adv_node_handler')
     # Permit any string value to be provided as the editor.

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1855,7 +1855,11 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if alignment == 'right':
                 attribs['ac:style'] = 'float: right;'
         elif self.v2:
-            attribs['ac:inline'] = 'true'
+            # ideally, images will be inlined but recent v2 editor will
+            # restrict sizing to the line; restrict the feature using a
+            # configuration option for now
+            if self.builder.config.confluence_adv_inlined_images:
+                attribs['ac:inline'] = 'true'
 
         if 'alt' in node:
             alt = node['alt']


### PR DESCRIPTION
Recent changes to Confluence's v2 editor restricted inlined images to a line-height. This is undesired for a default configuration. To avoid this, v2 images will no longer be configured with an inline hint.