### PR TITLE
translator: correct video support with asset changes

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -3217,7 +3217,7 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             if width is None:
                 self.warn('unsupported unit type for confluence: ' + wu)
 
-        video_key, _, _ = self.assets.add(source_path, self.docname)
+        video_key, _ = self.assets.add(source_path, self.docname)
 
         if not video_key:
             self.warn(f'Unable to find video name: {source_path}')


### PR DESCRIPTION
When changing asset processing \[1\], the change missed cleaning up the handling of the video nodes; correcting.

\[1\]: 15877c29d1355f617598d2cebeea9013fb55a149