### PR TITLE
env: maintain tracked page identifier cache between builds

### DIFF
--- a/sphinxcontrib/confluencebuilder/env.py
+++ b/sphinxcontrib/confluencebuilder/env.py
@@ -210,6 +210,9 @@ class ConfluenceCacheInfo:
         new_dochashs = dict(self._cached_dochash)
         new_dochashs.update(self._active_dochash)
 
+        new_pids = dict(self._cached_pids)
+        new_pids.update(self._active_pids)
+
         try:
             with self._cache_cfg_file.open('w', encoding='utf-8') as f:
                 json.dump(new_cfg, f)
@@ -224,6 +227,6 @@ class ConfluenceCacheInfo:
 
         try:
             with self._cache_publish_file.open('w', encoding='utf-8') as f:
-                json.dump(self._active_pids, f)
+                json.dump(new_pids, f)
         except OSError as e:
             self.builder.warn('failed to save cache (pids): ' + e)


### PR DESCRIPTION
When a cache is kept for tracking previously published pages and their identifiers, if a processing event results in pages not needing to be updated, unchanged pages can cause their page identifiers to be removed from the active list. This can result in a following pass to cleanup legacy-flagged pages for pages that are still considered unchanged.

The cache implementation should be maintaining the assumed cached identifier for pages if they remain changed for a run. Updating the implementation to always populate the cached page identifiers before replacing them with new active page identifiers (if any).