### PR TITLE
support user overrides of api retry failure attempts/duration

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1752,6 +1752,42 @@ Advanced publishing configuration
 
     .. versionadded:: 2.5
 
+.. _confluence_publish_retry_attempts:
+
+.. confval:: confluence_publish_retry_attempts
+
+    Allows a user to override how many retry attempts are permitted when a
+    single API request fails. By default, this extension uses a maximum
+    retry of two, allowing a single request to be attempted three times
+    for select failure events.
+
+    Failure scenarios that are retried on include all 500-series errors,
+    as well as couple of observed/reported corner cases reported by
+    Confluence instances during the life-cycle of this extension.
+
+    .. code-block:: python
+
+        confluence_publish_retry_attempts = 2
+
+    See also :lref:`confluence_publish_retry_duration`.
+
+    .. versionadded:: 2.10
+
+.. _confluence_publish_retry_duration:
+
+.. confval:: confluence_publish_retry_duration
+
+    The duration (in seconds) to wait between API retry events on select
+    failures. By default, the duration waited is four seconds.
+
+    .. code-block:: python
+
+        confluence_publish_retry_duration = 4
+
+    See also :lref:`confluence_publish_retry_attempts`.
+
+    .. versionadded:: 2.10
+
 .. confval:: confluence_request_session_override
 
     A hook to manipulate a Requests_ session prepared by this extension. Allows

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -214,6 +214,10 @@ def setup(app):
     cm.add_conf_int('confluence_publish_orphan_container')
     # Override the path prefixes for various REST API requests.
     cm.add_conf('confluence_publish_override_api_prefix')
+    # Number of attempts permitted when trying to retry a failed API request
+    cm.add_conf('confluence_publish_retry_attempts')
+    # Duration (in seconds) between retrying failed API requests
+    cm.add_conf('confluence_publish_retry_duration')
     # Manipulate a requests instance.
     cm.add_conf('confluence_request_session_override')
     # Authentication passthrough for Confluence REST interaction.

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -590,6 +590,16 @@ def validate_configuration(builder):
 
     # ##################################################################
 
+    validator.conf('confluence_publish_retry_attempts') \
+             .int_(positive=True)
+
+    # ##################################################################
+
+    validator.conf('confluence_publish_retry_duration') \
+             .int_(positive=True)
+
+    # ##################################################################
+
     validator.conf('confluence_publish_root') \
              .int_(positive=True)
 

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -906,6 +906,28 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_publish_prefix'] = 'dummy'
         self._try_config()
 
+    def test_config_check_publish_retry_attempts(self):
+        self.config['confluence_publish_retry_attempts'] = 10
+        self._try_config()
+
+        self.config['confluence_publish_retry_attempts'] = '999'
+        self._try_config()
+
+        self.config['confluence_publish_retry_attempts'] = -1
+        with self.assertRaises(ConfluenceConfigError):
+            self._try_config()
+
+    def test_config_check_publish_retry_duration(self):
+        self.config['confluence_publish_retry_duration'] = 2
+        self._try_config()
+
+        self.config['confluence_publish_retry_duration'] = '2'
+        self._try_config()
+
+        self.config['confluence_publish_retry_duration'] = -1
+        with self.assertRaises(ConfluenceConfigError):
+            self._try_config()
+
     def test_config_check_publish_root(self):
         # enable publishing enabled checks
         self._prepare_valid_publish()


### PR DESCRIPTION
There are select scenarios where this extension may retry a failed API event when publishing. The original implementation included a fixed retry attempt (max three attempts) and a retry duration of four seconds.

To make things more flexible for users, these options are now configurable from the project configuration.