### PR TITLE
rest: adjust publish retry events based on transient errors

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -124,8 +124,10 @@ def confluence_error_retries():
                     if any(x in ex_str for x in API_NORETRY_ERRORS):
                         raise
 
-                    # Always retry on 5xx error codes.
-                    if ex.status_code >= 500 and ex.status_code <= 599:
+                    # Retry on transient errors.
+                    #
+                    # See: https://everything.curl.dev/usingcurl/downloads/retry.html#retry
+                    if ex.status_code in (408, 429, 500, 502, 503, 504):
                         pass
                     # Check if the reported state is a retry condition, but
                     # Confluence does not report a 5xx error code for the


### PR DESCRIPTION
The curl documentation gives a good capture of transient errors and what it's `--retry` call supports a retry on. Instead of having this extension retry on all 500 errors, narrow down the scope to specific errors more so valid for a retry. We also extend the retry events on select timeout-related events.