### PR TITLE
support page updates for resolved comments over skipping

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1898,21 +1898,36 @@ Advanced publishing configuration
         There is no support to keep inlined comments on updated pages at
         this time.
 
-    Indicates to skip updates on pages which have inlined comments. Before
-    a page update is issued, a warning will be generated if this extension
-    detects that a page has inlined comments added to it. Page updates
-    remove any inlined comments embedded in the page source. If a users
-    wants to prevent any updates on pages to prevent the loss of inlined
-    comments, they can configure this option to ``True``. By default, pages
-    will always be updated with a value of ``False``.
+    Indicates to skip updates on pages which have inlined comments. By default,
+    pages will always be updated with a value of ``False``.
+
+    If this option is set to ``True``, if a page to be update is detected to
+    have an embedded comment reference, a warning will be generated and the
+    page will not be updated.
 
     .. code-block:: python
 
         confluence_publish_skip_commented_pages = True
 
+    If this option is set to ``ignored-resolved``, the page will be checked
+    for embedded comment references. In the event that comments are found and
+    all comments are resolved, the page will be updated/overridden as if no
+    comments where there. However, if any unresolved comments are detected,
+    a warning will be generated and the page will not be updated.
+
+    .. code-block:: python
+
+        confluence_publish_skip_commented_pages = 'ignored-resolved'
+
+    Users may be interesting in turning `warnings into errors`_ to report a
+    non-zero exit status for these warnings.
+
     See also :lref:`suppress_warnings_config`.
 
     .. versionadded:: 2.13
+    .. versionchanged:: 3.1
+
+        Support the ``ignored-resolved`` value.
 
 .. _confluence_publish_trample:
 
@@ -2671,3 +2686,4 @@ Deprecated options
 .. _sphinxcontrib-mermaid: https://pypi.org/project/sphinxcontrib-mermaid/
 .. _suppress_warnings: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-suppress_warnings
 .. _toctree: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree
+.. _warnings into errors: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-W

--- a/sphinxcontrib/confluencebuilder/__init__.py
+++ b/sphinxcontrib/confluencebuilder/__init__.py
@@ -256,7 +256,7 @@ def setup(app):
     # Publish only new/updates content within the root document's hierarchy.
     cm.add_conf_bool('confluence_publish_trample')
     # Whether to skip page updates for pages that have inlined comments
-    cm.add_conf_bool('confluence_publish_skip_commented_pages')
+    cm.add_conf('confluence_publish_skip_commented_pages')
     # Manipulate a requests instance.
     cm.add_conf('confluence_request_session_override')
     # Authentication passthrough for Confluence REST interaction.

--- a/sphinxcontrib/confluencebuilder/config/checks.py
+++ b/sphinxcontrib/confluencebuilder/config/checks.py
@@ -31,6 +31,7 @@ from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePublishM
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePublishMissingUsernameAskConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePublishMissingUsernameAuthConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePublishMissingUsernamePassConfigError
+from sphinxcontrib.confluencebuilder.config.exceptions import ConfluencePublishSkipCommentedConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceServerAuthConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceSourcelinkRequiredConfigError
 from sphinxcontrib.confluencebuilder.config.exceptions import ConfluenceSourcelinkReservedConfigError
@@ -603,6 +604,19 @@ def validate_configuration(builder):
 
     validator.conf('confluence_publish_root') \
              .int_(positive=True)
+
+    # ##################################################################
+
+    # confluence_publish_skip_commented_pages
+    try:
+        validator.conf('confluence_publish_skip_commented_pages').bool()
+    except ConfluenceConfigError:
+        try:
+            validator.conf('confluence_publish_skip_commented_pages').matching(
+                'ignored-resolved',
+            )
+        except ConfluenceConfigError as ex:
+            raise ConfluencePublishSkipCommentedConfigError from ex
 
     # ##################################################################
 

--- a/sphinxcontrib/confluencebuilder/config/exceptions.py
+++ b/sphinxcontrib/confluencebuilder/config/exceptions.py
@@ -324,6 +324,17 @@ properly set with the publisher's Confluence username.
 ''')
 
 
+class ConfluencePublishSkipCommentedConfigError(ConfluenceConfigError):
+    def __init__(self):
+        super().__init__('''\
+unsupported publish skip commented packages value
+
+The option 'confluence_publish_skip_commented_pages' has been provided to
+tailor how the environment will handle commented packages. Accepted values
+include 'True', 'False' and 'ignored-resolved'.
+''')
+
+
 class ConfluenceServerAuthConfigError(ConfluenceConfigError):
     def __init__(self):
         super().__init__('''\


### PR DESCRIPTION
Users can use `confluence_publish_skip_commented_pages` to hint to skip page updates that have comments. This also captures pages that have comments that are resolved.

In order to be flexible for users who want to drop comment references for pages with resolved comments, this commit introduces the option:

```
confluence_publish_skip_commented_pages = 'ignored-resolved'
```

If a page with comment entries detects all comments have been resolved (or dangling), pages will not be skipped but instead updated as normally.

Note that this is not a perfect solution, as a page update will still drop comment references on the page, causing all remaining comments to be dangling.