### PR TITLE
transmute: support new no-wrap flag for math directives

### DIFF
--- a/sphinxcontrib/confluencebuilder/transmute/__init__.py
+++ b/sphinxcontrib/confluencebuilder/transmute/__init__.py
@@ -354,7 +354,7 @@ def replace_math_blocks(builder, doctree):
         inlined_math = isinstance(node, nodes.math)
 
         if not inlined_math:
-            if node['nowrap']:
+            if node.get('no-wrap', node.get('nowrap', False)):
                 latex = node.astext()
             else:
                 latex = wrap_displaymath(node.astext(), None, numbering=False)


### PR DESCRIPTION
In Sphinx v8.2, math directives now promote the use of `no-wrap` over `nowrap`. Adjust the implementation to support both for now.