### PR TITLE
doc: drop centos install nodes

### DIFF
--- a/doc/install-virtualenv.rst
+++ b/doc/install-virtualenv.rst
@@ -28,20 +28,6 @@ Arch (virtualenv)
     $ python -m sphinxcontrib.confluencebuilder --version
     sphinxcontrib.confluencebuilder <version>
 
-CentOS (virtualenv)
-~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: shell-session
-
-    $ sudo yum install epel-release
-    $ sudo yum install python-pip
-    $ sudo yum install python-virtualenv
-    $ virtualenv sphinx-venv
-    $ source sphinx-venv/bin/activate
-    $ pip install sphinxcontrib-confluencebuilder
-    $ python -m sphinxcontrib.confluencebuilder --version
-    sphinxcontrib.confluencebuilder <version>
-
 Fedora (virtualenv)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -50,17 +50,6 @@ Arch
     $ python -m sphinxcontrib.confluencebuilder --version
     sphinxcontrib.confluencebuilder <version>
 
-CentOS
-~~~~~~
-
-.. code-block:: shell-session
-
-    $ sudo yum install epel-release
-    $ sudo yum install python-pip
-    $ pip install sphinxcontrib-confluencebuilder
-    $ python -m sphinxcontrib.confluencebuilder --version
-    sphinxcontrib.confluencebuilder <version>
-
 Fedora
 ~~~~~~
 


### PR DESCRIPTION
CentOS is a discounted distribution. Dropping its help from the installation documentation.