### PR TITLE
publisher: improve error message on update attempts on restricted pages

### DIFF
--- a/sphinxcontrib/confluencebuilder/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/exceptions.py
@@ -85,6 +85,29 @@ as the identifier could not be found.
 ''')
 
 
+class ConfluencePagePermissionError(ConfluenceError):
+    def __init__(self, page_name):
+        super().__init__(f'''
+---
+Permission denied on page update for: {page_name}
+
+An attempt has been made to add/update a page on Confluence, but the
+instance has reported a "title already exists" error. Typically, the
+reason for this is a result of a page has/had been configured with
+restrictive permissions, preventing this publish request from making a
+new page update.
+
+It is recommended to try the publish request again in the case this
+error state resolves itself. If this persisted, try contacting the
+owner of the space for help (e.g. manually removing the legacy page).
+
+Note that if the target page cannot be found, the page may have been
+previously archived with restricted permission. The page may need to be
+manually removed to correct the issue.
+---
+''')
+
+
 class ConfluencePermissionError(ConfluenceError):
     def __init__(self, details):
         super().__init__(f'''


### PR DESCRIPTION
When a user attempts to publish to Confluence that results in a page update to a restricted page, Confluence API reports a 404 error as the page cannot be found, versus a 403 error. This occurs when another user may have setup view/edit permissions on a page. There is also the fun case where if a user archives the page, the permissions are still configured making it more confusing that the page appears to be legit missing.

This commit attempts to improve the error handling for such scenarios. For cases where we have found a page and failed to update with a 404, we will assume that the page is an edit-locked page (granted, it may be an odd timing error of someone deleting the page between fetch and update, but we have tailored the error message to hint to "try again" for such scenarios). In the case where a new page is being added since we detected no existing page and a title conflict exists, we will assume the page is a view-restricted page.