### PR TITLE
workflows: test against python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,11 @@ jobs:
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx74, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx80, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx81, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx72, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx73, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx74, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx80, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx81, cache: ~/.cache/pip }
 
             # other OSes
             #  - test against all other supported OSes, using most recent interpreter/sphinx


### PR DESCRIPTION
While Python 3.13.x has been enabled in the tox configuration, the build workflow was never updated to test this interpreter version; updating.