### PR TITLE
builder: interim dry-run cast fix

### DIFF
--- a/sphinxcontrib/confluencebuilder/builder.py
+++ b/sphinxcontrib/confluencebuilder/builder.py
@@ -575,7 +575,10 @@ class ConfluenceBuilder(Builder):
                     parent_id = new_parent_id
 
             uploaded_id = self.publisher.store_page(title, data, parent_id)
-        self.state.register_upload_id(docname, int(uploaded_id))
+
+        # TMP: interim cast logic until we can cleanup all the ids to be int
+        uploaded_id_int = int(uploaded_id) if uploaded_id else uploaded_id
+        self.state.register_upload_id(docname, uploaded_id_int)
 
         self._cache_info.track_last_page_id(docname, uploaded_id)
 


### PR DESCRIPTION
With the partial work performed to transition towards internal page identifier management to integer types, this broke dry-run invokes. To quickly address this, only cast in the case if we got an identifier from a publish event (i.e. only `None` when dry-run mode on new pages).