### PR TITLE
Fix documentation for `jira` directive

### DIFF
--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -623,7 +623,7 @@ Confluence documents.
             .. jira:: project = "TEST"
                 :count: true
 
-    .. rst:directive:option:: maximum_issues: count
+    .. rst:directive:option:: maximum-issues: count
         :type: number
 
         The maximum number of issues a ``jira`` directive will display. By
@@ -632,7 +632,7 @@ Confluence documents.
         .. code-block:: rst
 
             .. jira:: project = "TEST"
-                :maximum_issues: 10
+                :maximum-issues: 10
 
     .. rst:directive:option:: server: instance
         :type: string


### PR DESCRIPTION
This patch corrects the name of the `maximum-issues` option in the `jira` directive’s documentation.  Previously, that option was erroneously listed using snake_case instead of kebab-case.