### PR TITLE
Testing for Sphinx 9.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,27 +36,22 @@ jobs:
       matrix:
         include:
             # test each python/sphinx pair supported
-            - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx74, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx80, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.10", toxenv: py310-sphinx81, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx74, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx80, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx81, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx82, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.11", toxenv: py311-sphinx90, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx74, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx80, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx81, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx82, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx90, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.12", toxenv: py312-sphinx91, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx74, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx80, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx81, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx82, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx90, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.13", toxenv: py313-sphinx91, cache: ~/.cache/pip }
-            - { os:  ubuntu-latest, python: "3.14", toxenv: py314-sphinx74, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.14", toxenv: py314-sphinx80, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.14", toxenv: py314-sphinx81, cache: ~/.cache/pip }
             - { os:  ubuntu-latest, python: "3.14", toxenv: py314-sphinx82, cache: ~/.cache/pip }

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ files and optionally publish them to a Confluence instance.
 
 * [Confluence][confluence] Cloud or Data Center 8.5+
 * [Python][python] 3.10+
-* [Requests][requests] 2.25.0+
-* [Sphinx][sphinx] 7.4+
+* [Requests][requests] 2.30.0+
+* [Sphinx][sphinx] 8.0+
 
 ## Installing
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,8 +19,8 @@ release = sphinxcontrib.confluencebuilder.__version__
 
 supported_confluence_ver = '8.5+'
 supported_python_ver = '3.10+'
-supported_requests_ver = '2.25.0+'
-supported_sphinx_ver = '7.4+'
+supported_requests_ver = '2.30.0+'
+supported_sphinx_ver = '8.0+'
 
 root_doc = 'contents'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ classifiers = [
     'Topic :: Utilities',
 ]
 dependencies = [
-    'requests>=2.25.0',
-    'sphinx>=7.4',
+    'requests>=2.30.0',
+    'sphinx>=8.0',
 ]
 dynamic = [
     'version',

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -83,7 +83,7 @@ def setup(app):
     ConfluenceLogger.initialize()
     cm = app.config_manager_ = ConfigManager(app)
 
-    app.require_sphinx('7.4')
+    app.require_sphinx('8.0')
     app.add_builder(ConfluenceBuilder)
     app.add_builder(ConfluenceReportBuilder)
     app.add_builder(SingleConfluenceBuilder)

--- a/support/task-full-check.sh
+++ b/support/task-full-check.sh
@@ -12,14 +12,10 @@ cfg_envs=(
     doc-html
     doc-latexpdf
     mypy
-    py310-sphinx74
-    py310-sphinx74-release
     py310-sphinx80
     py310-sphinx80-release
     py310-sphinx81
     py310-sphinx81-release
-    py311-sphinx74
-    py311-sphinx74-release
     py311-sphinx80
     py311-sphinx80-release
     py311-sphinx81
@@ -28,8 +24,6 @@ cfg_envs=(
     py311-sphinx82-release
     py311-sphinx90
     py311-sphinx90-release
-    py312-sphinx74
-    py312-sphinx74-release
     py312-sphinx80
     py312-sphinx80-release
     py312-sphinx81
@@ -38,8 +32,6 @@ cfg_envs=(
     py312-sphinx82-release
     py312-sphinx90
     py312-sphinx90-release
-    py313-sphinx74
-    py313-sphinx74-release
     py312-sphinx91
     py312-sphinx91-release
     py313-sphinx80
@@ -52,8 +44,6 @@ cfg_envs=(
     py313-sphinx90-release
     py313-sphinx91
     py313-sphinx91-release
-    py314-sphinx74
-    py314-sphinx74-release
     py314-sphinx80
     py314-sphinx80-release
     py314-sphinx81

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     ruff
     pylint
-    py{310,311,312,313,314}-sphinx{74,80,81}
+    py{310,311,312,313,314}-sphinx{80,81}
     py{311,312,313,314}-sphinx{82,90}
     py{312,313,314}-sphinx{91}
     mypy
@@ -10,7 +10,6 @@ envlist =
 [testenv]
 deps =
     -r{toxinidir}/requirements_dev.txt
-    sphinx74: sphinx>=7.4,<7.5
     sphinx80: sphinx>=8.0,<8.1
     sphinx81: sphinx>=8.1,<8.2
     sphinx82: sphinx>=8.2,<8.3


### PR DESCRIPTION
### support testing sphinx 9.1.x series

With the release of Sphinx v9.1, adding it as part of the checks.

### drop sphinx 7.4.x support

With the release of Sphinx v9.1, we will drop our testing for v7.4.x since our maintenance efforts only support up to the last five Sphinx versions.