### PR TITLE
Documentation cleanup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/docs.yml'
       - 'doc/**'
       - 'CHANGES.rst'
+      - 'requirements_docs.txt'
   pull_request:
     branches:
     - main
@@ -17,6 +18,7 @@ on:
       - '.github/workflows/docs.yml'
       - 'doc/**'
       - 'CHANGES.rst'
+      - 'requirements_docs.txt'
 
 jobs:
   build:
@@ -33,6 +35,7 @@ jobs:
         python -m venv venv
         . venv/bin/activate
         pip install -e .
+        pip install -r requirements_docs.txt
 
     - name: HTML
       run: |

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,6 +27,7 @@ root_doc = 'contents'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    'sphinx_inline_tabs',
 ]
 
 if any('spelling' in arg for arg in sys.argv):

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1,24 +1,10 @@
 Configuration
 =============
 
-The following is an example of simple configuration (``conf.py``) for
-Confluence generation and publishing:
-
-.. code-block:: python
-
-    extensions = [
-        'sphinxcontrib.confluencebuilder',
-    ]
-    confluence_publish = True
-    confluence_space_key = 'TEST'
-    confluence_parent_page = 'Documentation'
-    confluence_server_url = 'https://intranet-wiki.example.com/'
-    confluence_server_user = 'myawesomeuser'
-    confluence_ask_password = True
-
-All configurations introduced by this extension are listed below. This
-extension may take advantage of a subset of `Sphinx configurations`_ as well
-when preparing documents.
+All configurations introduced by this extension are listed below. These may
+be used in a documentation project's `Sphinx configuration`_ (``conf.py``).
+This extension may take advantage of a subset of Sphinx-defined configurations
+as well when preparing documents.
 
 .. versionadded:: 1.9
 
@@ -35,6 +21,121 @@ when preparing documents.
     .. contents::
        :depth: 1
        :local:
+
+Example configurations
+----------------------
+
+The following shows example configurations (``conf.py``) for
+Confluence generation and publishing:
+
+.. tab:: Cloud
+
+    .. only:: latex
+
+        Example Cloud Configuration
+        ***************************
+
+    .. code-block:: python
+
+        extensions = [
+            'sphinxcontrib.confluencebuilder',
+        ]
+        confluence_publish = True
+        confluence_space_key = 'MYPRJ'
+        confluence_server_url = 'https://example.atlassian.net/'
+        confluence_parent_page = 'Documentation'
+        confluence_server_user = 'myawesomeuser@example.com'
+
+    With use of a token environment variable:
+
+    .. code-block:: none
+
+        export CONFLUENCE_API_TOKEN=TOKEN
+         (or)
+        set CONFLUENCE_API_TOKEN=TOKEN
+
+.. tab:: Cloud (Scoped Token)
+
+    .. only:: latex
+
+        Example Cloud (Scoped Token) Configuration
+        ******************************************
+
+    .. code-block:: python
+
+        extensions = [
+            'sphinxcontrib.confluencebuilder',
+        ]
+        confluence_publish = True
+        confluence_space_key = 'MYPRJ'
+        confluence_server_url = 'https://example.atlassian.net/'
+        confluence_parent_page = 'Documentation'
+        confluence_server_user = 'myawesomeuser@example.com'
+        confluence_api_token_scoped = True
+
+    With use of a token environment variable:
+
+    .. code-block:: none
+
+        export CONFLUENCE_API_TOKEN=TOKEN
+         (or)
+        set CONFLUENCE_API_TOKEN=TOKEN
+
+.. tab:: Cloud (Custom Domain)
+
+    .. raw:: latex
+
+        \newpage
+
+    .. only:: latex
+
+        Example Cloud (Custom Domain) Configuration
+        *******************************************
+
+    .. code-block:: python
+
+        extensions = [
+            'sphinxcontrib.confluencebuilder',
+        ]
+        confluence_publish = True
+        confluence_space_key = 'MYPRJ'
+        confluence_server_url = 'https://wiki.example.com/'
+        confluence_parent_page = 'Documentation'
+        confluence_server_user = 'myawesomeuser@example.com'
+        confluence_cloud = True
+
+    With use of a token environment variable:
+
+    .. code-block:: none
+
+        export CONFLUENCE_API_TOKEN=TOKEN
+         (or)
+        set CONFLUENCE_API_TOKEN=TOKEN
+
+.. tab:: Data Center
+
+    .. only:: latex
+
+        Example Data Center Configuration
+        *********************************
+
+    .. code-block:: python
+
+        extensions = [
+            'sphinxcontrib.confluencebuilder',
+        ]
+        confluence_publish = True
+        confluence_space_key = 'MYPRJ'
+        confluence_server_url = 'https://wiki.example.com/'
+        confluence_parent_page = 'Documentation'
+
+    With use of a token environment variable:
+
+    .. code-block:: none
+
+        export CONFLUENCE_PUBLISH_TOKEN=TOKEN
+         (or)
+        set CONFLUENCE_PUBLISH_TOKEN=TOKEN
 
 Essential configuration
 -----------------------
@@ -2680,7 +2781,7 @@ Deprecated options
 .. _Requests -- Authentication: https://requests.readthedocs.io/en/stable/user/authentication/
 .. _Requests SSL Cert Verification: https://requests.readthedocs.io/en/stable/user/advanced/#ssl-cert-verification
 .. _Requests: https://pypi.python.org/pypi/requests
-.. _Sphinx configurations: https://www.sphinx-doc.org/en/master/usage/configuration.html
+.. _Sphinx configuration: https://www.sphinx-doc.org/en/master/usage/configuration.html
 .. _Sphinx's command line: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-D
 .. _TLS/SSL wrapper for socket object: https://docs.python.org/3/library/ssl.html#ssl.create_default_context
 .. _Using Personal Access Tokens: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1713,7 +1713,7 @@ Advanced publishing configuration
 .. confval:: confluence_publish_intersphinx
 
     A publish event will upload a generated intersphinx's inventory
-    (`object.inv`) as an attachment to the configured root_doc_. Inventory
+    (``object.inv``) as an attachment to the configured root_doc_. Inventory
     files are typically small and should not cause issues for most users.
     However, if a user desired to not publish an inventory for their
     documentation, this option can be configured to ``False``. By default,

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -26,7 +26,7 @@ when preparing documents.
     environment. For example, if :lref:`confluence_publish` is not explicitly
     set inside ``conf.py`` or provided via `Sphinx's command line`_, this
     extension may check the ``CONFLUENCE_PUBLISH`` environment option as a
-    fallback. Note that this only applies options provided below and will
+    fallback. Note that this only applies to options provided below and will
     not work for other configuration options provided by Sphinx or other
     Sphinx extensions.
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2359,14 +2359,17 @@ Advanced processing configuration
     Some documentation may rely on HTML-specific content, and if this HTML
     content is not too complex, this may be renderable on a Confluence
     instance. Users wanting to allow this can enable this option to have
-    HTML content directly injected on pages, or even placed inside an
-    HTML-supported macro (if such a macro is available for the target
-    Confluence instance):
+    HTML content directly injected on pages:
 
     .. code-block:: python
 
         confluence_permit_raw_html = True
-         (or)
+
+    Or even placed inside an HTML-supported macro (if such a macro is
+    available for the target Confluence instance):
+
+    .. code-block:: python
+
         confluence_permit_raw_html = 'html'
 
     Using this option is not supported. Content may be automatically

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -356,8 +356,7 @@ Generic configuration
 
     .. note::
 
-        This option is only supported using the ``v1``
-        :ref:`editor <confluence_editor>`.
+        This option is only supported on Confluence Data Center.
 
     Specifies the color scheme to use when displaying a Confluence code
     block macro.
@@ -1441,8 +1440,7 @@ Advanced publishing configuration
 
     .. note::
 
-        This option is only supported using the ``v1``
-        :ref:`editor <confluence_editor>`.
+        This option is only supported on Confluence Data Center.
 
     Configures the mode which pages will be fetched from Confluence. For
     Confluence Data Center instances, there may be performance issues when

--- a/doc/directives.rst
+++ b/doc/directives.rst
@@ -784,8 +784,7 @@ Smart links
 
 .. note::
 
-    Smart links will only render when using the v2 editor
-    (see :lref:`confluence_editor`).
+    Smart links will only render when using Confluence Cloud.
 
 .. rst:directive:: confluence_doc
 

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -42,19 +42,18 @@ Type                    Notes
 `hyperlink targets`_    Supported
 `images`_               Limited support.
 
-                        When using a Confluence v2 editor, images cannot be
-                        inlined.
+                        When using Confluence Cloud, images cannot be inlined.
 `inline markup`_        Supported
 `list-table`_           Supported
 `literal blocks`_       Supported
 `math`_                 Supported with additional system tools.
 
                         Requires a LaTeX and dvipng/dvisvgm installation.
-                        When using a Confluence v2 editor, images cannot be
+                        When using Confluence Cloud, images cannot be
                         offset to be aligned in a paragraph.
 `parsed literal block`_ Limited support.
 
-                        When using a Confluence v2 editor, literal blocks
+                        When using Confluence Cloud, literal blocks
                         cannot be parsed and the contents will be placed
                         inside a code macro.
 `option lists`_         Supported
@@ -106,7 +105,7 @@ Type                    Notes
 `glossary`_             Supported
 `hlist`_                Limited support.
 
-                        When using a Confluence v2 editor, the maximum columns
+                        When using Confluence Cloud, the maximum columns
                         for an hlist is three.
 `manpage`_              Supported
 `production list`_      Supported

--- a/doc/roles.rst
+++ b/doc/roles.rst
@@ -129,8 +129,7 @@ Smart links
 
 .. note::
 
-    Smart links will only render when using the v2 editor
-    (see :lref:`confluence_editor`).
+    Smart links will only render when using Confluence Cloud.
 
 Support for inlined smart links can be created using the following roles.
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,1 @@
+sphinx-inline-tabs

--- a/tests/validation-sets/restructuredtext/code.rst
+++ b/tests/validation-sets/restructuredtext/code.rst
@@ -7,10 +7,10 @@ Code
 
         .. attention::
 
-            Limitations using the Fabric (``v2``) editor:
+            Limitations on Confluence Cloud:
 
-            - Confluence does not support applying a code line offset.
-            - Confluence does not support disabling code lines.
+            - Confluence Cloud does not support applying a code line offset.
+            - Confluence Cloud does not support disabling code lines.
 
 reStructuredText provides a `code`_ directive help render a literal block
 where if a code language is specified, the content is parsed by a syntax

--- a/tests/validation-sets/restructuredtext/enumerated-list.rst
+++ b/tests/validation-sets/restructuredtext/enumerated-list.rst
@@ -14,7 +14,7 @@ Enumerated list
 
         .. attention::
 
-            Limitations using the Fabric (``v2``) editor:
+            Limitations on Confluence Cloud:
 
             - Enumerator lists do not support explicit styling.
 

--- a/tests/validation-sets/restructuredtext/images.rst
+++ b/tests/validation-sets/restructuredtext/images.rst
@@ -7,7 +7,7 @@ Images
 
         .. attention::
 
-            Limitations using the Fabric (``v2``) editor:
+            Limitations on Confluence Cloud:
 
             - Images cannot be inlined with expected sizes (`CONFCLOUD-68501`_).
             - SVGs may not render properly (`CONFCLOUD-1762`_).

--- a/tests/validation-sets/restructuredtext/indentation.rst
+++ b/tests/validation-sets/restructuredtext/indentation.rst
@@ -7,11 +7,11 @@ Indentation
 
         .. attention::
 
-            Limitations using the Fabric (``v2``) editor:
+            Limitations on Confluence Cloud:
 
-            - Confluence does not support indenting block types. For example,
-              an indented paragraph with a list will always have the list rendered
-              without an indentation.
+            - Confluence Cloud does not support indenting block types. For
+              example, an indented paragraph with a list will always have the
+              list rendered without an indentation.
 
 reStructuredText supports the ability to `indent`_ content. The builder will
 translate the indented content into respective indented paragraphs. Content that

--- a/tests/validation-sets/restructuredtext/literal-blocks.rst
+++ b/tests/validation-sets/restructuredtext/literal-blocks.rst
@@ -7,9 +7,9 @@ Literal Blocks
 
         .. attention::
 
-            Limitations using the Fabric (``v2``) editor:
+            Limitations on Confluence Cloud:
 
-            - Confluence does not support disabling code lines.
+            - Confluence Cloud does not support disabling code lines.
 
 reStructuredText provides a `literal block`_ directive help render a block
 of content in a monospaced typeface. Example markup is as follows:

--- a/tests/validation-sets/restructuredtext/math.rst
+++ b/tests/validation-sets/restructuredtext/math.rst
@@ -13,10 +13,10 @@ Math
 
         .. attention::
 
-            Limitations using the Fabric (``v2``) editor:
+            Limitations on Confluence Cloud:
 
-            - Confluence does not allow image offset alignments in a paragraph.
-            - Confluence does not render gracefully SVG-generated images.
+            - Confluence Cloud does not allow image offset alignments in a paragraph.
+            - Confluence Cloud does not render gracefully SVG-generated images.
 
 reStructuredText defines a `math directive`_. Example markup is as follows:
 

--- a/tests/validation-sets/restructuredtext/parsed-literal-block.rst
+++ b/tests/validation-sets/restructuredtext/parsed-literal-block.rst
@@ -7,10 +7,10 @@ Parsed Literal Block
 
         .. attention::
 
-            Limitations using the Fabric (``v2``) editor:
+            Limitations on Confluence Cloud:
 
-            - Confluence does not support disabling code lines.
-            - Confluence does not support parsing literal content.
+            - Confluence Cloud does not support disabling code lines.
+            - Confluence Cloud does not support parsing literal content.
 
 reStructuredText provides a `parsed literals`_ directive help render a
 literal block where the text is parsed for inline markup. Example markup

--- a/tests/validation-sets/sphinx/code.rst
+++ b/tests/validation-sets/sphinx/code.rst
@@ -21,10 +21,10 @@ Code block
 
         .. attention::
 
-            Limitations using the Fabric (``v2``) editor:
+            Limitations on Confluence Cloud:
 
-            - Confluence does not support applying a code line offset.
-            - Confluence does not support disabling code lines.
+            - Confluence Cloud does not support applying a code line offset.
+            - Confluence Cloud does not support disabling code lines.
 
 The following contains a series of code examples using `Sphinx's code markup`_.
 Example markup is as follows:

--- a/tests/validation-sets/sphinx/hlist.rst
+++ b/tests/validation-sets/sphinx/hlist.rst
@@ -7,7 +7,7 @@ Horizontal list
 
         .. attention::
 
-            Limitations using the Fabric (``v2``) editor:
+            Limitations on Confluence Cloud:
 
             - Maximum number of columns (``:columns:``) supported is
               three (``3``).

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ commands = {envpython} -m sphinx -M latexpdf . _build -E -a
 [testenv:doc-spelling]
 deps =
     {[testenv]deps}
+    -r requirements_docs.txt
     sphinxcontrib-spelling
 changedir = doc
 commands = {envpython} -m sphinx -M spelling . _build -E -a


### PR DESCRIPTION
- doc: rework using of fabric/v1/v2 editors to just server/cloud
- doc: grammar
- doc: formatting
- doc: reword raw html for clarity
- doc: rework base example