### PR TITLE
builder: use pathlib for internal imgmath override

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -131,8 +131,8 @@ class ConfluenceBuilder(Builder):
         # The imgmath extension allows a builder to override where temporary
         # files are build -- use this to hint to using a temporary directory
         # on the same partition the output directory to help prevent issues.
-        self._imgmath_tempdir = tempfile.mkdtemp(
-            prefix='.imgmath-', dir=self.out_dir)
+        self._imgmath_tempdir = Path(tempfile.mkdtemp(
+            prefix='.imgmath-', dir=self.out_dir))
 
         if self.config.confluence_publish:
             process_ask_configs(self.config)


### PR DESCRIPTION
Updating the internal overwrite of the imgmath temporary directory to use the pathlib module. Upstream version of Sphinx has updated its implementation to use pathlib, and using a str causes issues when running the imgmath extension.

Using `Path` should be fine for existing/older versions of Sphinx, as its value used with `os.path.join` handles `Path` objects.