### PR TITLE
Document label scopes required for scoped tokens

### DIFF
--- a/doc/advanced-publish-permissions.rst
+++ b/doc/advanced-publish-permissions.rst
@@ -27,6 +27,8 @@ scopes are required:
     read:content-details:confluence
     write:attachment:confluence
     delete:attachment:confluence
+    read:label:confluence
+    write:label:confluence
     write:watcher:confluence
 
 .. references ------------------------------------------------------------------

--- a/doc/guide-scope-token.rst
+++ b/doc/guide-scope-token.rst
@@ -28,10 +28,12 @@ On this page:
   - ``read:content-details:confluence``
   - ``read:content.metadata:confluence``
   - ``read:content.property:confluence``
+  - ``read:label:confluence``
   - ``read:page:confluence``
   - ``read:space:confluence``
   - ``write:attachment:confluence``
   - ``write:content.property:confluence``
+  - ``write:label:confluence``
   - ``write:page:confluence``
   - ``write:watcher:confluence``
   - ``delete:attachment:confluence``


### PR DESCRIPTION
## Summary

- add the granular read and write label scopes to the publishing permissions reference
- keep the scoped-token setup guide synchronized with the same requirements

The Confluence content-label endpoint requires both `read:label:confluence` and `write:label:confluence` when adding labels with granular scopes.

Fixes #1187

## Verification

- `python -m sphinx -M html doc /tmp/confluencebuilder-html -E -a -W --keep-going`
- verified both generated HTML pages contain both scope identifiers
- `git diff --check`