### PR TITLE
internal delay all cloud property update events

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -258,6 +258,8 @@ def setup(app):
     cm.add_conf_bool('confluence_adv_bulk_archiving')
     # Force override for detected Cloud state.
     cm.add_conf_bool('confluence_adv_cloud')
+    # Disable any delays when publishing property updates on Cloud
+    cm.add_conf_bool('confluence_adv_disable_cloud_prop_delay')
     # Disable workaround for: https://jira.atlassian.com/browse/CONFCLOUD-74698
     cm.add_conf_bool('confluence_adv_disable_confcloud_74698')
     # Disable workaround for inline-extension anchor injection

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1112,13 +1112,6 @@ class ConfluencePublisher:
 
                     uploaded_page_id = rsp['id']
 
-                    # always wait a little moment before updating properies on
-                    # cloud -- it seems to take a moment to complete creating
-                    # initial properties after we build a new page, and we want
-                    # to avoid a conflict (409) if possible
-                    if self.cloud:
-                        time.sleep(0.5)
-
                     # we have properties we would like to apply, but we cannot
                     # just create new ones if Confluence already created ones
                     # implicitly in the new page update -- we will need to
@@ -1242,6 +1235,14 @@ class ConfluencePublisher:
             page_id: the id of the page to update
             properties: the properties to update
         """
+
+        # always wait a little moment before updating properties on
+        # cloud -- it seems to take a moment to complete creating or
+        # updating properties after we build process a page, and we want
+        # to avoid a conflict (409) if possible
+        if self.cloud:
+            if not self.config.confluence_adv_disable_cloud_prop_delay:
+                time.sleep(0.5)
 
         # we have properties we would like to apply, but we cannot
         # just create new ones if Confluence already created ones


### PR DESCRIPTION
When attempting to update page properties, an internal delay was added for new pages to help reduce the chance for errors such as conflicts observed. This commit extends the small wait for page updates as well, to help ensure page update scenarios can avoid conflicts/issues when immediately trying to update properties after a page update.

Related to this, we also introduce an internal configuration option `confluence_adv_disable_cloud_prop_delay`, allowing advanced users the means to opt-out of any delay.