### PR TITLE
translator: register section anchors for all editors

### DIFF
--- a/tests/unit-tests/test_rst_contents.py
+++ b/tests/unit-tests/test_rst_contents.py
@@ -60,7 +60,9 @@ class TestConfluenceRstContents(ConfluenceTestCase):
             self.assertEqual(len(headers), 5)
 
             for header, expected in zip(headers, expected_header_text):
-                self.assertEqual(header.text, expected)
+                txt = ''.join(
+                    header.find_all(string=True, recursive=False)).strip()
+                self.assertEqual(txt, expected)
 
     @setup_builder('confluence')
     def test_storage_rst_contents_backlinks_top(self):

--- a/tests/unit-tests/test_rst_headings.py
+++ b/tests/unit-tests/test_rst_headings.py
@@ -6,6 +6,10 @@ from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 
 
+def strval(obj):
+    return ''.join(obj.find_all(string=True, recursive=False)).strip()
+
+
 class TestConfluenceRstHeadings(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
@@ -23,21 +27,21 @@ class TestConfluenceRstHeadings(ConfluenceTestCase):
 
             header_lvl2 = data.find('h2')
             self.assertIsNotNone(header_lvl2)
-            self.assertEqual(header_lvl2.text, 'header 2')
+            self.assertEqual(strval(header_lvl2), 'header 2')
 
             header_lvl3 = data.find_all('h3')
             self.assertIsNotNone(header_lvl3)
             self.assertEqual(len(header_lvl3), 2)
-            self.assertEqual(header_lvl3[0].text, 'header 3')
-            self.assertEqual(header_lvl3[1].text, 'header 12')
+            self.assertEqual(strval(header_lvl3[0]), 'header 3')
+            self.assertEqual(strval(header_lvl3[1]), 'header 12')
 
             header_lvl4 = data.find('h4')
             self.assertIsNotNone(header_lvl4)
-            self.assertEqual(header_lvl4.text, 'header 4')
+            self.assertEqual(strval(header_lvl4), 'header 4')
 
             header_lvl5 = data.find('h5')
             self.assertIsNotNone(header_lvl5)
-            self.assertEqual(header_lvl5.text, 'header 5')
+            self.assertEqual(strval(header_lvl5), 'header 5')
 
             header_lvl6 = data.find_all('h6')
             self.assertIsNotNone(header_lvl6)
@@ -51,28 +55,29 @@ class TestConfluenceRstHeadings(ConfluenceTestCase):
         out_dir = self.build(self.dataset, config=config)
 
         with parse('index', out_dir) as data:
-            header_lvl1 = data.find('h1')
+            header_lvl1 = data.find('h1', recursive=False)
+            print(header_lvl1)
             self.assertIsNotNone(header_lvl1)
-            self.assertEqual(header_lvl1.text, 'header 1')
+            self.assertEqual(strval(header_lvl1), 'header 1')
 
-            header_lvl2 = data.find('h2')
+            header_lvl2 = data.find('h2', recursive=False)
             self.assertIsNotNone(header_lvl2)
-            self.assertEqual(header_lvl2.text, 'header 2')
+            self.assertEqual(strval(header_lvl2), 'header 2')
 
-            header_lvl3 = data.find_all('h3')
+            header_lvl3 = data.find_all('h3', recursive=False)
             self.assertIsNotNone(header_lvl3)
             self.assertEqual(len(header_lvl3), 2)
-            self.assertEqual(header_lvl3[0].text, 'header 3')
-            self.assertEqual(header_lvl3[1].text, 'header 12')
+            self.assertEqual(strval(header_lvl3[0]), 'header 3')
+            self.assertEqual(strval(header_lvl3[1]), 'header 12')
 
-            header_lvl4 = data.find('h4')
+            header_lvl4 = data.find('h4', recursive=False)
             self.assertIsNotNone(header_lvl4)
-            self.assertEqual(header_lvl4.text, 'header 4')
+            self.assertEqual(strval(header_lvl4), 'header 4')
 
-            header_lvl5 = data.find('h5')
+            header_lvl5 = data.find('h5', recursive=False)
             self.assertIsNotNone(header_lvl5)
-            self.assertEqual(header_lvl5.text, 'header 5')
+            self.assertEqual(strval(header_lvl5), 'header 5')
 
-            header_lvl6 = data.find_all('h6')
+            header_lvl6 = data.find_all('h6', recursive=False)
             self.assertIsNotNone(header_lvl6)
             self.assertEqual(len(header_lvl6), 6)

--- a/tests/unit-tests/test_rst_references.py
+++ b/tests/unit-tests/test_rst_references.py
@@ -65,13 +65,8 @@ class TestConfluenceRstReferences(ConfluenceTestCase):
 
             # anchors ##################################################
 
-            anchors = data.find_all('ac:structured-macro',
+            anchor = data.find('ac:structured-macro',
                 {'ac:name': 'anchor'})
-            self.assertEqual(len(anchors), 1)
-
-            # (anchor 1)
-            anchor = anchors.pop(0)
-
             anchor_id = anchor.find('ac:parameter')
             self.assertIsNotNone(anchor_id)
             self.assertEqual(anchor_id.text, 'my-reference-label1')

--- a/tests/unit-tests/test_singlepage_toctree.py
+++ b/tests/unit-tests/test_singlepage_toctree.py
@@ -14,6 +14,12 @@ class TestConfluenceSinglepageToctree(ConfluenceTestCase):
         out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
+            # ignore any anchor tags for these checks
+            for tag in data.find_all(
+                    'ac:structured-macro', attrs={'ac:name': 'anchor'}):
+                print(tag)
+                tag.decompose()
+
             tags = data.find_all()
             self.assertIsNotNone(tags)
             self.assertEqual(len(tags), 12)
@@ -76,6 +82,12 @@ class TestConfluenceSinglepageToctree(ConfluenceTestCase):
         out_dir = self.build(dataset)
 
         with parse('index', out_dir) as data:
+            # ignore any anchor tags for these checks
+            for tag in data.find_all(
+                    'ac:structured-macro', attrs={'ac:name': 'anchor'}):
+                print(tag)
+                tag.decompose()
+
             tags = data.find_all()
             self.assertIsNotNone(tags)
             self.assertEqual(len(tags), 6)


### PR DESCRIPTION
To help ensure anchor links to section work across all editor types and on all Confluence variants, ensure we always inject section anchors.

Historically, this extension would only create anchors if required. Sections should have their own identifiers pre-made by Confluence. However, the identifiers are not consistent between different variations of Confluence and certain features (e.g. ac:links to anchors) expect certain anchor names. Over time we duplicated some anchors to help make things smooth when the new Confluence editor was made. Unfortunately, recent testing still showed not all links would function as expected. This commit tries to cover all anchor cases by always forcefully creating anchors in sections (and compatibility anchors), no matter what the editor is. When testing on Confluence Data Center, references appeared to work as they always have. With Confluence Cloud, references appear to function across different editors with when checking reference tests and inspecting `contents` usage.