### PR TITLE
rest: update/correct filtering of headers for debug logging

### DIFF
--- a/sphinxcontrib/confluencebuilder/debug.py
+++ b/sphinxcontrib/confluencebuilder/debug.py
@@ -35,3 +35,19 @@ class PublishDebug(Flag):
     all = data | headers | urllib3
     # enable all developer logging
     developer = deprecated | all
+
+
+# list of headers to filter out in any debug captures
+FILTERED_HEADERS = [
+    'Atl-Confluence-Via',
+    'Atl-Request-Id',
+    'Atl-Traceid',
+    'Authorization',
+    'Cookie',
+    'Link',
+    'Report-To',
+    'Server-Timing',
+    'Via',
+    'X-Amz-Cf-Id',
+    'X-Amz-Cf-Pop',
+]

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -5,6 +5,7 @@ from email.utils import mktime_tz
 from email.utils import parsedate_tz
 from functools import wraps
 from requests.adapters import HTTPAdapter
+from sphinxcontrib.confluencebuilder.debug import FILTERED_HEADERS
 from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceAuthenticationFailedUrlError
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceBadApiError
@@ -434,14 +435,7 @@ class Rest:
             # see non-redacted content
             filtered_headers = dict(req.headers)
             if PublishDebug.headers_raw not in publish_debug_opts:
-                fde = [
-                    'Atl-Confluence-Via',
-                    'Atl-Request-Id',
-                    'Atl-Traceid',
-                    'Authorization',
-                    'Cookie',
-                ]
-                for entry in fde:
+                for entry in FILTERED_HEADERS:
                     if filtered_headers.get(entry):
                         filtered_headers[entry] = '(redacted)'
 
@@ -469,9 +463,15 @@ class Rest:
 
         # debug logging
         if dump:
+            filtered_headers = dict(rsp.headers)
+            if PublishDebug.headers_raw not in publish_debug_opts:
+                for entry in FILTERED_HEADERS:
+                    if filtered_headers.get(entry):
+                        filtered_headers[entry] = '(redacted)'
+
             print('(debug) Response]')
             print(f'Code: {rsp.status_code}')
-            print('\n'.join(f'{k}: {v}' for k, v in rsp.headers.items()))
+            print('\n'.join(f'{k}: {v}' for k, v in filtered_headers.items()))
             print(flush=True)
 
             if dump_body and rsp.text:


### PR DESCRIPTION
Updated the set of headers to automatically filter during debug logging. We now ensure filtering runs on both outgoing and incoming events.