### PR TITLE
Improved support for scoped API tokens

### DIFF
--- a/doc/advanced-publish-permissions.rst
+++ b/doc/advanced-publish-permissions.rst
@@ -1,3 +1,5 @@
+.. _publish_permissions:
+
 Publishing permissions
 ======================
 
@@ -11,14 +13,20 @@ following permissions_ when attempting to publish to a configured space:
 Delete permissions are only required for environments using the
 :lref:`confluence_cleanup_purge` capabilitity.
 
-For environments using an OAuth connector, the following scopes are required:
+For environments using an OAuth connector or scoped API tokens, the following
+scopes are required:
 
 .. code-block:: none
 
-    delete:content:confluence
+    read:space:confluence
+    read:content.metadata:confluence
+    read:page:confluence
+    write:page:confluence
+    delete:page:confluence
+    read:attachment:confluence
     read:content-details:confluence
     write:attachment:confluence
-    write:content:confluence
+    delete:attachment:confluence
     write:watcher:confluence
 
 .. references ------------------------------------------------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -59,6 +59,8 @@ Essential configuration
     Re-publishing supports checking for page changes. Pages that have not
     changed will not be updated (see :lref:`confluence_publish_force`).
 
+.. _confluence_server_url:
+
 .. confval:: confluence_server_url
 
     The URL for the Confluence instance to publish to. The URL should be
@@ -140,6 +142,15 @@ Essential configuration
 
         Use this option for Confluence Cloud.
 
+    .. note::
+
+        If using a scoped API token, users are required to also enable
+        :lref:`confluence_api_token_scoped` option or ensure their
+        :lref:`confluence_server_url` configuration points to a modern
+        Confluence API endpoint ("api.atlassian.com") for their site.
+
+        View :ref:`required scope permission <publish_permissions>`.
+
     .. caution::
 
         It is never recommended to store an API token into a committed/shared
@@ -164,6 +175,45 @@ Essential configuration
         confluence_api_token = 'YDYDD3qVvKV0FbkErSxaQ2olmy...AMGwaPe8=02381T9A'
 
     .. versionadded:: 2.6
+
+.. _confluence_api_token_scoped:
+
+.. confval:: confluence_api_token_scoped
+
+    .. tip::
+
+        Use this option for Confluence Cloud when using an API scoped token.
+
+    Enable this option to automatically convert a Confluence Cloud Wiki URL
+    to a Confluence Cloud API endpoint URL. When using an API scoped token,
+    Confluence expects an alternative API endpoint for calls. For example,
+
+    .. code-block:: none
+
+        https://example.atlassian.net/wiki/
+
+    The following is needed:
+
+    .. code-block:: none
+
+        https://api.atlassian.com/ex/confluence/550e8400-e29b-41d4-a716-446655440000/
+
+    The GUID for a space can be determined by venturing to:
+
+    .. code-block:: none
+
+        https://example.atlassian.net/_edge/tenant_info
+
+    Users may opt to configuring :lref:`confluence_server_url` to the newer
+    API endpoint for scoped tokens. However, enabling this option can perform
+    the translation for users who prefer to configure the Wiki endpoint. By
+    default, this option is not enabled with a value of ``False``.
+
+    .. code-block:: python
+
+        confluence_api_token_scoped = True
+
+    .. versionadded:: 2.7
 
 .. _confluence_publish_token:
 

--- a/doc/guide-scope-token.rst
+++ b/doc/guide-scope-token.rst
@@ -1,0 +1,78 @@
+.. index:: Scoped Token
+
+Configure access for a scoped token
+===================================
+
+.. versionadded:: 2.7
+
+.. note::
+
+    Scoped tokens only apply to Confluence Cloud.
+
+Setup a scoped token
+--------------------
+
+To create a scoped token, venture to a user's API token management page:
+
+    | API Tokens
+    | https://id.atlassian.com/manage-profile/security/api-tokens
+
+On this page:
+
+- Select the button ``Create API token with scopes``.
+- Name the API token and configure a desired expiry date.
+- Select the ``Confluence`` application.
+- Check each of the following scopes required for this extension:
+
+  - ``read:space:confluence``
+  - ``read:content.metadata:confluence``
+  - ``read:page:confluence``
+  - ``write:page:confluence``
+  - ``delete:page:confluence``
+  - ``read:attachment:confluence``
+  - ``read:content-details:confluence``
+  - ``write:attachment:confluence``
+  - ``delete:attachment:confluence``
+  - ``write:watcher:confluence``
+
+- Review and create.
+
+
+Configuring the extension
+-------------------------
+
+Using a scoped token requires at least one of the following two configuration
+changes. The easiest option is to hint to this extension that a scoped token
+is being used by configuring:
+
+.. code-block:: python
+
+    confluence_api_token_scoped = True
+
+This should help automatically resolve a modern API endpoint for Confluence
+interaction. Alternatively, if wanting to explicitly configure the modern API
+endpoint, determine a space's Cloud identifier (if not already) by venturing
+to:
+
+.. code-block:: none
+
+    https://<SPACE>.atlassian.net/_edge/tenant_info
+
+For example:
+
+.. code-block:: none
+
+    https://example.atlassian.net/_edge/tenant_info
+
+This page should provide a GUID value which can be used in a modern Confluence
+API endpoint required for scoped tokens:
+
+.. code-block:: python
+
+    confluence_server_url = 'https://api.atlassian.com/ex/confluence/<GUID>/'
+
+For example:
+
+.. code-block:: python
+
+    confluence_server_url = 'https://api.atlassian.com/ex/confluence/550e8400-e29b-41d4-a716-446655440000/'

--- a/doc/guides.rst
+++ b/doc/guides.rst
@@ -12,6 +12,7 @@ the Confluence Builder extension in a Sphinx-enabled environment.
     guide-confluence-macros
     guide-highlight-default
     guide-math
+    guide-scope-token
     guide-strike
     guide-ci
     guide-sso

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -103,6 +103,8 @@ def setup(app):
     cm.add_conf_bool('confluence_publish')
     # API token to authenticate to Confluence API with.
     cm.add_conf('confluence_api_token')
+    # Whether the API token is a scoped token
+    cm.add_conf_bool('confluence_api_token_scoped')
     # PAT to authenticate to Confluence API with.
     cm.add_conf('confluence_publish_token')
     # Password to login to Confluence API with.

--- a/sphinxcontrib/confluencebuilder/cmd/conntest.py
+++ b/sphinxcontrib/confluencebuilder/cmd/conntest.py
@@ -13,6 +13,7 @@ from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
+from sphinxcontrib.confluencebuilder.util import detect_cloud
 from sphinxcontrib.confluencebuilder.util import temp_dir
 from urllib.parse import urlparse
 import json
@@ -191,7 +192,7 @@ def conntest_main(args_parser):
             else:
                 print('warning; missing scheme.')
 
-            if parsed.netloc and parsed.netloc.endswith('atlassian.net'):
+            if detect_cloud(confluence_server_url):
                 print('Detected an Atlassian Cloud configuration.')
                 is_cloud = True
     else:

--- a/sphinxcontrib/confluencebuilder/cmd/conntest.py
+++ b/sphinxcontrib/confluencebuilder/cmd/conntest.py
@@ -12,6 +12,7 @@ from sphinxcontrib.confluencebuilder.config.env import apply_env_overrides
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
+from sphinxcontrib.confluencebuilder.std.confluence import API_CLOUD_ENDPOINT
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
 from sphinxcontrib.confluencebuilder.util import detect_cloud
 from sphinxcontrib.confluencebuilder.util import temp_dir
@@ -313,6 +314,13 @@ def conntest_main(args_parser):
         print('failed!', flush=True)
         logger.error(traceback.format_exc())
     else:
+        # skip any manifest check for modern api cloud endpoint; not sure if
+        # there is a metadata-providing endpoint at this time
+        if publisher.rest.url.startswith(API_CLOUD_ENDPOINT):
+            if not base_url.startswith(API_CLOUD_ENDPOINT):
+                print(f'Resolved API endpoint: {publisher.rest.url}')
+            return 0
+
         try:
             print('Fetching Confluence instance information... ', end='')
             sys.stdout.flush()

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -16,6 +16,7 @@ from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceConfigEr
 from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
+from sphinxcontrib.confluencebuilder.std.confluence import API_CLOUD_ENDPOINT
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
 from sphinxcontrib.confluencebuilder.util import detect_cloud
 from sphinxcontrib.confluencebuilder.util import temp_dir
@@ -175,7 +176,14 @@ def report_main(args_parser):
             info += ' connected: no\n'
             rv = 1
 
-        if session:
+        # skip any manifest check for modern api cloud endpoint; not sure if
+        # there is a metadata-providing endpoint at this time
+        if session and publisher.rest.url.startswith(API_CLOUD_ENDPOINT):
+            if base_url.startswith(API_CLOUD_ENDPOINT):
+                info += '  endpoint: set\n'
+            else:
+                info += '  endpoint: resolved\n'
+        elif session:
             try:
                 # fetch
                 print('fetching confluence instance information...')

--- a/sphinxcontrib/confluencebuilder/cmd/report.py
+++ b/sphinxcontrib/confluencebuilder/cmd/report.py
@@ -17,6 +17,7 @@ from sphinxcontrib.confluencebuilder.logger import ConfluenceLogger as logger
 from sphinxcontrib.confluencebuilder.publisher import ConfluencePublisher
 from sphinxcontrib.confluencebuilder.reportbuilder import ConfluenceReportBuilder
 from sphinxcontrib.confluencebuilder.util import ConfluenceUtil
+from sphinxcontrib.confluencebuilder.util import detect_cloud
 from sphinxcontrib.confluencebuilder.util import temp_dir
 from urllib.parse import urlparse
 from urllib3 import __version__ as urllib3_version
@@ -255,7 +256,7 @@ def report_main(args_parser):
             else:
                 value = '(set; no scheme)'
 
-            if parsed.netloc and parsed.netloc.endswith('atlassian.net'):
+            if detect_cloud(value):
                 value += ' (cloud)'
 
             config['confluence_server_url'] = value

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 from sphinxcontrib.confluencebuilder.debug import PublishDebug
+from sphinxcontrib.confluencebuilder.std.confluence import API_CLOUD_ENDPOINT
 from sphinxcontrib.confluencebuilder.util import str2bool
 import contextlib
 
@@ -43,6 +44,12 @@ def apply_defaults(app):
 
     if conf.confluence_adv_restricted is None:
         conf.confluence_adv_restricted = []
+
+    # force default v2 api if a scoped api token or modern api is detected
+    confluence_server_url = conf.confluence_server_url or ''
+    if conf.confluence_api_mode is None and (conf.confluence_api_token_scoped \
+            or confluence_server_url.startswith(API_CLOUD_ENDPOINT)):
+        conf.confluence_api_mode = 'v2'
 
     if conf.confluence_ca_cert:
         if not Path(conf.confluence_ca_cert).is_absolute():

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -4,6 +4,9 @@
 from sphinxcontrib.confluencebuilder.std.sphinx import DEFAULT_HIGHLIGHT_STYLE
 import os
 
+# modern cloud api endpoint (scoped tokens)
+API_CLOUD_ENDPOINT = 'https://api.atlassian.com/ex/confluence'
+
 # prefix for all api path requests to a confluence instance (v1 api)
 API_REST_V1 = 'rest/api'
 

--- a/sphinxcontrib/confluencebuilder/util.py
+++ b/sphinxcontrib/confluencebuilder/util.py
@@ -186,7 +186,8 @@ def detect_cloud(site):
     except ValueError:
         pass
     else:
-        if parsed.hostname and parsed.hostname.endswith('atlassian.net'):
+        cloud_domains = ('atlassian.com', 'atlassian.net')
+        if parsed.hostname and parsed.hostname.endswith(cloud_domains):
             is_cloud = True
 
     return is_cloud


### PR DESCRIPTION
Providing support for API tokens which have scopes applied to them.
Confluence requires scoped API tokens to utilize a new API endpoint.
The changes introduced in this commit help a user to automatically
handle this endpoint change if a scoped API token is hinted.

Alternatively, users can still set the server URL to the modern
Confluence API endpoint URL. Before this change, this worked in
combination of forcing `confluence_api_mode = "v2"` to ensure v2 API 
calls are made (required since some v1 API calls do not function with
scoped APIs). Explicitly configuring a v2 API mode is no longer required
since this extension uses the scoped API-related configurations to hint
at using v2 API by default.