### PR TITLE
correct backref (footnotes/citations) updates in singleconfluence

### DIFF
--- a/sphinxcontrib/confluencebuilder/singlebuilder.py
+++ b/sphinxcontrib/confluencebuilder/singlebuilder.py
@@ -215,11 +215,20 @@ class SingleConfluenceBuilder(ConfluenceBuilder):
                 target['ids'] = new_ids
 
         for target in findall(tree, nodes.Element):
+            # update any reference targets to their new identifier (if any)
             refid = target.get('refid')
             if refid:
                 new_refid = updated_refids.get(refid)
                 if new_refid:
                     target['refid'] = new_refid
+
+            # update any back references to their new identifier (if any)
+            backrefs = target.get('backrefs')
+            if backrefs:
+                for idx, backref in enumerate(backrefs):
+                    new_backref = updated_refids.get(backref)
+                    if new_backref:
+                        backrefs[idx] = new_backref
 
         # in the cloned tree, look for other toctrees that we can include
         # into our new single tree


### PR DESCRIPTION
When the merging of documentation occurs for a `singleconfluence` run, identifiers are updated to ensure uniqueness. However, for citations and footnotes, the back references were not updated causing unexpected links on updated identifiers. To address this, when updating elements with new identifiers, check for back-references to be updated as well.