### PR TITLE
tests: avoid intersphinx processing in legacy pages test

### DIFF
--- a/tests/unit-tests/test_legacy_pages.py
+++ b/tests/unit-tests/test_legacy_pages.py
@@ -18,6 +18,7 @@ class TestConfluenceLegacyPages(ConfluenceTestCase):
 
         config = dict(self.config)
         config['confluence_publish'] = True
+        config['confluence_publish_intersphinx'] = False
         config['confluence_server_url'] = 'https://example.com/'
         config['confluence_space_key'] = 'TEST'
         config['confluence_cleanup_purge'] = True


### PR DESCRIPTION
When attempting to sanity check the handling of legacy pages (for cleanup), the mocked publisher does not aim to support asset-related content. Since intersphinx database can be published by default, the logic an attempt to retrieve page information for the intersphinx database to publish. To avoid this, explicitly disable intersphinx processing for this test.