### PR TITLE
fix: build anchor macros for section titles containing special charac…

### DIFF
--- a/sphinxcontrib/confluencebuilder/storage/translator.py
+++ b/sphinxcontrib/confluencebuilder/storage/translator.py
@@ -288,10 +288,13 @@ class ConfluenceStorageFormatTranslator(ConfluenceBaseTranslator):
             #    respective document name) which helps allow `ac:link` macros
             #    properly link when coming from v1 or v2 editor pages.
             # - Helps support anchor links for legacy editor on Confluence Cloud
-            if 'names' in node.parent:
-                for name in node.parent['names']:
-                    anchor = name.replace(' ', '-')
-                    target_name = f'{docname}/#{anchor}'
+            # Key off the section's `ids` (docutils' ascii-safe slugs), not
+            # `names` (which preserves punctuation like "&"), since `ids` is
+            # the exact key `_register_doctree_targets` in builder.py always
+            # registers under, regardless of special characters in the title.
+            if 'ids' in node.parent:
+                for id_ in node.parent['ids']:
+                    target_name = f'{docname}/#{id_}'
                     target = self.state.target(target_name)
                     if target and target not in new_targets:
                         self._build_anchor(node, target, force_compat=True)

--- a/tests/unit-tests/datasets/rst/title-ampersand/index.rst
+++ b/tests/unit-tests/datasets/rst/title-ampersand/index.rst
@@ -1,0 +1,11 @@
+title ampersand
+================
+
+.. contents:: Contents
+   :local:
+   :depth: 3
+
+Foo & Bar
+---------
+
+content

--- a/tests/unit-tests/test_rst_title_ampersand.py
+++ b/tests/unit-tests/test_rst_title_ampersand.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# Copyright Sphinx Confluence Builder Contributors (AUTHORS)
+
+from tests.lib.parse import parse
+from tests.lib.testcase import ConfluenceTestCase
+from tests.lib.testcase import setup_builder
+
+
+class TestConfluenceRstTitleAmpersand(ConfluenceTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.dataset = cls.datasets / 'rst' / 'title-ampersand'
+
+    @setup_builder('confluence')
+    def test_storage_rst_title_ampersand_anchor(self):
+        out_dir = self.build(self.dataset)
+
+        with parse('index', out_dir) as data:
+            headers = data.find_all('h2')
+            self.assertEqual(len(headers), 2)
+
+            toc_header, section_header = headers
+            self.assertEqual(toc_header.text.strip(), 'Contents')
+
+            # heading text itself should render correctly (already escaped
+            # properly before this fix)
+            self.assertIn('Foo & Bar', section_header.get_text())
+
+            # an anchor macro should still be built for this heading, even
+            # though its title contains an ampersand
+            anchor_tags = section_header.find_all(
+                'ac:structured-macro', {'ac:name': 'anchor'})
+            self.assertGreaterEqual(len(anchor_tags), 1)
+
+            for anchor_tag in anchor_tags:
+                self.assertIsNotNone(anchor_tag.find('ac:parameter'))
+
+            # the local table-of-contents link should resolve to the same
+            # (id-based) anchor target
+            toc_link = toc_header.find_next('ac:link')
+            self.assertIsNotNone(toc_link)
+            self.assertTrue(toc_link.has_attr('ac:anchor'))
+            self.assertEqual(toc_link['ac:anchor'], 'foo-bar')


### PR DESCRIPTION
…ters

Section titles containing characters flagged as "unsafe" by ascii_quote() (e.g. `&`) never received an `<ac:structured-macro ac:name="anchor">` in the generated storage-format output, even though the heading text itself rendered correctly.

The anchor target for a title is registered in
`_register_doctree_targets` (builder.py) keyed on the section's `ids` (docutils' ascii-safe, punctuation-stripped slug), unconditionally. But `visit_title` (storage/translator.py) looked that target up using a different key, rebuilt from the section's `names` (which keeps punctuation like `&`). For titles with no special characters both keys happened to match; for a title like "Foo & Bar" they diverged ("foo-bar" vs "foo-&-bar"), the lookup silently returned nothing, and the anchor macro was skipped entirely.

The fix makes `visit_title` key its lookup off the section's `ids` directly, matching exactly what is registered, so the anchor is always found regardless of the title's characters.

Adds a regression test (dataset + test case) covering a section title with an ampersand, including its local table-of-contents backlink.