### PR TITLE
rest: relax content-type check for dumping request data

### DIFF
--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -451,7 +451,7 @@ class Rest:
             if dump_body and req.body:
                 print('(debug) Request data]')
                 content_type = req.headers.get('Content-Type') or ''
-                if content_type == 'application/json;charset=utf-8':
+                if 'application/json' in content_type:
                     try:
                         json_data = json.dumps(json.loads(req.body), indent=2)
                         print(json_data)

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -435,6 +435,9 @@ class Rest:
             filtered_headers = dict(req.headers)
             if PublishDebug.headers_raw not in publish_debug_opts:
                 fde = [
+                    'Atl-Confluence-Via',
+                    'Atl-Request-Id',
+                    'Atl-Traceid',
                     'Authorization',
                     'Cookie',
                 ]


### PR DESCRIPTION
When configured to log request data to the standard output stream, the check used to consider printing JSON data checked if the content type was marked as `application/json;charset=utf-8`. However, it has been observed in recent testing that content type used for JSON-related requests was set to `application/json`.

Adjusting to check to just look for `application/json` in the content type before attempting to parse/output JSON content in a debug mode.