### PR TITLE
Improve property duplication detection and handling

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -1252,8 +1252,7 @@ class ConfluencePublisher:
             # return (timing issue); so if we get a conflict error (409),
             # we will retry a fetch/update again
             MAX_ATTEMPTS_TO_UPDATE_PROPERTY = 2
-            attempt = 1
-            while attempt <= MAX_ATTEMPTS_TO_UPDATE_PROPERTY:
+            for attempt in range(MAX_ATTEMPTS_TO_UPDATE_PROPERTY):
                 prop_key = prop['key']
                 prop_entry = self.get_page_property(page_id, prop_key)
 
@@ -1265,19 +1264,16 @@ class ConfluencePublisher:
                 prop_entry['value'] = prop['value']
 
                 try:
-                    self.store_page_property(
-                        page_id,
-                        prop_key,
-                        prop_entry,
-                    )
+                    self.store_page_property(page_id, prop_key, prop_entry)
                 except ConfluenceBadApiError as ex:
-                    if ex.status_code != 409:
+                    if attempt >= MAX_ATTEMPTS_TO_UPDATE_PROPERTY -1:
                         raise
 
                     # retry on conflict
-                    logger.info('property update conflict; retrying...')
-
-                    attempt += 1
+                    if ex.status_code == 409:
+                        logger.info('property update conflict; retrying...')
+                    else:
+                        raise
                 else:
                     break
 

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -621,9 +621,7 @@ class ConfluencePublisher:
                 props_to_fetch.append('editor')
 
             for prop_key in props_to_fetch:
-                prop_entry = self.get_page_property(page_id, prop_key, {
-                    'value': None,
-                })
+                prop_entry = self.get_page_property(page_id, prop_key)
                 meta_props[prop_key] = prop_entry
 
         return page_id, page
@@ -712,19 +710,23 @@ class ConfluencePublisher:
         get a property from the provided page id
 
         Performs an API call to acquire a property held on a specific page.
-        This call can returns the page properties dictionary if found;
-        otherwise ``None`` will be returned.
+        This call can returns the page properties dictionary. If the property
+        was not found, it will return a pre-populated properties entry with
+        a value of ``None``.
 
         Args:
             page_id: the page identifier
             key: the property key
-            default (optional): default value if no property exists
+            default (optional): default value for property if no property exists
 
         Returns:
             the property value
         """
 
-        props = default
+        props = {
+            'key': key,
+            'value': default,
+        }
 
         if page_id:
             try:
@@ -951,10 +953,7 @@ class ConfluencePublisher:
 
         # fetch known properties (associated with this extension) from the page
         page_id = page['id'] if page else None
-        cb_props = self.get_page_property(page_id, CB_PROP_KEY, {
-            'key': CB_PROP_KEY,
-            'value': {},
-        })
+        cb_props = self.get_page_property(page_id, CB_PROP_KEY, default={})
 
         # calculate the hash for a page; we will first use this to check if
         # there is a update to apply, and if we do need to update, we will
@@ -1182,10 +1181,7 @@ class ConfluencePublisher:
             raise ConfluenceMissingPageIdError(self.space_key, page_id) from ex
 
         # fetch known properties (associated with this extension) from the page
-        cb_props = self.get_page_property(page_id, CB_PROP_KEY, {
-            'key': CB_PROP_KEY,
-            'value': {},
-        })
+        cb_props = self.get_page_property(page_id, CB_PROP_KEY, default={})
 
         # calculate the hash for a page; we will first use this to check if
         # there is a update to apply, and if we do need to update, we will
@@ -1253,9 +1249,7 @@ class ConfluencePublisher:
             attempt = 1
             while attempt <= MAX_ATTEMPTS_TO_UPDATE_PROPERTY:
                 prop_key = prop['key']
-                prop_entry = self.get_page_property(page_id, prop_key, {
-                    'value': None,
-                })
+                prop_entry = self.get_page_property(page_id, prop_key)
 
                 # ignore if the property already matches the desired
                 # value

--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -737,6 +737,12 @@ class ConfluencePublisher:
                     })
                     if rsp['results']:
                         props = rsp['results'][0]
+
+                        total_props = len(rsp['results'])
+                        if total_props > 1:
+                            logger.warn('multiple properties detected for key '
+                                       f'(page: {page_id}; '
+                                       f'total: {total_props}): {key}')
                 else:
                     prop_path = f'{self.APIV1}content/{page_id}/property/{key}'
                     props = self.rest.get(prop_path)


### PR DESCRIPTION
### publisher: warn if multiple same-key properties are detected on a page

In theory, there should only be a mapping of one property per key on a page. It has been reported in some scenarios that duplicate keys may exist on a Confluence database, which appears to be an undesired state. To help with debugging, if multiple results are detected, report this as a warning.

### publisher: ensure api failure is reported after failed retry attempts

When attempting to update a property, the implementation can try at least two times when dealing with a conflict scenario (typically, for new page update events). While the retries are performed, the logic should have been always raising an error if the final retry failed; correcting.

### publisher: attempt to perform a property refresh on hidden conflict

Users have reported scenarios where a property update may fail due to a duplicate property entry registered in Confluence's db. In this scenario, Confluence can report a 400 error. To try to help push the database back into an ideal state, we will request to remove the property to cleanup then re-push a new property entry back in -- this should be fine for all property types that this extension intends to manage.
