### PR TITLE
rework assets to always be standalone

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1239,25 +1239,6 @@ Advanced publishing configuration
 
     .. versionadded:: 1.3
 
-.. confval:: confluence_asset_force_standalone
-
-    Provides an override to always publish individual assets (images, downloads,
-    etc.) on each individual document which uses them. This extension will
-    attempt to minimize the amount of publishing of shared assets on multiple
-    documents by only hosting an asset in a single document. For example, if two
-    documents use the same image, the image will be hosted on the root document
-    of a set and each document will reference the attachment on the root page. A
-    user may wish to override this feature. By configuring this option to
-    ``True``, this extension will publish asset files as an attachment for each
-    document which may use the asset. By default, this extension will attempt to
-    host shared assets on a single document with a value of ``False``.
-
-    .. code-block:: python
-
-        confluence_asset_force_standalone = True
-
-    .. versionadded:: 1.3
-
 .. _confluence_asset_override:
 
 .. confval:: confluence_asset_override
@@ -2469,6 +2450,14 @@ Other options
 
 Deprecated options
 ------------------
+
+.. confval:: confluence_asset_force_standalone
+
+    This option has been dropped as the shared assets feature is no longer
+    supported. As of v2.15, a page will always host its own assets.
+
+    .. versionadded:: 1.3
+    .. versionremoved:: 2.15
 
 .. confval:: confluence_lang_transform
 

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -197,8 +197,6 @@ def setup(app):
     # (configuration - advanced publishing)
     # Register additional mime types to be selected for image candidates.
     cm.add_conf('confluence_additional_mime_types', 'confluence')
-    # Forcing all assets to be standalone.
-    cm.add_conf_bool('confluence_asset_force_standalone', 'confluence')
     # Tri-state asset handling (auto, force push or disable).
     cm.add_conf_bool('confluence_asset_override')
     # File/path to Certificate Authority
@@ -344,6 +342,7 @@ def setup(app):
     # dropped
     cm.add_conf_bool('confluence_adv_disable_confcloud_74698')
     cm.add_conf_bool('confluence_adv_disable_confcloud_ieaj')
+    cm.add_conf_bool('confluence_asset_force_standalone')
     cm.add_conf_int('confluence_max_doc_depth')
 
     # ##########################################################################

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -154,12 +154,6 @@ def validate_configuration(builder):
 
     # ##################################################################
 
-    # confluence_asset_force_standalone
-    validator.conf('confluence_asset_force_standalone') \
-             .bool()
-
-    # ##################################################################
-
     # confluence_asset_override
     validator.conf('confluence_asset_override') \
              .bool()

--- a/sphinxcontrib/confluencebuilder/config/notifications.py
+++ b/sphinxcontrib/confluencebuilder/config/notifications.py
@@ -12,6 +12,8 @@ DEPRECATED_CONFIGS = {
         'use "confluence_cleanup_search_mode" instead',
     'confluence_adv_permit_raw_html':
         'use "confluence_permit_raw_html" instead',
+    'confluence_asset_force_standalone':
+        'option does nothing',
     'confluence_lang_transform':
         'use "confluence_lang_overrides" instead',
     'confluence_adv_trace_data':

--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -128,7 +128,12 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
 
             doctree = self.assemble_doctree()
             self._prepare_doctree_writing(self.config.root_doc, doctree)
-            self.assets.process_document(doctree, self.config.root_doc)
+
+        with progress_message(C('pre-process assets')):
+            if self._verbose:
+                print()
+
+            self.assets.preprocess_doctree(doctree, self.config.root_doc)
 
         with progress_message(C('writing single confluence document')):
             if self._verbose:

--- a/sphinxcontrib/confluencebuilder/translator.py
+++ b/sphinxcontrib/confluencebuilder/translator.py
@@ -207,7 +207,6 @@ class ConfluenceBaseTranslator(BaseTranslator):
         uri = node['uri']
         uri = self.encode(uri)
 
-        dochost = None
         img_key = None
         img_sz = None
         internal_img = uri.find('://') == -1 and not uri.startswith('data:')
@@ -219,22 +218,16 @@ class ConfluenceBaseTranslator(BaseTranslator):
             if 'single' in self.builder.name:
                 asset_docname = self.docname
 
-            img_key, dochost, img_path = \
-                self.assets.fetch(node, docname=asset_docname)
+            img_key, img_path = self.assets.fetch(
+                node, docname=asset_docname, allow_new=not is_svg)
 
-            # if this image has not already be processed (injected at a later
-            # stage in the sphinx process); try processing it now
-            if not img_key:
-                # if this is an svg image, additional processing may also needed
-                if is_svg:
-                    confluence_supported_svg(self.builder, node)
+            # if this image was not pre-processed before and is an svg image,
+            # additional processing may also needed
+            if not img_key and is_svg:
+                confluence_supported_svg(self.builder, node)
 
-                if not asset_docname:
-                    asset_docname = self.docname
-
-                img_key, dochost, img_path = \
-                    self.assets.process_image_node(
-                        node, asset_docname, standalone=True)
+                img_key, img_path = self.assets.fetch(
+                    node, docname=asset_docname)
 
             if not img_key:
                 self.warn('unable to find image: ' + uri)
@@ -309,7 +302,6 @@ class ConfluenceBaseTranslator(BaseTranslator):
 
         # forward image options
         opts = {}
-        opts['dochost'] = dochost
         opts['height'] = height
         opts['hu'] = hu
         opts['key'] = img_key

--- a/tests/unit-tests/test_shared_asset.py
+++ b/tests/unit-tests/test_shared_asset.py
@@ -6,7 +6,7 @@ from tests.lib.testcase import ConfluenceTestCase
 from tests.lib.testcase import setup_builder
 
 
-class TestConfluenceSharedAsset(ConfluenceTestCase):
+class TestConfluenceAssets(ConfluenceTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -14,7 +14,7 @@ class TestConfluenceSharedAsset(ConfluenceTestCase):
         cls.dataset = cls.datasets / 'assets'
 
     @setup_builder('confluence')
-    def test_storage_sharedasset_defaults(self):
+    def test_storage_assets_example(self):
         out_dir = self.build(self.dataset)
 
         with parse('doc-a', out_dir) as data:
@@ -27,40 +27,6 @@ class TestConfluenceSharedAsset(ConfluenceTestCase):
             self.assertEqual(attachment['ri:filename'], 'image03.png')
 
             page_ref = attachment.find('ri:page')
-            self.assertIsNotNone(page_ref)
-            self.assertTrue(page_ref.has_attr('ri:content-title'))
-            self.assertEqual(page_ref['ri:content-title'], 'shared asset')
-
-        with parse('doc-b', out_dir) as data:
-            image = data.find('ac:image')
-            self.assertIsNotNone(image)
-
-            attachment = image.find('ri:attachment')
-            self.assertIsNotNone(attachment)
-            self.assertTrue(attachment.has_attr('ri:filename'))
-            self.assertEqual(attachment['ri:filename'], 'image03.png')
-
-            page_ref = attachment.find('ri:page')
-            self.assertIsNotNone(page_ref)
-            self.assertTrue(page_ref.has_attr('ri:content-title'))
-            self.assertEqual(page_ref['ri:content-title'], 'shared asset')
-
-    @setup_builder('confluence')
-    def test_storage_sharedasset_force_standalone(self):
-        config = dict(self.config)
-        config['confluence_asset_force_standalone'] = True
-        out_dir = self.build(self.dataset, config=config)
-
-        with parse('doc-a', out_dir) as data:
-            image = data.find('ac:image')
-            self.assertIsNotNone(image)
-
-            attachment = image.find('ri:attachment')
-            self.assertIsNotNone(attachment)
-            self.assertTrue(attachment.has_attr('ri:filename'))
-            self.assertEqual(attachment['ri:filename'], 'image03.png')
-
-            page_ref = attachment.find('ri:page')
             self.assertIsNone(page_ref)
 
         with parse('doc-b', out_dir) as data:
@@ -76,7 +42,7 @@ class TestConfluenceSharedAsset(ConfluenceTestCase):
             self.assertIsNone(page_ref)
 
     @setup_builder('confluence')
-    def test_storage_sharedasset_no_newline_assets(self):
+    def test_storage_assets_no_newline(self):
         out_dir = self.build(self.dataset)
 
         # confluence (error 500) attachment newline check

--- a/tests/unit-tests/test_singlepage_assets.py
+++ b/tests/unit-tests/test_singlepage_assets.py
@@ -34,28 +34,3 @@ class TestConfluenceSinglepageAssets(ConfluenceTestCase):
 
                 page_ref = attachment.find('ri:page')
                 self.assertIsNone(page_ref)
-
-    @setup_builder('singleconfluence')
-    def test_storage_singlepage_asset_force_standalone(self):
-        """validate single page assets are self-contained alt (storage)"""
-        #
-        # Ensure when generating a single page that all assets on a page are
-        # pointing (implicitly) to itself (i.e. no `ri:page` entry) -- ensure
-        # the `confluence_asset_force_standalone` option is not causing issues.
-
-        config = dict(self.config)
-        config['confluence_asset_force_standalone'] = True
-        out_dir = self.build(self.dataset, config=config)
-
-        with parse('index', out_dir) as data:
-            images = data.find_all('ac:image')
-            self.assertEqual(len(images), 2)
-
-            for image in images:
-                attachment = image.find('ri:attachment')
-                self.assertIsNotNone(attachment)
-                self.assertTrue(attachment.has_attr('ri:filename'))
-                self.assertEqual(attachment['ri:filename'], 'image03.png')
-
-                page_ref = attachment.find('ri:page')
-                self.assertIsNone(page_ref)


### PR DESCRIPTION
This extension originally introduced the concept of "shared assets" by allowing pages to share duplicate assets by publishing an asset in the main document and referencing the attachment from the hosted document. While the can reduce the amount of published assets, it came with a higher maintenance cost in the code. The code has started to become more complex, especially when trying to introduce lazy-asset initialization while supporting POSIX parallel builds (to be addressed in the future). To help simplify things, if a page requires an attachment (e.g. image), it will now always host said asset (as if the legacy configuration option `confluence_asset_force_standalone` was enabled).

A side benefit from this change is that there should no longer be any complications of moving/replacing the main document on Confluence without having to deal with linked attachments.