### PR TITLE
initial/limited inlined comment check support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1795,6 +1795,29 @@ Advanced publishing configuration
 
     .. versionadded:: 2.10
 
+.. confval:: confluence_publish_skip_commented_pages
+
+    .. note::
+
+        There is no support to keep inlined comments on updated pages at
+        this time.
+
+    Indicates to skip updates on pages which have inlined comments. Before
+    a page update is issued, a warning will be generated if this extension
+    detects that a page has inlined comments added to it. Page updates
+    remove any inlined comments embedded in the page source. If a users
+    wants to prevent any updates on pages to prevent the loss of inlined
+    comments, they can configure this option to ``True``. By default, pages
+    will always be updated with a value of ``False``.
+
+    .. code-block:: python
+
+        confluence_publish_skip_commented_pages = True
+
+    See also :lref:`suppress_warnings_config`.
+
+    .. versionadded:: 2.13
+
 .. confval:: confluence_request_session_override
 
     A hook to manipulate a Requests_ session prepared by this extension. Allows
@@ -2294,6 +2317,8 @@ Third-party related options
 Other options
 -------------
 
+.. _suppress_warnings_config:
+
 .. confval:: suppress_warnings
 
     This extension supports suppressing warnings using Sphinx's
@@ -2303,7 +2328,16 @@ Other options
     - ``confluence`` -- All warnings
     - ``confluence.deprecated`` -- Configuration deprecated warnings
     - ``confluence.deprecated_develop`` -- Development deprecated warnings
+    - ``confluence.inline-comment`` -- Inlined comment warnings
     - ``confluence.unsupported_code_lang`` -- Unsupported code language
+
+    For example:
+
+    .. code-block:: python
+
+        suppress_warnings = [
+            'confluence.unsupported_code_lang',
+        ]
 
     .. versionadded:: 2.1
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -218,6 +218,8 @@ def setup(app):
     cm.add_conf('confluence_publish_retry_attempts')
     # Duration (in seconds) between retrying failed API requests
     cm.add_conf('confluence_publish_retry_duration')
+    # Whether to skip page updates for pages that have inlined comments
+    cm.add_conf_bool('confluence_publish_skip_commented_pages')
     # Manipulate a requests instance.
     cm.add_conf('confluence_request_session_override')
     # Authentication passthrough for Confluence REST interaction.


### PR DESCRIPTION
Provides a crude check to warn if a page update will result in the lost of inlined comments on a page. Users can fail a publish attempt in these situations using `--fail-on-warning` \[1\], if desired.

This commit also adds the `confluence_publish_skip_commented_pages` option, to allow skipping page updates on inlined commented pages (instead of overwriting the page).

Note that resolved comments are still considered a flagged state for inlined comment. So, a page update will warn even if all comments are resolved.

\[1\]: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-W