### PR TITLE
python 3.14 marking/testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,11 @@ jobs:
             - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx80, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx81, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx82, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.14", toxenv: py314-sphinx73, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.14", toxenv: py314-sphinx74, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.14", toxenv: py314-sphinx80, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.14", toxenv: py314-sphinx81, cache: ~/.cache/pip }
+            - { os:  ubuntu-latest, python: "3.14", toxenv: py314-sphinx82, cache: ~/.cache/pip }
 
             # other OSes
             #  - test against all other supported OSes, using most recent interpreter/sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Documentation',
     'Topic :: Documentation :: Sphinx',
     'Topic :: Utilities',

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist =
     ruff
     pylint
     py39-sphinx{73,74}
-    py{310,311,312,313}-sphinx{73,74,80,81}
-    py{311,312,313}-sphinx{82}
+    py{310,311,312,313,314}-sphinx{73,74,80,81}
+    py{311,312,313,314}-sphinx{82}
     mypy
 
 [testenv]


### PR DESCRIPTION
Since Python 3.14 is officially releases, include it in the default set of interpreters to build/test against.