### PR TITLE
translator: support new production node newline

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -2168,7 +2168,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             else:
                 prefix = ' ' * len(lastname)
                 self.body.append(f'{prefix}    ')
-            text = production.astext()
+            text = production.astext().rstrip()
             text = self.encode(text)
             self.body.append(text + self.nl)
 


### PR DESCRIPTION
In Sphinx v8.2, production entries appear to provide a newline entry for us. While this means we do not have to append on ourselves, we still want to support some older versions of Sphinx. For now, strip any trailing newline and still append our own.