### PR TITLE
support property retry events for extension-specific properties

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -960,6 +960,7 @@ class ConfluencePublisher:
         # fetch known properties (associated with this extension) from the page
         page_id = page['id'] if page else None
         cb_props = self.get_page_property(page_id, CB_PROP_KEY, {
+            'key': CB_PROP_KEY,
             'value': {},
         })
 
@@ -1197,6 +1198,7 @@ class ConfluencePublisher:
 
         # fetch known properties (associated with this extension) from the page
         cb_props = self.get_page_property(page_id, CB_PROP_KEY, {
+            'key': CB_PROP_KEY,
             'value': {},
         })
 
@@ -1534,7 +1536,7 @@ class ConfluencePublisher:
 
         # push an updated to confluence builder property which includes an
         # updated hash value
-        self.store_page_property(page_id, CB_PROP_KEY, cb_props)
+        self._update_page_properties(page_id, [cb_props])
 
         # ensure remove any watch flags on the update if watching is disabled
         if not self.watch:

--- a/tests/unit-tests/test_publisher_page.py
+++ b/tests/unit-tests/test_publisher_page.py
@@ -66,7 +66,8 @@ class TestConfluencePublisherPage(unittest.TestCase):
                     'number': '1',
                 },
             }
-            daemon.register_get_rsp(200, scb_fetch_props_rsp)
+            daemon.register_get_rsp(200, scb_fetch_props_rsp)  # initial
+            daemon.register_get_rsp(200, scb_fetch_props_rsp)  # re-fetch
 
             # prepare response for update event
             daemon.register_put_rsp(200, dict(page_fetch_rsp))
@@ -104,6 +105,9 @@ class TestConfluencePublisherPage(unittest.TestCase):
             self.assertIsNotNone(update_req)
 
             # check that the property request on the page was done
+            props_fetch_req = daemon.pop_get_request()
+            self.assertIsNotNone(props_fetch_req)
+
             props_fetch_req = daemon.pop_get_request()
             self.assertIsNotNone(props_fetch_req)
 
@@ -156,7 +160,8 @@ class TestConfluencePublisherPage(unittest.TestCase):
                     'number': '1',
                 },
             }
-            daemon.register_get_rsp(200, scb_fetch_props_rsp)
+            daemon.register_get_rsp(200, scb_fetch_props_rsp)  # initial
+            daemon.register_get_rsp(200, scb_fetch_props_rsp)  # re-fetch
 
             # prepare response for update event
             daemon.register_put_rsp(200, dict(page_fetch_rsp))
@@ -197,6 +202,9 @@ class TestConfluencePublisherPage(unittest.TestCase):
             self.assertIsNotNone(update_req)
 
             # check that the property request on the page was done
+            props_fetch_req = daemon.pop_get_request()
+            self.assertIsNotNone(props_fetch_req)
+
             props_fetch_req = daemon.pop_get_request()
             self.assertIsNotNone(props_fetch_req)
 


### PR DESCRIPTION
This extension will update page properties under a get-then-update process, where a retry attempt will be made to help deal with conflict scenarios. This only applied to Confluence-specific properties and not this extension's custom property (e.g. used for page hash tracking).

This commit is updated the implementation to perform the get-then-update with retries for all property submissions, in attempt to prevent odd publish scenarios for users.