### PR TITLE
Replace special anchor handling

### DIFF
--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -295,10 +295,6 @@ def setup(app):
     cm.add_conf_bool('confluence_adv_cloud')
     # Disable any delays when publishing property updates on Cloud
     cm.add_conf_bool('confluence_adv_disable_cloud_prop_delay')
-    # Disable workaround for: https://jira.atlassian.com/browse/CONFCLOUD-74698
-    cm.add_conf_bool('confluence_adv_disable_confcloud_74698')
-    # Disable workaround for inline-extension anchor injection
-    cm.add_conf_bool('confluence_adv_disable_confcloud_ieaj')
     # Disable any attempts to initialize this extension's custom entities.
     cm.add_conf_bool('confluence_adv_disable_init')
     # Flag to permit the use of embedded certificates from requests.
@@ -342,6 +338,8 @@ def setup(app):
     # replaced by confluence_space_key
     cm.add_conf('confluence_space_name')
     # dropped
+    cm.add_conf_bool('confluence_adv_disable_confcloud_74698')
+    cm.add_conf_bool('confluence_adv_disable_confcloud_ieaj')
     cm.add_conf_int('confluence_max_doc_depth')
 
     # ##########################################################################

--- a/sphinxcontrib/confluencebuilder/transform.py
+++ b/sphinxcontrib/confluencebuilder/transform.py
@@ -39,13 +39,13 @@ class ConfluenceHyperlinkCollector(HyperlinkCollector):
             ))
 
         for refnode in self.document.findall(is_confluence_href_node):
-            uri = refnode['confluence-params']['href']
+            uri = refnode['confluence-params']['href']  # type: ignore[index]
 
             if newuri := app.emit_firstresult('linkcheck-process-uri', uri):
                 uri = newuri
 
             try:
-                lineno = get_node_line(refnode)
+                lineno = get_node_line(refnode)  # type: ignore[arg-type]
             except ValueError:
                 lineno = -1
 

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -11,6 +11,7 @@ from sphinxcontrib.confluencebuilder.std.confluence import FONT_SIZE
 from sphinxcontrib.confluencebuilder.std.confluence import FONT_X_HEIGHT
 from subprocess import check_call
 from hashlib import sha256
+from urllib.parse import quote
 from urllib.parse import urlparse
 import getpass
 import os
@@ -90,6 +91,28 @@ class ConfluenceUtil:
             elif not url.endswith('/'):
                 url += '/'
         return url
+
+
+def ascii_quote(text):
+    """
+    quote the ascii character range of a string
+
+    This utility calls will return a URL quoted value of a string for all
+    detected ASCII characters.
+
+    This is primarily used to help detect prospect anchor targets in Confluence
+    where Confluence may silently remove anchors with unsupported characters
+    (varies per editor).
+
+    Args:
+        text: the text to quote
+
+    Returns:
+        the quoted text
+    """
+
+    chars = [quote(x) if ord(x) < 128 else x for x in text]
+    return ''.join(chars)
 
 
 def convert_length(value, unit, pct=True):

--- a/tests/sample-sets/header-links/rst-v1-first.rst
+++ b/tests/sample-sets/header-links/rst-v1-first.rst
@@ -66,8 +66,8 @@ Vivamus iaculis, sapien ac blandit faucibus, mauris felis sodales enim, et facil
 
 .. _main-rst-v1-extra2:
 
-An Extra Header
----------------
+An (Extra) Header
+-----------------
 
 .. note::
 

--- a/tests/sample-sets/header-links/rst-v2-first.rst
+++ b/tests/sample-sets/header-links/rst-v2-first.rst
@@ -66,8 +66,8 @@ Vivamus iaculis, sapien ac blandit faucibus, mauris felis sodales enim, et facil
 
 .. _main-rst-v2-extra2:
 
-An Extra Header
----------------
+An (Extra) Header
+-----------------
 
 .. note::
 

--- a/tests/unit-tests/test_references_confluence.py
+++ b/tests/unit-tests/test_references_confluence.py
@@ -722,6 +722,6 @@ class TestConfluenceReferencesConfluence(ConfluenceTestCase):
             self.assertIsNotNone(a_href)
             self.assertTrue(a_href.has_attr('href'))
             self.assertEqual(a_href['href'],
-                '#Markdown-v2-Second-sub-heading-(jump-above)')
+                '#markdown-v2-second-sub-heading-jump-above')
             self.assertEqual(a_href.text,
                 'Markdown v2 Second sub-heading (jump above)')


### PR DESCRIPTION
This extension has tried to utilizing Confluence-generated anchor targets for sections over the years. However, there have been a lot of inconsistent target values with Confluence Cloud/v2 when sections have some characters (e.g. parenthesis). Confluence may inject `[inlineExtension]` prefixes in header identifiers or completely ignore anchor values that have these characters. While we attempted to account for these unique situations, issues keep arising as both Confluence and this extension evolves.

To try to avoid any more issues, we will no longer attempt to map directly to pre-made section identifiers when these characters are detected. Since a recent change \[1\] now force-adds all docutils anchor entries for sections, when an issued section target is detected, we will instead use the section identifier value instead.

\[1\]: ca031faa68f1f1e6b4c38e06b63d0338ace58040