### PR TITLE
translator: delayed anchor injection for other refids

### DIFF
--- a/tests/unit-tests/test_references_confluence.py
+++ b/tests/unit-tests/test_references_confluence.py
@@ -86,21 +86,25 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
 
             # anchor in local-toc
             ltoc_entry = local_toc_entries.pop(0)
-            ltoc_anchor = ltoc_entry.find(
+            ltoc_anchors = ltoc_entry.find_all(
                 'ac:structured-macro', {'ac:name': 'anchor'})
-            self.assertIsNotNone(ltoc_anchor)
-            anchor_param = ltoc_anchor.find('ac:parameter')
-            self.assertIsNotNone(anchor_param)
-            anchor_01_id = anchor_param.text
+            self.assertGreaterEqual(len(ltoc_anchors), 1)
+            anchor_01_ids = []
+            for ltoc_anchor in ltoc_anchors:
+                anchor_param = ltoc_anchor.find('ac:parameter')
+                self.assertIsNotNone(anchor_param)
+                anchor_01_ids.append(anchor_param.text)
 
             # anchor in local-toc
             ltoc_entry = local_toc_entries.pop(0)
-            ltoc_anchor = ltoc_entry.find(
+            ltoc_anchors = ltoc_entry.find_all(
                 'ac:structured-macro', {'ac:name': 'anchor'})
-            self.assertIsNotNone(ltoc_anchor)
-            anchor_param = ltoc_anchor.find('ac:parameter')
-            self.assertIsNotNone(anchor_param)
-            anchor_02_id = anchor_param.text
+            self.assertGreaterEqual(len(ltoc_anchors), 1)
+            anchor_02_ids = []
+            for ltoc_anchor in ltoc_anchors:
+                anchor_param = ltoc_anchor.find('ac:parameter')
+                self.assertIsNotNone(anchor_param)
+                anchor_02_ids.append(anchor_param.text)
 
             # anchor after pre-content
             content_element = data.find('p', text='pre-content')
@@ -138,7 +142,7 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
             # header link to a local-toc entry
             ac_link = ac_links.pop(0)
             self.assertTrue(ac_link.has_attr('ac:anchor'))
-            self.assertEqual(ac_link['ac:anchor'], anchor_01_id)
+            self.assertIn(ac_link['ac:anchor'], anchor_01_ids)
             ac_link_body = ac_link.find('ac:link-body')
             self.assertIsNotNone(ac_link_body)
             self.assertEqual(ac_link_body.text, 'An Extra Header')
@@ -146,7 +150,7 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
             # header link to a local-toc entry
             ac_link = ac_links.pop(0)
             self.assertTrue(ac_link.has_attr('ac:anchor'))
-            self.assertEqual(ac_link['ac:anchor'], anchor_02_id)
+            self.assertIn(ac_link['ac:anchor'], anchor_02_ids)
             ac_link_body = ac_link.find('ac:link-body')
             self.assertIsNotNone(ac_link_body)
             self.assertEqual(ac_link_body.text, 'An Extra Header')
@@ -295,21 +299,25 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
 
             # anchor in local-toc
             ltoc_entry = local_toc_entries.pop(0)
-            ltoc_anchor = ltoc_entry.find(
+            ltoc_anchors = ltoc_entry.find_all(
                 'ac:structured-macro', {'ac:name': 'anchor'})
-            self.assertIsNotNone(ltoc_anchor)
-            anchor_param = ltoc_anchor.find('ac:parameter')
-            self.assertIsNotNone(anchor_param)
-            anchor_01_id = anchor_param.text
+            self.assertGreaterEqual(len(ltoc_anchors), 1)
+            anchor_01_ids = []
+            for ltoc_anchor in ltoc_anchors:
+                anchor_param = ltoc_anchor.find('ac:parameter')
+                self.assertIsNotNone(anchor_param)
+                anchor_01_ids.append(anchor_param.text)
 
             # anchor in local-toc
             ltoc_entry = local_toc_entries.pop(0)
-            ltoc_anchor = ltoc_entry.find(
+            ltoc_anchors = ltoc_entry.find_all(
                 'ac:structured-macro', {'ac:name': 'anchor'})
-            self.assertIsNotNone(ltoc_anchor)
-            anchor_param = ltoc_anchor.find('ac:parameter')
-            self.assertIsNotNone(anchor_param)
-            anchor_02_id = anchor_param.text
+            self.assertGreaterEqual(len(ltoc_anchors), 1)
+            anchor_02_ids = []
+            for ltoc_anchor in ltoc_anchors:
+                anchor_param = ltoc_anchor.find('ac:parameter')
+                self.assertIsNotNone(anchor_param)
+                anchor_02_ids.append(anchor_param.text)
 
             # anchor after pre-content
             content_element = data.find('p', text='pre-content')
@@ -331,7 +339,7 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
             # header link to a local-toc entry
             ac_link = ac_links.pop(0)
             self.assertTrue(ac_link.has_attr('ac:anchor'))
-            self.assertEqual(ac_link['ac:anchor'], anchor_01_id)
+            self.assertIn(ac_link['ac:anchor'], anchor_01_ids)
             ac_link_body = ac_link.find('ac:link-body')
             self.assertIsNotNone(ac_link_body)
             self.assertEqual(ac_link_body.text, 'An Extra Header')
@@ -339,7 +347,7 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
             # header link to a local-toc entry
             ac_link = ac_links.pop(0)
             self.assertTrue(ac_link.has_attr('ac:anchor'))
-            self.assertEqual(ac_link['ac:anchor'], anchor_02_id)
+            self.assertIn(ac_link['ac:anchor'], anchor_02_ids)
             ac_link_body = ac_link.find('ac:link-body')
             self.assertIsNotNone(ac_link_body)
             self.assertEqual(ac_link_body.text, 'An Extra Header')
@@ -497,21 +505,25 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
 
             # anchor in first header
             header_entry = header_entries.pop(0)
-            header_anchor = header_entry.find(
+            header_anchors = header_entry.find_all(
                 'ac:structured-macro', {'ac:name': 'anchor'})
-            self.assertIsNotNone(header_anchor)
-            anchor_param = header_anchor.find('ac:parameter')
-            self.assertIsNotNone(anchor_param)
-            anchor_01_id = anchor_param.text
+            self.assertGreaterEqual(len(ltoc_anchors), 1)
+            anchor_01_ids = []
+            for header_anchor in header_anchors:
+                anchor_param = header_anchor.find('ac:parameter')
+                self.assertIsNotNone(anchor_param)
+                anchor_01_ids.append(anchor_param.text)
 
             # anchor in second header
             header_entry = header_entries.pop(0)
-            header_anchor = header_entry.find(
+            header_anchors = header_entry.find_all(
                 'ac:structured-macro', {'ac:name': 'anchor'})
-            self.assertIsNotNone(header_anchor)
-            anchor_param = header_anchor.find('ac:parameter')
-            self.assertIsNotNone(anchor_param)
-            anchor_02_id = anchor_param.text
+            self.assertGreaterEqual(len(ltoc_anchors), 1)
+            anchor_02_ids = []
+            for header_anchor in header_anchors:
+                anchor_param = header_anchor.find('ac:parameter')
+                self.assertIsNotNone(anchor_param)
+                anchor_02_ids.append(anchor_param.text)
 
             # ##########################################################
             # find the expected ac:link macros
@@ -522,7 +534,7 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
             # heading jump to other heading
             ac_link = ac_links.pop(0)
             self.assertTrue(ac_link.has_attr('ac:anchor'))
-            self.assertEqual(ac_link['ac:anchor'], anchor_01_id)
+            self.assertIn(ac_link['ac:anchor'], anchor_01_ids)
             link_page = ac_link.find('ri:page')
             self.assertIsNone(link_page)
             ac_link_body = ac_link.find('ac:link-body')
@@ -532,7 +544,7 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
             # link to the sub-heading on this page
             ac_link = ac_links.pop(0)
             self.assertTrue(ac_link.has_attr('ac:anchor'))
-            self.assertEqual(ac_link['ac:anchor'], anchor_01_id)
+            self.assertIn(ac_link['ac:anchor'], anchor_01_ids)
             link_page = ac_link.find('ri:page')
             self.assertIsNone(link_page)
             ac_link_body = ac_link.find('ac:link-body')
@@ -543,7 +555,7 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
             # link to the second sub-heading on this page
             ac_link = ac_links.pop(0)
             self.assertTrue(ac_link.has_attr('ac:anchor'))
-            self.assertEqual(ac_link['ac:anchor'], anchor_02_id)
+            self.assertIn(ac_link['ac:anchor'], anchor_02_ids)
             link_page = ac_link.find('ri:page')
             self.assertIsNone(link_page)
             ac_link_body = ac_link.find('ac:link-body')
@@ -607,21 +619,25 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
 
             # anchor in first header
             header_entry = header_entries.pop(0)
-            header_anchor = header_entry.find(
+            header_anchors = header_entry.find_all(
                 'ac:structured-macro', {'ac:name': 'anchor'})
-            self.assertIsNotNone(header_anchor)
-            anchor_param = header_anchor.find('ac:parameter')
-            self.assertIsNotNone(anchor_param)
-            anchor_01_id = anchor_param.text
+            self.assertGreaterEqual(len(ltoc_anchors), 1)
+            anchor_01_ids = []
+            for header_anchor in header_anchors:
+                anchor_param = header_anchor.find('ac:parameter')
+                self.assertIsNotNone(anchor_param)
+                anchor_01_ids.append(anchor_param.text)
 
             # anchor in second header
             header_entry = header_entries.pop(0)
-            header_anchor = header_entry.find(
+            header_anchors = header_entry.find_all(
                 'ac:structured-macro', {'ac:name': 'anchor'})
-            self.assertIsNotNone(header_anchor)
-            anchor_param = header_anchor.find('ac:parameter')
-            self.assertIsNotNone(anchor_param)
-            anchor_02_id = anchor_param.text
+            self.assertGreaterEqual(len(ltoc_anchors), 1)
+            anchor_02_ids = []
+            for header_anchor in header_anchors:
+                anchor_param = header_anchor.find('ac:parameter')
+                self.assertIsNotNone(anchor_param)
+                anchor_02_ids.append(anchor_param.text)
 
             # ##########################################################
             # find the expected ac:link macros

--- a/tests/validation-sets/restructuredtext/references.rst
+++ b/tests/validation-sets/restructuredtext/references.rst
@@ -61,6 +61,46 @@ pharetra quis orci. Maecenas lobortis neque ipsum, quis ultricies velit auctor
 eu. Quisque pellentesque suscipit sodales. In sapien massa, tincidunt vel nisl
 id, sodales bibendum dui. Pellentesque consectetur a risus sed aliquam.
 
+Reference in a list: `other values`_
+
+#. Curabitur tincidunt eros non auctor commodo.
+#. Fusce vestibulum erat id massa vehicula, a suscipit ligula vestibulum.
+
+   .. _other values:
+
+#. Fusce quis nibh quis dui aliquet maximus ac vel felis.
+#. Duis vehicula sem non turpis eleifend imperdiet.
+
+Integer aliquet purus elementum leo pulvinar elementum. Aenean id orci cursus,
+viverra velit id, aliquam ipsum. Pellentesque nec magna ultricies, consequat
+metus a, sollicitudin libero. Aenean placerat, nibh at fermentum rutrum, metus
+nulla interdum mauris, sit amet sagittis diam elit vel elit. Vestibulum a
+mattis metus, et condimentum metus. Praesent pharetra, nisi ullamcorper
+tincidunt convallis, purus dolor placerat justo, at sodales elit nisl sed nisi.
+Nam bibendum tempor elit a fermentum. Vivamus tellus massa, vulputate a dolor
+eu, placerat pharetra justo. Pellentesque habitant morbi tristique senectus et
+netus et malesuada fames ac turpis egestas. Nunc fringilla nibh id dictum
+semper. Nam pharetra, tortor at porttitor sollicitudin, eros erat ultricies
+ante, nec cursus dui risus nec velit.
+
+Cras cursus in magna non ultrices. In nulla arcu, malesuada a blandit id,
+pretium ac dui. Praesent porta sodales turpis, vitae efficitur libero finibus
+sit amet. Nulla vitae molestie leo. Suspendisse nisl sapien, pulvinar ut
+ultricies ac, placerat vel ipsum. Pellentesque in ex volutpat, tincidunt eros
+sed, tristique nisi. Suspendisse sit amet dui justo. Maecenas convallis ligula
+a vestibulum pulvinar. Phasellus magna magna, maximus eu elit lacinia,
+venenatis ultrices libero.
+
+Mauris lobortis fringilla vestibulum. Donec quis sagittis erat. Mauris bibendum
+metus magna, sit amet pellentesque nibh mollis vitae. Maecenas interdum eget
+mi ac consectetur. Pellentesque fermentum gravida nisi, quis accumsan leo
+fringilla posuere. Proin sed luctus ipsum. Sed sit amet augue dui. Donec
+lobortis porta sapien, sit amet faucibus ipsum iaculis at. Nunc vel enim vel
+neque malesuada lacinia. Aliquam ante velit, interdum vitae purus eu, tristique
+placerat augue. Etiam ut consequat neque. Praesent tempor metus in lorem
+efficitur iaculis. Vivamus enim risus, molestie sed massa sit amet, iaculis
+facilisis velit. Aenean ornare tincidunt vestibulum. Nulla bibendum nisi in
+neque congue rutrum. 
 
 .. references ------------------------------------------------------------------
 


### PR DESCRIPTION
Expands the populated anchor set to include anchors for other reference identifier not processed. To support these anchor points, we populate known anchors to be added at a point of time where they can be added into the page. If we do not, it will generate anchors in locations where Confluence will render newlines. For example, adding an anchor before a paragraph, Confluence styling will ensure the paragraph starts on a new block leaving a less than ideal rendering. Instead, we populate anchors as we process and then jump them into the first block we can.