### PR TITLE
Add option confluence_table_width

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -359,6 +359,17 @@ Generic configuration
 
     .. versionadded:: 1.3
 
+.. confval:: confluence_default_table_width
+
+    Width for a table (v2 editor).
+    It has been observed that when attempting to fix specific column widths on
+    a table in the v2 editor, Confluence applies a default data width of 760 on
+    the table. By default, this value is 760.
+
+    .. code-block:: python
+
+        confluence_default_table_width = 2000
+
 .. confval:: confluence_disable_env_conf
 
     A boolean value to configure whether to ignore environment-provided
@@ -2005,19 +2016,6 @@ Advanced processing configuration
     .. code-block:: python
 
         confluence_file_suffix = '.conf'
-
-.. _confluence_table_width:
-
-.. confval:: confluence_table_width
-
-    Width for a table (v2 editor).
-    It has been observed that when attempting to fix specific column widths on
-    a table in the v2 editor, Confluence applies a default data width of 760 on
-    the table. By default, this value is 760.
-
-    .. code-block:: python
-
-        confluence_table_width = 2000
 
 .. _confluence_html_macro:
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2006,6 +2006,19 @@ Advanced processing configuration
 
         confluence_file_suffix = '.conf'
 
+.. _confluence_table_width:
+
+.. confval:: confluence_table_width
+
+    Width for a table (v2 editor).
+    It has been observed that when attempting to fix specific column widths on
+    a table in the v2 editor, Confluence applies a default data width of 760 on
+    the table. By default, this value is 760.
+
+    .. code-block:: python
+
+        confluence_table_width = 2000
+
 .. _confluence_html_macro:
 
 .. confval:: confluence_html_macro

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -123,6 +123,8 @@ def setup(app):
     cm.add_conf('confluence_code_block_theme', 'confluence')
     # Default alignment for tables, figures, etc.
     cm.add_conf('confluence_default_alignment', 'confluence')
+    # Table width (v2 editor).
+    cm.add_conf('confluence_default_table_width', 'confluence')
     # Do not attempt to pull configuration values from the environment.
     cm.add_conf_bool('confluence_disable_env_conf')
     # Enablement of a generated domain index documents
@@ -261,8 +263,6 @@ def setup(app):
     # (configuration - advanced processing)
     # Filename suffix for generated files.
     cm.add_conf('confluence_file_suffix', 'confluence')
-    # Table width (v2 editor).
-    cm.add_conf('confluence_default_table_width', 'confluence')
     # Macro configuration for Confluence-managed HTML content.
     cm.add_conf('confluence_html_macro', 'confluence')
     # Configuration for named JIRA Servers

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -261,6 +261,8 @@ def setup(app):
     # (configuration - advanced processing)
     # Filename suffix for generated files.
     cm.add_conf('confluence_file_suffix', 'confluence')
+    # Table width (v2 editor).
+    cm.add_conf_int('confluence_table_width', 'confluence')
     # Macro configuration for Confluence-managed HTML content.
     cm.add_conf('confluence_html_macro', 'confluence')
     # Configuration for named JIRA Servers

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -262,7 +262,7 @@ def setup(app):
     # Filename suffix for generated files.
     cm.add_conf('confluence_file_suffix', 'confluence')
     # Table width (v2 editor).
-    cm.add_conf_int('confluence_table_width', 'confluence')
+    cm.add_conf('confluence_default_table_width', 'confluence')
     # Macro configuration for Confluence-managed HTML content.
     cm.add_conf('confluence_html_macro', 'confluence')
     # Configuration for named JIRA Servers

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -326,7 +326,8 @@ def validate_configuration(builder):
             validator.conf('confluence_default_table_width').string()
             width, unit = extract_length(config.confluence_default_table_width)
             if unit == '%':
-                raise ConfluenceDefaultTableWidthError("Percentage is not a valid unit.")
+                msg="Percentage is not a valid unit."
+                raise ConfluenceDefaultTableWidthError(msg)
         except ConfluenceConfigError as ex:
             raise ConfluenceDefaultTableWidthError(ex) from ex
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -8,6 +8,7 @@ from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceClientCe
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceClientCertMissingCertConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceDefaultAlignmentConfigError
+from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceDefaultTableWidthError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceDomainIndicesConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceEditorConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceFooterFileConfigError
@@ -320,7 +321,10 @@ def validate_configuration(builder):
     try:
         validator.conf('confluence_default_table_width').string()
     except ConfluenceConfigError:
-        validator.conf('confluence_default_table_width').int_(positive=True)
+        try:
+            validator.conf('confluence_default_table_width').int_(positive=True)
+        except ConfluenceConfigError as ex:
+            raise ConfluenceDefaultTableWidthError(ex) from ex
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -317,8 +317,10 @@ def validate_configuration(builder):
     # ##################################################################
 
     # confluence_default_table_width
-    validator.conf('confluence_default_table_width') \
-             .int_(positive=True)
+    try:
+        validator.conf('confluence_default_table_width').string()
+    except ConfluenceConfigError:
+        validator.conf('confluence_default_table_width').int_(positive=True)
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -316,8 +316,8 @@ def validate_configuration(builder):
 
     # ##################################################################
 
-    # confluence_table_width
-    validator.conf('confluence_table_width') \
+    # confluence_default_table_width
+    validator.conf('confluence_default_table_width') \
              .int_(positive=True)
 
     # ##################################################################

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -316,6 +316,12 @@ def validate_configuration(builder):
 
     # ##################################################################
 
+    # confluence_table_width
+    validator.conf('confluence_table_width') \
+             .int_(positive=True)
+
+    # ##################################################################
+
     # confluence_html_macro
     validator.conf('confluence_html_macro') \
              .string()

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -44,6 +44,7 @@ from sphinxcontrib.confluencebuilder.config.validation import ConfigurationValid
 from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.std.confluence import API_MODES
 from sphinxcontrib.confluencebuilder.std.confluence import EDITORS
+from sphinxcontrib.confluencebuilder.util import extract_length
 from sphinxcontrib.confluencebuilder.util import handle_cli_file_subset
 from requests.auth import AuthBase
 import os
@@ -319,10 +320,13 @@ def validate_configuration(builder):
 
     # confluence_default_table_width
     try:
-        validator.conf('confluence_default_table_width').string()
+        validator.conf('confluence_default_table_width').int_(positive=True)
     except ConfluenceConfigError:
         try:
-            validator.conf('confluence_default_table_width').int_(positive=True)
+            validator.conf('confluence_default_table_width').string()
+            width, unit = extract_length(config.confluence_default_table_width)
+            if unit == '%':
+                raise ConfluenceDefaultTableWidthError("Percentage is not a valid value.")
         except ConfluenceConfigError as ex:
             raise ConfluenceDefaultTableWidthError(ex) from ex
 

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -326,7 +326,7 @@ def validate_configuration(builder):
             validator.conf('confluence_default_table_width').string()
             width, unit = extract_length(config.confluence_default_table_width)
             if unit == '%':
-                raise ConfluenceDefaultTableWidthError("Percentage is not a valid value.")
+                raise ConfluenceDefaultTableWidthError("Percentage is not a valid unit.")
         except ConfluenceConfigError as ex:
             raise ConfluenceDefaultTableWidthError(ex) from ex
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.std.confluence import API_CLOUD_ENDPOINT
 from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
+from sphinxcontrib.confluencebuilder.util import convert_length
+from sphinxcontrib.confluencebuilder.util import extract_length
 from sphinxcontrib.confluencebuilder.util import str2bool
 import contextlib
 

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -80,9 +80,8 @@ def apply_defaults(app):
         if conf.confluence_file_suffix.endswith('.'):
             conf.confluence_file_suffix = '.conf'
 
-    if conf.confluence_table_width:
-        if conf.confluence_table_width is None:
-            conf.confluence_table_width = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
+    if conf.confluence_default_table_width is None:
+        conf.confluence_default_table_width = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 
     if conf.confluence_global_labels:
         # remove empty labels

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -80,7 +80,10 @@ def apply_defaults(app):
         if conf.confluence_file_suffix.endswith('.'):
             conf.confluence_file_suffix = '.conf'
 
-    if conf.confluence_default_table_width is None:
+    table_width, twu = extract_length(str(conf.confluence_default_table_width))
+    if table_width is not None:
+        conf.confluence_default_table_width = convert_length(table_width, twu, pct=False)
+    else:
         conf.confluence_default_table_width = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 
     if conf.confluence_global_labels:

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -79,6 +79,10 @@ def apply_defaults(app):
         if conf.confluence_file_suffix.endswith('.'):
             conf.confluence_file_suffix = '.conf'
 
+    if conf.confluence_table_width:
+        if conf.confluence_table_width is None:
+            conf.confluence_table_width = 760
+
     if conf.confluence_global_labels:
         # remove empty labels
         labels = conf.confluence_global_labels

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -82,11 +82,12 @@ def apply_defaults(app):
         if conf.confluence_file_suffix.endswith('.'):
             conf.confluence_file_suffix = '.conf'
 
-    table_width, twu = extract_length(str(conf.confluence_default_table_width))
-    if table_width is not None:
-        conf.confluence_default_table_width = convert_length(table_width, twu, pct=False)
-    else:
-        conf.confluence_default_table_width = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
+    if conf.confluence_default_table_width:
+        table_width, twu = extract_length(str(conf.confluence_default_table_width))
+        if table_width is not None:
+            conf.confluence_default_table_width = convert_length(table_width, twu, pct=False)
+        else:
+            conf.confluence_default_table_width = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 
     if conf.confluence_global_labels:
         # remove empty labels

--- a/sphinxcontrib/confluencebuilder/config/defaults.py
+++ b/sphinxcontrib/confluencebuilder/config/defaults.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from sphinxcontrib.confluencebuilder.debug import PublishDebug
 from sphinxcontrib.confluencebuilder.std.confluence import API_CLOUD_ENDPOINT
+from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 from sphinxcontrib.confluencebuilder.util import str2bool
 import contextlib
 
@@ -81,7 +82,7 @@ def apply_defaults(app):
 
     if conf.confluence_table_width:
         if conf.confluence_table_width is None:
-            conf.confluence_table_width = 760
+            conf.confluence_table_width = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 
     if conf.confluence_global_labels:
         # remove empty labels

--- a/sphinxcontrib/confluencebuilder/config/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/config/exceptions.py
@@ -55,6 +55,16 @@ found. Ensure the following file exists:
 ''')
 
 
+class ConfluenceDefaultTableWidthError(ConfluenceConfigError):
+    def __init__(self, msg):
+        super().__init__(f'''\
+{msg}
+
+The option 'confluence_default_table_width' has been provided to override the
+default width for tables in editor v2. Accepted values include a string or a positive integer.
+''')
+
+
 class ConfluenceDefaultAlignmentConfigError(ConfluenceConfigError):
     def __init__(self, msg):
         super().__init__(f'''\

--- a/sphinxcontrib/confluencebuilder/config/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/config/exceptions.py
@@ -62,17 +62,8 @@ class ConfluenceDefaultTableWidthError(ConfluenceConfigError):
 
 The option 'confluence_default_table_width' has been provided to override the
 default width for tables in editor v2. Accepted values include a string or a positive integer.
-If the value is a string one can define a unit otherwise 'px' is internally used as default.
-Accepted units include:
-
- - px
- - em
- - ex
- - mm
- - cm
- - in
- - pt
- - pc
+String values will be interpreted by units supported by the markup processed.
+Strings without units or integer values will be interpreted as a pixel value.
 ''')
 
 

--- a/sphinxcontrib/confluencebuilder/config/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/config/exceptions.py
@@ -62,6 +62,17 @@ class ConfluenceDefaultTableWidthError(ConfluenceConfigError):
 
 The option 'confluence_default_table_width' has been provided to override the
 default width for tables in editor v2. Accepted values include a string or a positive integer.
+If the value is a string one can define a unit otherwise 'px' is internally used as default.
+Accepted units include:
+
+ - px
+ - em
+ - ex
+ - mm
+ - cm
+ - in
+ - pt
+ - pc
 ''')
 
 

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -19,13 +19,6 @@ API_MODES = {
     'v2',
 }
 
-# default width for a table (v2 editor)
-#
-# It has been observed that when attempting to fix specific column widths on
-# a table in the v2 editor, Confluence applies a default data width of 760 on
-# the table.
-CONFLUENCE_DEFAULT_V2_TABLE_WIDTH = 760
-
 # maximum length for a confluence page title
 #
 # The maximum length of a Confluence page is set to 255. This is a Confluence-

--- a/sphinxcontrib/confluencebuilder/std/confluence.py
+++ b/sphinxcontrib/confluencebuilder/std/confluence.py
@@ -19,6 +19,13 @@ API_MODES = {
     'v2',
 }
 
+# default width for a table (v2 editor)
+#
+# It has been observed that when attempting to fix specific column widths on
+# a table in the v2 editor, Confluence applies a default data width of 760 on
+# the table.
+CONFLUENCE_DEFAULT_V2_TABLE_WIDTH = 760
+
 # maximum length for a confluence page title
 #
 # The maximum length of a Confluence page is set to 255. This is a Confluence-

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1144,9 +1144,16 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         table_classes = node.get('classes', [])
         attribs = {}
 
-        # Apply the default table width when using the v2 editor.
-        if self.v2:
+         # Apply the default table width when using the v2 editor.
+        if self.v2 and config.confluence_default_table_width:
             attribs['data-table-width'] = config.confluence_default_table_width
+        # For v2 editor, if we have given explicit widths for columns in the
+        # table (e.g. CSV table), we need to apply a data table width or the
+        # editor will ignore the column-specific widths. If widths are
+        # detected, apply the default table width observed when using the v2
+        # editor.
+        elif self.v2 and 'colwidths-given' in table_classes:
+            attribs['data-table-width'] = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 
         # [sphinxcontrib-needs]
         # force needs tables to a maximum width

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -1146,8 +1146,8 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         attribs = {}
 
          # Apply the default table width when using the v2 editor.
-        if self.v2 and config.confluence_default_table_width:
-            attribs['data-table-width'] = config.confluence_default_table_width
+        if self.v2 and self.builder.config.confluence_default_table_width:
+            attribs['data-table-width'] = self.builder.config.confluence_default_table_width
         # For v2 editor, if we have given explicit widths for columns in the
         # table (e.g. CSV table), we need to apply a data table width or the
         # editor will ignore the column-specific widths. If widths are

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -14,6 +14,7 @@ from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceError
 from sphinxcontrib.confluencebuilder.locale import L
 from sphinxcontrib.confluencebuilder.nodes import confluence_parameters_fetch as PARAMS
+from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_WIDTH
 from sphinxcontrib.confluencebuilder.std.confluence import FALLBACK_HIGHLIGHT_STYLE
 from sphinxcontrib.confluencebuilder.std.confluence import FCMMO
@@ -124,11 +125,13 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self.colspecs = []
         self._tocdepth = self.state.toctree_depth(self.docname)
 
-        if isinstance(config.confluence_default_table_width, string):
-            table_width, twu = extract_length(config.confluence_default_table_width)
-            self._v2_default_table_width = convert_length(table_width, twu)
-        else:
-            self._v2_default_table_width = config.confluence_default_table_width
+        self._v2_default_table_width = config.confluence_default_table_width
+        if isinstance(self._v2_default_table_width, str):
+            table_width, twu = extract_length(self._v2_default_table_width)
+            if table_width is not None:
+                self._v2_default_table_width = convert_length(table_width, twu)
+            else:
+                self._v2_default_table_width = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 
         # override editor if the document specifies another
         editor_override = metadata.get('editor')

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -121,9 +121,14 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self._reference_context = []
         self._thead_context = []
         self._v2_header_added = False
-        self._v2_default_table_width = config.confluence_default_table_width
         self.colspecs = []
         self._tocdepth = self.state.toctree_depth(self.docname)
+
+        if isinstance(config.confluence_default_table_width, string):
+            table_width, twu = extract_length(config.confluence_default_table_width)
+            self._v2_default_table_width = convert_length(table_width, twu)
+        else:
+            self._v2_default_table_width = config.confluence_default_table_width
 
         # override editor if the document specifies another
         editor_override = metadata.get('editor')

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -129,7 +129,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         if isinstance(self._v2_default_table_width, str):
             table_width, twu = extract_length(self._v2_default_table_width)
             if table_width is not None:
-                self._v2_default_table_width = convert_length(table_width, twu)
+                self._v2_default_table_width = convert_length(table_width, twu, pct=False)
             else:
                 self._v2_default_table_width = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -14,6 +14,7 @@ from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceError
 from sphinxcontrib.confluencebuilder.locale import L
 from sphinxcontrib.confluencebuilder.nodes import confluence_parameters_fetch as PARAMS
+from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_WIDTH
 from sphinxcontrib.confluencebuilder.std.confluence import FALLBACK_HIGHLIGHT_STYLE
 from sphinxcontrib.confluencebuilder.std.confluence import FCMMO

--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -14,7 +14,6 @@ from sphinxcontrib.confluencebuilder.compat import docutils_findall as findall
 from sphinxcontrib.confluencebuilder.exceptions import ConfluenceError
 from sphinxcontrib.confluencebuilder.locale import L
 from sphinxcontrib.confluencebuilder.nodes import confluence_parameters_fetch as PARAMS
-from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 from sphinxcontrib.confluencebuilder.std.confluence import CONFLUENCE_MAX_WIDTH
 from sphinxcontrib.confluencebuilder.std.confluence import FALLBACK_HIGHLIGHT_STYLE
 from sphinxcontrib.confluencebuilder.std.confluence import FCMMO
@@ -124,14 +123,6 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
         self._v2_header_added = False
         self.colspecs = []
         self._tocdepth = self.state.toctree_depth(self.docname)
-
-        self._v2_default_table_width = config.confluence_default_table_width
-        if isinstance(self._v2_default_table_width, str):
-            table_width, twu = extract_length(self._v2_default_table_width)
-            if table_width is not None:
-                self._v2_default_table_width = convert_length(table_width, twu, pct=False)
-            else:
-                self._v2_default_table_width = CONFLUENCE_DEFAULT_V2_TABLE_WIDTH
 
         # override editor if the document specifies another
         editor_override = metadata.get('editor')
@@ -1155,7 +1146,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
 
         # Apply the default table width when using the v2 editor.
         if self.v2:
-            attribs['data-table-width'] = self._v2_default_table_width
+            attribs['data-table-width'] = config.confluence_default_table_width
 
         # [sphinxcontrib-needs]
         # force needs tables to a maximum width

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -449,14 +449,15 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_default_table_width'] = '123456mm'
         self._try_config()
 
-        self.config['confluence_default_table_width'] = '123456%'
-        self._try_config()
-
         self.config['confluence_default_table_width'] = '123456 px'
         self._try_config()
 
         self.config['confluence_default_table_width'] = 'MyPage'
         self._try_config()
+
+        self.config['confluence_default_table_width'] = '123456%'
+        with self.assertRaises(ConfluenceDefaultTableWidthError):
+            self._try_config()
 
         self.config['confluence_default_table_width'] = 0
         with self.assertRaises(ConfluenceDefaultTableWidthError):

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -8,6 +8,7 @@ from sphinx.environment import BuildEnvironment
 from sphinx.errors import SphinxWarning
 from sphinxcontrib.confluencebuilder.builder import ConfluenceBuilder
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceConfigError
+from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceDefaultTableWidthError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePageGenerationNoticeConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePermitRawHtmlConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePublishCleanupConflictConfigError
@@ -435,23 +436,28 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_header_file'] = relbase + 'sample-header.tpl'
         self._try_config()
 
-    def test_config_check_confluence_table_width(self):
-        self.config['confluence_table_width'] = 123456
+    def test_config_check_confluence_default_table_width(self):
+        self.config['confluence_default_table_width'] = 123456
         self._try_config()
 
-        self.config['confluence_table_width'] = '123456'
+        self.config['confluence_default_table_width'] = '123456'
         self._try_config()
 
-        self.config['confluence_table_width'] = 0
-        with self.assertRaises(ConfluenceConfigError):
+        self.config['confluence_default_table_width'] = '123456 em'
+        self._try_config()
+
+        self.config['confluence_default_table_width'] = '123456 px'
+        self._try_config()
+
+        self.config['confluence_default_table_width'] = 'MyPage'
+        self._try_config()
+
+        self.config['confluence_default_table_width'] = 0
+        with self.assertRaises(ConfluenceDefaultTableWidthError):
             self._try_config()
 
-        self.config['confluence_table_width'] = -123456
-        with self.assertRaises(ConfluenceConfigError):
-            self._try_config()
-
-        self.config['confluence_table_width'] = 'MyPage'
-        with self.assertRaises(ConfluenceConfigError):
+        self.config['confluence_default_table_width'] = -123456
+        with self.assertRaises(ConfluenceDefaultTableWidthError):
             self._try_config()
 
     def test_config_check_confluence_html_macro(self):

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -435,6 +435,25 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_header_file'] = relbase + 'sample-header.tpl'
         self._try_config()
 
+    def test_config_check_confluence_table_width(self):
+        self.config['confluence_table_width'] = 123456
+        self._try_config()
+
+        self.config['confluence_table_width'] = '123456'
+        self._try_config()
+
+        self.config['confluence_table_width'] = 0
+        with self.assertRaises(ConfluenceConfigError):
+            self._try_config()
+
+        self.config['confluence_table_width'] = -123456
+        with self.assertRaises(ConfluenceConfigError):
+            self._try_config()
+
+        self.config['confluence_table_width'] = 'MyPage'
+        with self.assertRaises(ConfluenceConfigError):
+            self._try_config()
+
     def test_config_check_confluence_html_macro(self):
         self.config['confluence_html_macro'] = ''
         self._try_config()

--- a/tests/unit-tests/test_config_checks.py
+++ b/tests/unit-tests/test_config_checks.py
@@ -446,6 +446,12 @@ class TestConfluenceConfigChecks(unittest.TestCase):
         self.config['confluence_default_table_width'] = '123456 em'
         self._try_config()
 
+        self.config['confluence_default_table_width'] = '123456mm'
+        self._try_config()
+
+        self.config['confluence_default_table_width'] = '123456%'
+        self._try_config()
+
         self.config['confluence_default_table_width'] = '123456 px'
         self._try_config()
 

--- a/tests/unit-tests/test_util_extract_length.py
+++ b/tests/unit-tests/test_util_extract_length.py
@@ -10,6 +10,7 @@ class TestConfluenceUtilExtractLength(unittest.TestCase):
         self.assertEqual(extract_length(None), (None, None))
         self.assertEqual(extract_length(' '), (None, None))
         self.assertEqual(extract_length('px'), (None, None))
+        self.assertEqual(extract_length(str(None)), (None, None))
 
     def test_util_extractlen_unitless(self):
         self.assertEqual(extract_length('123'), ('123', None))


### PR DESCRIPTION
Default table width for editor v2 with 'widths' set is currently 760 and can not be changed.
If one has a lot of columns than 760 is just way to narrow. 
Confluence seems to be able to handle bigger width values quiet well and users might want to experiment with this value to have nicer tables.