### PR TITLE
publisher: restore raising of an api error

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1655,6 +1655,8 @@ class ConfluencePublisher:
                 raise ConfluenceUnreconciledPageError(
                     page_name, page['id'], self.server_url, ex) from ex
 
+            raise
+
         # post-update requests (api v2 mode)
         update_page_id = update_page['id']
 


### PR DESCRIPTION
When refactoring the retry REST call implementation \[1\], this change undesirably suppressed API errors on page update events. We should always be raising the `ConfluenceBadApiError` exception if we do not have a specific override exception to replace it with.

\[1\]: 6a1f9badd4716234271b75ac79dfe097ee6c3287