### PR TITLE
publish: split post form data and files

### DIFF
--- a/sphinxcontrib/confluencebuilder/publisher.py
+++ b/sphinxcontrib/confluencebuilder/publisher.py
@@ -841,20 +841,24 @@ class ConfluencePublisher:
             chunked_hash = '\n'.join(
                 [hash_[i:i + 16] for i in range(0, len(hash_), 16)])
 
-            data = {
+            form_data = {
                 'comment': chunked_hash,
+            }
+
+            files = {
                 'file': (name, data, mimetype),
             }
 
             if not self.notify:
                 # using str over bool to support requests pre-v2.19.0
-                data['minorEdit'] = 'true'
+                form_data['minorEdit'] = 'true'
 
             if not attachment:
                 url = f'{self.APIV1}content/{page_id}/child/attachment'
 
                 try:
-                    rsp = self.rest.post(url, None, files=data)
+                    rsp = self.rest.post(
+                        url, None, form_data=form_data, files=files)
                     uploaded_attachment_id = rsp['results'][0]['id']
                 except ConfluenceBadApiError as ex:
                     # file type restricted? generate a warning
@@ -898,7 +902,8 @@ class ConfluencePublisher:
             if attachment:
                 url = '{}content/{}/child/attachment/{}/data'.format(
                     self.APIV1, page_id, attachment['id'])
-                rsp = self.rest.post(url, None, files=data)
+                rsp = self.rest.post(
+                    url, None, form_data=form_data, files=files)
                 uploaded_attachment_id = rsp['id']
 
             if not self.watch:

--- a/sphinxcontrib/confluencebuilder/rest.py
+++ b/sphinxcontrib/confluencebuilder/rest.py
@@ -342,9 +342,9 @@ class Rest:
     @confluence_error_retries()
     @rate_limited_retries()
     @requests_exception_wrappers()
-    def post(self, path, data, files=None, *, url=None):
+    def post(self, path, data, form_data=None, files=None, *, url=None):
         rsp = self._process_request(
-            'POST', path, json=data, files=files, url=url)
+            'POST', path, json=data, data=form_data, files=files, url=url)
 
         if not rsp.ok:
             errdata = self._format_error(rsp, path)


### PR DESCRIPTION
When posting file attachments, this extension historically (since v1.0) published both form and file data through Requests `files` option. This may not have been proper, but has functioned for some time when interacting with stock Confluence Cloud and Confluence Data Center editions.

However, recent reports from users have hinted in server processing errors where a Java Spring Framework's `CommonsMultipartFile` usage complains. Unknown if a result of newer framework versions or its use with specific Marketplace addons.

No matter the case, this commit aims to correct the post requests when uploading attachment data. This commit ensures any form data is published using Requests `data` argument, and files using `files` argument. Initial testing with Confluence Cloud and Confluence Data Center v10.2.11 show success in publication.